### PR TITLE
Paste current id if it exists

### DIFF
--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -181,8 +181,11 @@ class ZettlrRenderer {
     let image = clipboard.readImage()
     let rtf = clipboard.readRTF()
 
+    // If the file has an id, paste it instead of generating a new one
+    let f = this.getCurrentFile()
+    let id = (f && f.id) ? f.id : generateId(global.config.get('zkn.idGen'))
     // Write an ID to the clipboard
-    clipboard.writeText(generateId(global.config.get('zkn.idGen')))
+    clipboard.writeText(id)
     // Paste the ID
     remote.getCurrentWebContents().paste()
 


### PR DESCRIPTION
When you press Ctrl+L / Cmd+L, Zettlr inserts a unique id in the document. The id is always freshly generated: you can insert 100 different ids. It's okay I guess. But.

I think the idea for this key is to generate a new id when there isn't one. But where there's a registered id, it makes more sense to keep it, and not generate new ids.

This PR changes the behaviour of Ctrl+L, so that when a file has an id, it inserts it instead of generating a new one. That would help me in moving ids from file names to file contents (I made this mistake of keeping ids in file names), and I guess it will be helpful in not creating multiple ids for a single file.

One thing it's missing is that in case of a new file, it should paste just one id, instead of generating many. Not sure how to do that withoug breaking anything. Do I just `this.getCurrentFile().id = ...`?

Tested on Fedora Linux 31.