### PR TITLE
Added AppImage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "release:mac": "node scripts/build-app.js --mac",
         "release:win": "node scripts/build-app.js --win",
         "release:linux": "node scripts/build-app.js --linux",
+        "release:app-image": "node scripts/build-app.js --app-image",
         "less": "node scripts/less.js",
         "less:extract": "node scripts/extract-css.js",
         "handlebars": "node scripts/handlebars.js",

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -18,6 +18,7 @@ const path = require('path')
 let flags = process.argv // Contains the CLI flags
 let buildTargets // Contains all build targets
 let onlyDir = false // Is set to true, if --dir flag is given on command line
+const arifactFilenameFormat = 'Zettlr-${version}-${platform}-${arch}.${ext}'
 
 // Set the current working directory to the app's root.
 process.chdir(path.resolve(__dirname, '../'))
@@ -94,18 +95,18 @@ const config = {
   mac: {
     category: 'public.app-category.productivity',
     target: (onlyDir) ? 'dir' : 'dmg',
-    artifactName: 'Zettlr-macos-x64-${version}.${ext}', // eslint-disable-line
+    artifactName: arifactFilenameFormat, // eslint-disable-line
     icon: 'resources/icons/icns/icon.icns',
     darkModeSupport: true
   },
   win: {
     target: (onlyDir) ? 'dir' : 'nsis',
-    artifactName: 'Zettlr-win32-x64-${version}.${ext}', // eslint-disable-line
+    artifactName: arifactFilenameFormat, // eslint-disable-line
     icon: 'resources/icons/ico/icon.ico'
   },
   linux: {
     target: (onlyDir) ? 'dir' : buildTargets.includes('--app-image') ? appImageTarget : [ 'deb', 'rpm' ],
-    artifactName: 'Zettlr-linux-${version}-${arch}.${ext}', // eslint-disable-line
+    artifactName: arifactFilenameFormat, // eslint-disable-line
     synopsis: 'Markdown editor',
     category: 'Office',
     icon: 'resources/icons/png',

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -62,10 +62,18 @@ const config = {
   copyright: 'Zettlr is licensed under GNU GPL v3.',
   fileAssociations: [
     {
-      ext: [ 'md', 'markdown' ],
+      ext: 'md',
       name: 'Markdown',
-      mimeType: 'text/markdown',
       description: 'Markdown document',
+      mimeType: 'text/markdown',
+      role: 'Editor',
+      isPackage: false
+    },
+    {
+      ext: 'markdown',
+      name: 'Markdown',
+      description: 'Markdown document',
+      mimeType: 'text/markdown',
       role: 'Editor',
       isPackage: false
     }
@@ -88,8 +96,18 @@ const config = {
     icon: 'resources/icons/ico/icon.ico'
   },
   linux: {
-    target: (onlyDir) ? 'dir' : [ 'deb', 'rpm' ],
-    artifactName: 'Zettlr-linux-x64-${version}.${ext}', // eslint-disable-line
+    target: (onlyDir) ? 'dir' : [
+      'deb',
+      'rpm',
+      {
+        target: 'AppImage',
+        arch: [
+          'x64',
+          'ia32'
+        ]
+      }
+    ],
+    artifactName: 'Zettlr-linux-${version}-${arch}.${ext}', // eslint-disable-line
     synopsis: 'Markdown editor',
     category: 'Office',
     icon: 'resources/icons/png',

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -30,7 +30,7 @@ if (flags.length > 2) {
 }
 
 // Extract the build targets
-buildTargets = flags.filter(elem => [ '--mac', '--win', '--linux' ].includes(elem))
+buildTargets = flags.filter(elem => [ '--mac', '--win', '--linux', '--app-image' ].includes(elem))
 
 if (buildTargets.length === 0) {
   // We need at least one build target, so let's assume the current platform
@@ -54,6 +54,14 @@ if (buildTargets.length === 0) {
 
 log.info('Starting build process')
 log.info(`Building for: ${buildTargets.map(elem => elem.substr(2)).join(', ')}`)
+
+const appImageTarget = [{
+  target: 'AppImage',
+  arch: [
+    'x64',
+    'ia32'
+  ]
+}]
 
 const config = {
   appId: 'com.zettlr.app',
@@ -96,17 +104,7 @@ const config = {
     icon: 'resources/icons/ico/icon.ico'
   },
   linux: {
-    target: (onlyDir) ? 'dir' : [
-      'deb',
-      'rpm',
-      {
-        target: 'AppImage',
-        arch: [
-          'x64',
-          'ia32'
-        ]
-      }
-    ],
+    target: (onlyDir) ? 'dir' : buildTargets.includes('--app-image') ? appImageTarget : [ 'deb', 'rpm' ],
     artifactName: 'Zettlr-linux-${version}-${arch}.${ext}', // eslint-disable-line
     synopsis: 'Markdown editor',
     category: 'Office',
@@ -158,6 +156,7 @@ async function runBuilder () {
     if (flag === '--mac') target = Platform.MAC.createTarget()
     if (flag === '--win') target = Platform.WINDOWS.createTarget()
     if (flag === '--linux') target = Platform.LINUX.createTarget()
+    if (flag === '--app-image') target = Platform.LINUX.createTarget()
     await builder.build({ 'targets': target, 'config': config })
     log.success(`Build for ${flag.substr(2)} complete!`)
   }

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -13,6 +13,7 @@ const path = require('path')
 * --mac: Build for macOS
 * --win: Build for Windows
 * --linux: Build for Linux
+* --app-image: Build for AppImage
 */
 
 let flags = process.argv // Contains the CLI flags


### PR DESCRIPTION
<!-- Thank you for opening up the pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

- Documented changes in the code. Of course not necessary when only bumping
  some external dependencies.
- Pull Request opened on the respective branch (and *not* master)
- Tested extensively and paid extra attention to potential cross-platform
  issues (e.g. Cmd/Ctrl/Super-key bindings)

 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences; e.g. "Fixes issue #xyz" or "Adds feature xyz for purpose abc ..." -->
## Description

Adds AppImage building feature for easy installing on every system.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

- When building linux it will build an AppImage for x64 and ia32.
- Changed artifact name to include the achitecture. Zettlr-linux-${version}-${arch}.${ext}
 I thought version should be before arch but I can change this back if you want.
- Changed file associations array. It was necessary for Appimage building.
  This could maybe have not intendend effects?

<!-- Please provide any testing system -->
## Tested On
 - OS: Debian Ubuntu
 - OS Version: 18.04.03
 - Zettlr Version: v1.5.0-beta.1

