### PR TITLE
In fenced code block, add syntax highlighting for every language known.

### DIFF
--- a/source/common/data.json
+++ b/source/common/data.json
@@ -149,5 +149,95 @@
       "executivepaper": "Executive",
       "legalpaper": "Legal"
     },
-    "events": []
+    "events": [],
+    "highlightingModes": {
+      "text/javascript": {
+        "mode": "javascript",
+        "selectors": [ "javascript", "js", "node" ]
+      },
+      "application/json": {
+        "mode": "javascript",
+        "selectors": [ "json" ]
+      },
+      "text/x-csrc": {
+        "mode": "clike",
+        "selectors": [ "c" ]
+      },
+      "text/x-c++src": {
+        "mode": "clike",
+        "selectors": [ "c\\+\\+", "cpp" ]
+      },
+      "text/x-csharp": {
+        "mode": "clike",
+        "selectors": [ "c\\#", "csharp", "cs" ]
+      },
+      "text/x-java": {
+        "mode": "clike",
+        "selectors": [ "java" ]
+      },
+      "text/x-kotlin": {
+        "mode": "clike",
+        "selectors": [ "kotlin", "kt" ]
+      },
+      "text/x-objectivec": {
+        "mode": "clike",
+        "selectors": [ "objective-c", "objectivec", "objc" ]
+      },
+      "text/x-scala": {
+        "mode": "clike",
+        "selectors": [ "scala" ]
+      },
+      "text/css": {
+        "mode": "css",
+        "selectors": [ "css" ]
+      },
+      "text/x-scss": {
+        "mode": "css",
+        "selectors": [ "scss" ]
+      },
+      "text/x-less": {
+        "mode": "css",
+        "selectors": [ "less" ]
+      },
+      "text/x-php": {
+        "mode": "php",
+        "selectors": [ "php" ]
+      },
+      "text/x-python": {
+        "mode": "python",
+        "selectors": [ "python", "py" ]
+      },
+      "text/x-rsrc": {
+        "mode": "r",
+        "selectors": [ "r" ]
+      },
+      "text/x-ruby": {
+        "mode": "ruby",
+        "selectors": [ "ruby", "rb" ]
+      },
+      "text/x-sql": {
+        "mode": "sql",
+        "selectors": [ "sql" ]
+      },
+      "text/x-swift": {
+        "mode": "swift",
+        "selectors": [ "swift" ]
+      },
+      "text/x-sh": {
+        "mode": "shell",
+        "selectors": [ "shell", "sh", "bash" ]
+      },
+      "text/x-yaml": {
+        "mode": "yaml",
+        "selectors": [ "yaml", "yml" ]
+      },
+      "text/x-go": {
+        "mode": "go",
+        "selectors": [ "go" ]
+      },
+      "text/x-rustsrc": {
+        "mode": "rust",
+        "selectors": [ "rust", "rs" ]
+      }
+    }
 }

--- a/source/renderer/assets/codemirror/autoload.js
+++ b/source/renderer/assets/codemirror/autoload.js
@@ -5,6 +5,8 @@
  * in the main class.
  */
 
+const highlightingModes = require('../../../common/data').highlightingModes
+
 // 1. Mode addons
 require('codemirror/addon/mode/overlay')
 require('codemirror/addon/mode/multiplex') // Multiplex needed for syntax highlighting
@@ -28,18 +30,9 @@ require('codemirror/mode/gfm/gfm')
 require('codemirror/mode/stex/stex')
 
 // 6. Code highlighting modes
-require('codemirror/mode/javascript/javascript')
-require('codemirror/mode/clike/clike')
-require('codemirror/mode/css/css')
-require('codemirror/mode/php/php')
-require('codemirror/mode/python/python')
-require('codemirror/mode/r/r')
-require('codemirror/mode/ruby/ruby')
-require('codemirror/mode/sql/sql')
-require('codemirror/mode/swift/swift')
-require('codemirror/mode/shell/shell')
-require('codemirror/mode/yaml/yaml')
-require('codemirror/mode/go/go')
+for (let mode of new Set(Object.values(highlightingModes).map(hlmode => hlmode.mode))) {
+  require(`codemirror/mode/${mode}/${mode}`)
+}
 
 // 7. The folding addon
 require('codemirror/addon/fold/foldcode')

--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -1,6 +1,8 @@
 /* global CodeMirror define */
 // ZETTLR SPELLCHECKER PLUGIN
 
+const highlightingModes = require('../../../common/data').highlightingModes;
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('../../../node_modules/codemirror/lib/codemirror'))
@@ -20,141 +22,23 @@
   * @return {CodeMirrorMode}        The multiplex mode
   */
   CodeMirror.defineMode('multiplex', function (config) {
+    // Generate a fenced code tag detector for each mode we want to support
+    let codeModes = []
+
+    for (let [ mimeType, highlightingMode ] of Object.entries(highlightingModes)) {
+      let openRegex = new RegExp('```(' + highlightingMode.selectors.join('|') + ')$')
+      codeModes.push({
+        open: openRegex,
+        close: '```',
+        mode: CodeMirror.getMode(config, mimeType),
+        delimStyle: 'formatting-code-block',
+        innerStyle: 'fenced-code'
+      })
+    }
+
     return CodeMirror.multiplexingMode(
       CodeMirror.getMode(config, 'markdown-zkn'), // Default mode
-      {
-        open: '```javascript',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/javascript'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```java',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-java'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```cpp',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-c++src'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```csharp',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-csharp'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```objectivec',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-objectivec'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```css',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/css'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```less',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-less'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```php',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-php'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```python',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-python'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```ruby',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-ruby'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```sql',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-sql'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```swift',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-swift'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: /```shell|```bash/gm, // highlight.js differs between shell and bash
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-sh'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```kotlin',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-kotlin'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```go',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-go'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```yaml',
-        close: '```',
-        // We need regular expressions to keep the YAML mode simple. It now
-        // matches normal YAML blocks as fenced code as well as the Pandoc
-        // metadata blocks
-        // open: /(?<!.)(`{3}yaml|-{3})$/gm,
-        // close: /(?<!.)(`{3}|\.{3})$/gm,
-        mode: CodeMirror.getMode(config, 'text/x-yaml'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      // "c" and "r" have to be down here to prevent them overriding
-      // "ruby" or "cpp"
-      {
-        open: '```c',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-csrc'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
-      {
-        open: '```r',
-        close: '```',
-        mode: CodeMirror.getMode(config, 'text/x-rsrc'),
-        delimStyle: 'formatting-code-block',
-        innerStyle: 'fenced-code'
-      },
+      ...codeModes,
       {
         open: '```',
         close: '```',


### PR DESCRIPTION

## Description

Use the CodeMirror mode list to catch tag of fenced code blocks for each languages known. The tag are generated from the name and aliases CodeMirror modes.
Every tag is lowercase.

It support of a ton of languages, and tag aliases (example: I can use either `js` or `javascript`). 

## Changes

There is no more `objectivec` tag. It's been replaced by `objective-c` or `objc`.

I didn't see any performance changes, but I invite you to test it before.


<!-- Please provide any testing system -->
## Tested On
 - OS: Linux
 - Zettlr Version: last develop
