### PR TITLE
Update katex.css, fixes \frac issue.

### DIFF
--- a/source/common/assets/css/katex.css
+++ b/source/common/assets/css/katex.css
@@ -1,3 +1,4 @@
+/* stylelint-disable font-family-no-missing-generic-family-keyword */
 @font-face {
   font-family: 'KaTeX_AMS';
   src: url(../fonts/KaTeX/KaTeX_AMS-Regular.woff2) format('woff2'), url(../fonts/KaTeX/KaTeX_AMS-Regular.woff) format('woff'), url(../fonts/KaTeX/KaTeX_AMS-Regular.ttf) format('truetype');
@@ -54,6 +55,12 @@
 }
 @font-face {
   font-family: 'KaTeX_Math';
+  src: url(../fonts/KaTeX/KaTeX_Math-BoldItalic.woff2) format('woff2'), url(../fonts/KaTeX/KaTeX_Math-BoldItalic.woff) format('woff'), url(../fonts/KaTeX/KaTeX_Math-BoldItalic.ttf) format('truetype');
+  font-weight: bold;
+  font-style: italic;
+}
+@font-face {
+  font-family: 'KaTeX_Math';
   src: url(../fonts/KaTeX/KaTeX_Math-Italic.woff2) format('woff2'), url(../fonts/KaTeX/KaTeX_Math-Italic.woff) format('woff'), url(../fonts/KaTeX/KaTeX_Math-Italic.ttf) format('truetype');
   font-weight: normal;
   font-style: italic;
@@ -84,7 +91,7 @@
 }
 @font-face {
   font-family: 'KaTeX_Size1';
-  src: url(fon../fonts/KaTeXts/KaTeX_Size1-Regular.woff2) format('woff2'), url(../fonts/KaTeX/KaTeX_Size1-Regular.woff) format('woff'), url(../fonts/KaTeX/KaTeX_Size1-Regular.ttf) format('truetype');
+  src: url(../fonts/KaTeX/KaTeX_Size1-Regular.woff2) format('woff2'), url(../fonts/KaTeX/KaTeX_Size1-Regular.woff) format('woff'), url(../fonts/KaTeX/KaTeX_Size1-Regular.ttf) format('truetype');
   font-weight: normal;
   font-style: normal;
 }
@@ -112,27 +119,14 @@
   font-weight: normal;
   font-style: normal;
 }
-.katex-display {
-  display: block;
-  margin: 1em 0;
-  text-align: center;
-}
-.katex-display > .katex {
-  display: inline-block;
-  text-align: initial;
-}
 .katex {
   font: normal 1.21em KaTeX_Main, Times New Roman, serif;
   line-height: 1.2;
-  white-space: nowrap;
   text-indent: 0;
   text-rendering: auto;
 }
 .katex * {
   -ms-high-contrast-adjust: none !important;
-}
-.katex .katex-html {
-  display: inline-block;
 }
 .katex .katex-mathml {
   position: absolute;
@@ -143,9 +137,17 @@
   width: 1px;
   overflow: hidden;
 }
