### PR TITLE
Use raw string to transfer i18n data from main process to renderer process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed wrong error logging in the Citeproc provider.
 - Added the necessary `cslenvironment` to Zettlr's default TeX template so that Pandoc >2.8 does not throw errors. Thanks to @frederik-elwert for implementing!
 - Cleaned up the keymap for CodeMirror. It's now centralised within `generate-keymap.js` and not scattered in all the plugins anymore.
+- Rewrote the i18n loading logic, resulting in huge performance gains on startup. Thanks to @BAKFR for implementing!
 
 # 1.5.0
 

--- a/source/common/lang/i18n.js
+++ b/source/common/lang/i18n.js
@@ -50,15 +50,17 @@ function i18n (lang = 'en-US') {
 
   // Cannot do this asynchronously, because it HAS to be loaded directly
   // after the config and written into the global object
-  global.i18n = JSON.parse(fs.readFileSync(file.path, 'utf8'))
+  global.i18nRawData = fs.readFileSync(file.path, 'utf8')
+  global.i18n = JSON.parse(global.i18nRawData)
 
   // Also load the en-US fallback as we can be sure this WILL both stay
   // up to date and will be understood by most people.
   let fallback = getLanguageFile('en-US') // Will return either the shipped or updated file
-  global.i18nFallback = JSON.parse(fs.readFileSync(fallback.path, 'utf8'))
+  global.i18nFallbackRawData = fs.readFileSync(fallback.path, 'utf8')
+  global.i18nFallback = JSON.parse(global.i18nFallbackRawData)
 
   return file
-};
+}
 
 /**
  * This translates a given identifier string into the loaded language

--- a/source/common/lang/i18n.js
+++ b/source/common/lang/i18n.js
@@ -42,10 +42,11 @@ const FALLBACK = 'fallback'
 
 /**
  * This function loads a language JSON file specified by lang into the global i18n-object
+ * It must be used only in the main process; renderer processes must call loadI18nRenderer() instead.
  * @param  {String} [lang='en-US'] The language to be loaded
  * @return {Object}                The language metadata object.
  */
-function i18n (lang = 'en-US') {
+function loadI18nMain (lang = 'en-US') {
   let file = getLanguageFile(lang) // Will return a working path
 
   // Cannot do this asynchronously, because it HAS to be loaded directly
@@ -324,7 +325,7 @@ function enumDictFiles (paths = [ path.join(app.getPath('userData'), '/dict'), p
 }
 
 module.exports = {
-  i18n,
+  loadI18nMain,
   trans,
   getDictionaryFile,
   getLanguageFile,

--- a/source/common/lang/load-i18n-renderer.js
+++ b/source/common/lang/load-i18n-renderer.js
@@ -1,0 +1,28 @@
+/**
+ * BEGIN HEADER
+ *
+ * Contains:        Internationalization functions
+ * CVM-Role:        <none>
+ * Maintainer:      Kévin Bernard-Allies
+ * License:         GNU GPL v3
+ *
+ * Description:     This file contains i18n loader function used by every
+ *                  renderer processes.
+ *
+ * END HEADER
+ */
+
+const { remote } = require('electron')
+
+/**
+ * Load i18n data from main process into global variables "i18n" and
+ * "i18nFallback"
+ *
+ * NOTE: we use raw string for transferring data, because transferring a
+ * javascript object is incredibly slow: getGlobal() return a proxy object and
+ * each access execute an IPC FOR EACH ATTRIBUTE being read)
+ */
+module.exports = function loadI18n () {
+  global.i18n = JSON.parse(remote.getGlobal('i18nRawData'))
+  global.i18nFallback = JSON.parse(remote.getGlobal('i18nFallbackRawData'))
+}

--- a/source/main/zettlr.js
+++ b/source/main/zettlr.js
@@ -26,7 +26,7 @@ const ZettlrFile = require('./zettlr-file.js')
 const ZettlrDeadDir = require('./zettlr-dead-dir.js')
 const ZettlrTargets = require('./zettlr-targets.js')
 const ZettlrStats = require('./zettlr-stats.js')
-const { i18n, trans } = require('../common/lang/i18n')
+const { loadI18nMain, trans } = require('../common/lang/i18n')
 const hash = require('../common/util/hash')
 const ignoreDir = require('../common/util/ignore-dir')
 const ignoreFile = require('../common/util/ignore-file')
@@ -70,7 +70,7 @@ class Zettlr {
     this._bootServiceProviders()
 
     // Init translations
-    let metadata = i18n(global.config.get('appLang'))
+    let metadata = loadI18nMain(global.config.get('appLang'))
 
     // It may be that only a fallback has been provided or else. In this case we
     // must update the config to reflect this.

--- a/source/print/zettlr-print-window.js
+++ b/source/print/zettlr-print-window.js
@@ -13,6 +13,7 @@
  * END HEADER
  */
 
+const loadI18nRenderer = require('../common/lang/load-i18n-renderer')
 const ipc = require('electron').ipcRenderer
 const path = require('path')
 
@@ -35,7 +36,7 @@ class ZettlrPrintWindow {
 
     // as this class basically acts as the renderer class, we also have to take
     // care of specifics such as getting the translation strings, etc.
-    global.i18n = JSON.parse(JSON.stringify(require('electron').remote.getGlobal('i18n')))
+    loadI18nRenderer()
 
     // Directly inject the correct body class
     $('body').addClass(process.platform)

--- a/source/quicklook/zettlr-quicklook-window.js
+++ b/source/quicklook/zettlr-quicklook-window.js
@@ -14,6 +14,7 @@
  */
 
 const ZettlrQuicklook = require('../renderer/zettlr-quicklook.js')
+const loadI18nRenderer = require('../common/lang/load-i18n-renderer')
 const ipc = require('electron').ipcRenderer
 
 /**
@@ -35,7 +36,7 @@ class ZettlrQuicklookWindow {
 
     // as this class basically acts as the renderer class, we also have to take
     // care of specifics such as getting the translation strings, etc.
-    global.i18n = JSON.parse(JSON.stringify(require('electron').remote.getGlobal('i18n')))
+    loadI18nRenderer()
 
     // Directly inject the correct body class
     $('body').addClass(process.platform)

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -27,6 +27,7 @@ const createSidebar = require('./assets/vue/vue-sidebar')
 const { remote, shell, clipboard } = require('electron')
 
 const generateId = require('../common/util/generate-id')
+const loadI18nRenderer = require('../common/lang/load-i18n-renderer')
 
 const path = require('path')
 
@@ -49,13 +50,7 @@ class ZettlrRenderer {
     this._lang = 'en-US' // Default fallback
 
     // Write translation data into renderer process's global var
-    // Why do we have to stringify and parse it? Because otherwise the
-    // renderer's global.i18n-variable will simply be a huge object calling
-    // the main's IPC EVERY TIME it is accessed. Therefore, we take some more
-    // time to copy it completely into the renderer's memory. It will take up
-    // some time at the beginning, but it's not gonna impact that much.
-    global.i18n = JSON.parse(JSON.stringify(remote.getGlobal('i18n')))
-    global.i18nFallback = JSON.parse(JSON.stringify(remote.getGlobal('i18nFallback')))
+    loadI18nRenderer()
 
     // Immediately add the operating system class to the body element to
     // enable the correct font-family.


### PR DESCRIPTION
Previously, i18n data were transferred using a JSON object copied once at start.
It led to numerous IPC calls with heavy performance cost.
This commit add a loadI18n() method using raw string instead object, thus
avoiding these calls.

On my computer, i18n loading time went from ~150ms to less than 5ms
