### PR TITLE
Create a keyboard shortcut for Task Lists

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-plugin-markdown-shortcuts.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-markdown-shortcuts.js
@@ -596,4 +596,6 @@ const { clipboard } = require('electron');
   CodeMirror.keyMap['default']['Shift-Ctrl-I'] = 'markdownImage'
   CodeMirror.keyMap['default']['Shift-Cmd-C'] = 'markdownComment'
   CodeMirror.keyMap['default']['Shift-Ctrl-C'] = 'markdownComment'
+  CodeMirror.keyMap['default']['Cmd-T'] = 'markdownMakeTaskList'
+  CodeMirror.keyMap['default']['Ctrl-T'] = 'markdownMakeTaskList'
 })

--- a/source/renderer/assets/context/editor.json
+++ b/source/renderer/assets/context/editor.json
@@ -32,6 +32,7 @@
   },
   {
     "label": "menu.insert_tasklist",
+    "accelerator": "CmdOrCtrl+T",
     "command": "cm-command",
     "content": "markdownMakeTaskList"
   },


### PR DESCRIPTION
<!-- Thank you for opening up the pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

- Documented changes in the code. Of course not necessary when only bumping
  some external dependencies.
- Pull Request opened on the respective branch (and *not* master)
- Tested extensively and paid extra attention to potential cross-platform
  issues (e.g. Cmd/Ctrl/Super-key bindings)

 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences; e.g. "Fixes issue #xyz" or "Adds feature xyz for purpose abc ..." -->
## Description
Adds a new keyboard shortcut to create a Task List (`Cmd / Ctrl + T`).

I'm looking to use Zettlr primarily as a todo-list tracker so I make frequent use of task lists. Toggling them without leaving the keyboard is helpful and the Markdown syntax is _so many characters_, so a shortcut seemed like a good solution.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
I just updated the Markdown Shortcuts CodeMirror plugin and Editor's Context Menu. As best I can tell these are the only places in the application that reference Markdown shortcuts.

<!-- Please provide any testing system -->
## Tested On
 - OS: macOS
 - OS Version: 10.15.1 (Catalina)
 - Zettlr Version: Latest Develop

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
 - I chose `Cmd+T` / `Ctrl+T` because it both didn't appear to already be in use and because it's common across other note apps (Bear, for instance, uses `Cmd+T`). If we'd prefer to save T for other purposes (Insert Table, maybe?) we could consider using the somewhat unruly `Shift+Cmd+L` shortcut as used by Apple Notes.
 - I've only tested on macOS at the moment, but since the changes directly copy how other shortcuts are implemented I'm not *super* concerned.
 - Should this PR be accepted, the docs would need to be updated. Specifically, the [shortcuts reference](https://github.com/Zettlr/zettlr-docs/blob/master/docs/en/reference/shortcuts.md) and probably also the [Zettlr as a note-taking app](https://github.com/Zettlr/zettlr-docs/blob/master/docs/en/guides/guide-notes.md) guide.
 - Also, should this PR be accepted, I may consider implementing further enhancements to the Task List functionality, specifically adding another shortcut to toggle a given line's task list item as checked/unchecked, and updating the CSS to strike-through a checked list-item (or by applying actual strike-through Markdown -- `~` -- to the item)