### PR TITLE
Fixed error 'file.save is not a function'

### DIFF
--- a/source/main/commands/file-save.js
+++ b/source/main/commands/file-save.js
@@ -63,7 +63,7 @@ class SaveFile extends ZettlrCommand {
         }
         return false
       }
-      file = this._app.getCurrentDir().newfile(null)
+      file = await this._app.getCurrentDir().newfile(null)
       pathsUpdateNecessary = true
     } else {
       let f = this._app.getCurrentFile()


### PR DESCRIPTION
When creating a new file, the `this._app.getCurrentDir().newfile(null)` created a new file object but it didn't wait for the `newfile()` function to complete its processes of creating the object before it could actually return the newly created file object. So, the `file` object was null for the statements after `this._app.getCurrentDir().newfile(null)` and so there was no `file.save` in the null file object.
Adding `await` makes the line `this._app.getCurrentDir().newfile(null)` wait for the `newfile()` function to complete its work and return a file object.