+.katex .katex-html {
+  /* \newline is an empty block at top level, between .base elements */
+}
+.katex .katex-html > .newline {
+  display: block;
+}
 .katex .base {
   position: relative;
   display: inline-block;
+  white-space: nowrap;
+  width: min-content;
 }
 .katex .strut {
   display: inline-block;
@@ -165,8 +167,12 @@
 .katex .texttt {
   font-family: KaTeX_Typewriter;
 }
-.katex .mathit {
+.katex .mathdefault {
   font-family: KaTeX_Math;
+  font-style: italic;
+}
+.katex .mathit {
+  font-family: KaTeX_Main;
   font-style: italic;
 }
 .katex .mathrm {
@@ -184,26 +190,36 @@
 .katex .amsrm {
   font-family: KaTeX_AMS;
 }
-.katex .mathbb {
+.katex .mathbb,
+.katex .textbb {
   font-family: KaTeX_AMS;
 }
 .katex .mathcal {
   font-family: KaTeX_Caligraphic;
 }
-.katex .mathfrak {
+.katex .mathfrak,
+.katex .textfrak {
   font-family: KaTeX_Fraktur;
 }
 .katex .mathtt {
   font-family: KaTeX_Typewriter;
 }
-.katex .mathscr {
+.katex .mathscr,
+.katex .textscr {
   font-family: KaTeX_Script;
 }
-.katex .mathsf {
+.katex .mathsf,
+.katex .textsf {
   font-family: KaTeX_SansSerif;
 }
-.katex .mainit {
-  font-family: KaTeX_Main;
+.katex .mathboldsf,
+.katex .textboldsf {
+  font-family: KaTeX_SansSerif;
+  font-weight: bold;
+}
+.katex .mathitsf,
+.katex .textitsf {
+  font-family: KaTeX_SansSerif;
   font-style: italic;
 }
 .katex .mainrm {
@@ -242,6 +258,7 @@
   vertical-align: bottom;
   font-size: 1px;
   width: 2px;
+  min-width: 2px;
 }
 .katex .msupsub {
   text-align: left;
@@ -252,45 +269,18 @@
 .katex .mfrac .frac-line {
   display: inline-block;
   width: 100%;
+  border-bottom-style: solid;
+}
+.katex .mfrac .frac-line,
+.katex .overline .overline-line,
+.katex .underline .underline-line,
+.katex .hline,
+.katex .hdashline,
+.katex .rule {
+  min-height: 1px;
 }
 .katex .mspace {
   display: inline-block;
-}
-.katex .mspace.negativethinspace {
-  margin-left: -0.16667em;
-}
-.katex .mspace.muspace {
-  width: 0.055556em;
-}
-.katex .mspace.thinspace {
-  width: 0.16667em;
-}
-.katex .mspace.negativemediumspace {
-  margin-left: -0.22222em;
-}
-.katex .mspace.mediumspace {
-  width: 0.22222em;
-}
-.katex .mspace.thickspace {
-  width: 0.27778em;
-}
-.katex .mspace.sixmuspace {
-  width: 0.333333em;
-}
-.katex .mspace.eightmuspace {
-  width: 0.444444em;
-}
-.katex .mspace.enspace {
-  width: 0.5em;
-}
-.katex .mspace.twelvemuspace {
-  width: 0.666667em;
-}
-.katex .mspace.quad {
-  width: 1em;
-}
-.katex .mspace.qquad {
-  width: 2em;
 }
 .katex .llap,
 .katex .rlap,
@@ -325,9 +315,16 @@
   position: relative;
 }
 .katex .overline .overline-line,
-.katex .underline .underline-line {
+.katex .underline .underline-line,
+.katex .hline {
   display: inline-block;
   width: 100%;
+  border-bottom-style: solid;
+}
+.katex .hdashline {
+  display: inline-block;
+  width: 100%;
+  border-bottom-style: dashed;
 }
 .katex .sqrt > .root {
   margin-left: 0.27777778em;
@@ -862,18 +859,22 @@
   text-align: center;
 }
 .katex .accent .accent-body {
-  width: 0;
   position: relative;
+}
+.katex .accent .accent-body:not(.accent-full) {
+  width: 0;
 }
 .katex .overlay {
   display: block;
 }
 .katex .mtable .vertical-separator {
   display: inline-block;
-  margin: 0 -0.125em;
-  width: 0.25em;
-  overflow: hidden;
-  position: relative;
+  margin: 0 -0.025em;
+  border-right: 0.05em solid;
+  min-width: 1px;
+}
+.katex .mtable .vs-dashed {
+  border-right: 0.05em dashed;
 }
 .katex .mtable .arraycolsep {
   display: inline-block;
@@ -894,6 +895,7 @@
   display: block;
   position: absolute;
   width: 100%;
+  height: inherit;
   fill: currentColor;
   stroke: currentColor;
   fill-rule: nonzero;
@@ -909,17 +911,14 @@
 .katex svg path {
   stroke: none;
 }
-.katex .vertical-separator svg {
-  width: 0.25em;
-}
 .katex .stretchy {
   width: 100%;
   display: block;
   position: relative;
   overflow: hidden;
 }
-.katex .stretchy:before,
-.katex .stretchy:after {
+.katex .stretchy::before,
+.katex .stretchy::after {
   content: "";
 }
 .katex .hide-tail {
@@ -979,16 +978,29 @@
 .katex .cancel-pad {
   padding: 0 0.2em 0 0.2em;
 }
-.katex .mord + .cancel-lap,
-.katex .mbin + .cancel-lap {
+.katex .cancel-lap {
   margin-left: -0.2em;
-}
-.katex .cancel-lap + .mord,
-.katex .cancel-lap + .mbin,
-.katex .cancel-lap + .msupsub {
-  margin-left: -0.2em;
+  margin-right: -0.2em;
 }
 .katex .sout {
   border-bottom-style: solid;
   border-bottom-width: 0.08em;
+}
+.katex-display {
+  display: block;
+  margin: 1em 0;
+  text-align: center;
+}
+.katex-display > .katex {
+  display: block;
+  text-align: center;
+  white-space: nowrap;
+}
+.katex-display > .katex > .katex-html {
+  display: block;
+  position: relative;
+}
+.katex-display > .katex > .katex-html > .tag {
+  position: absolute;
+  right: 0;
 }


### PR DESCRIPTION
Here's a fix for issue #102 (frac displays incorrectly). I'm not sure how the bug came to be but the css appeared to be incorrect. (I assume `source/common/assets/katex.css` was out of date.) So I just copied the content of katex.css of the katex package to the one in the assets folder and corrected the paths to the fonts.

This seems to have solved a couple of issues, the missing horizontal line in \frac is now rendered correctly, the same goes for the missing line in \overline, and now variables in an equation are correctly rendered in italic.

The problem with \ne being rendered incorrectly appears to be a [known issue](https://github.com/KaTeX/KaTeX/issues/1842) so hopefully a future update of katex will solve that  particular issue.