### PR TITLE
De-duplicate ID when expanding ID links

### DIFF
--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -148,15 +148,15 @@ class ZettlrEditor {
           CodeMirror.on(completionObject, 'pick', (completion) => {
             // When a user inserts an ID, neither the citeproc IDs nor the
             // tagDB will be loaded, but a generated library containing the
-            // displayText-property.
+            // expandedText-property.
             if (this._currentDatabase !== this._tagDB &&
               this._currentDatabase !== this._citeprocIDs &&
-              completion.displayText) {
-              // We need to add completion.displayText after the completed thing.
+              completion.expandedText) {
+              // We need to add completion.expandedText after the completed thing.
               let cur = JSON.parse(JSON.stringify(cm.getCursor()))
               cur.ch += 2
               cm.setCursor(cur)
-              cm.replaceSelection(' ' + completion.displayText)
+              cm.replaceSelection(' ' + completion.expandedText)
             }
             this._autoCompleteStart = null
             this._currentDatabase = null // Reset the database used for the hints.
@@ -264,9 +264,14 @@ class ZettlrEditor {
           for (let file of flattenDirectoryTree(this._renderer.getCurrentDir())) {
             if (file.type !== 'file') continue
             let fname = path.basename(file.name, path.extname(file.name))
+            let expandedText
+            if(file.id && fname.includes(file.id + ' ')) {
+              expandedText = fname.replace(file.id + ' ', '')
+            }
             db[fname] = {
               'text': file.id || fname, // Use the ID, if given, or the filename
-              'displayText': fname // Always display the filename
+              'displayText': fname, // Always display the filename
+              'expandedText': expandedText || fname // Remove ID from expansion, or use filename
             }
           }
           this._currentDatabase = db


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

When expanding ID links, I would like the ID to be included in brackets, and the remainder of the file name to follow the brackets.

### Current behavior

Zettlr currently shows the file ID twice – once in the brackets, and once after the brackets:

![zettlr-id-autocomplete-current](https://user-images.githubusercontent.com/1111/71284071-bf107180-2316-11ea-913e-e51b7418efca.gif)

### Proposed new behavior

Display the ID in brackets, and remove it from the trailing text:

![zettlr-id-autocomplete](https://user-images.githubusercontent.com/1111/71283770-fcc0ca80-2315-11ea-94c8-1338e018defd.gif)

(note: I do think it makes sense to keep the ID in the hints list)

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

I made a small change to the `CodeMirror.on(completionObject, 'pick')` call in `zettlr-editor.js`.

<!-- Please provide any testing system -->
## Tested On
 - OS and version: macOS 10.13.6
 - Zettlr version: 1.5

<!-- If there is anything else that might be of interest, please provide it here
## Additional information -->