### PR TITLE
Modify TeX template for pandoc 2.8

### DIFF
--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -166,6 +166,8 @@ pdfborder={0 0 0}
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
+% The following commands are used by Pandoc if a CSL bibliography is present
+% to create proper indentation, especially for styles with hanging indentation.
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -166,6 +166,15 @@ pdfborder={0 0 0}
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+{$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+\everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+{\par}
+$endif$
+
 \title{$PDF_TITLE$}
 \author{$PDF_AUTHOR$}
 


### PR DESCRIPTION
Add the custom environment for CSL citations that pandoc 2.8 requires. Fixes #455.

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

Pandoc 2.8 uses a dedicated custom latex environment for typesetting indented bibliographies. If this is missing from the latex template, compilation will fail. This pull request adds the corresponding snippet.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Just added the corresponding snippet from the original pandoc template.

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Ubuntu 18.04
 - Zettlr version: 1.5.0
 - pandoc version: 2.7.3, 2.8, 2.9.1.1 (works fine also under pre-2.8!)
