### PR TITLE
Fix IME position at all zoom levels

### DIFF
--- a/resources/less/geometry/codemirror.less
+++ b/resources/less/geometry/codemirror.less
@@ -9,9 +9,18 @@
   // hidden. This way, pop-ups for non-western
   // fonts such as Hiragana/Katakana are correctly
   // aligned. Should also help accessibility-plugins.
-  &.CodeMirror-wrap > div > textarea {
-    font-size: 1.6em;
-    line-height: inherit;
+  &.CodeMirror-wrap > div:first-child {
+    height: 1.4375em !important;
+    width: 0 !important;
+    textarea {
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      height: 1.4375em !important;
+      top: 0 !important;
+      bottom: 0 !important;
+      margin: auto;
+    }
   }
 
   line-height:1.4375;


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
We have already applied [a workaround for the IME issue](https://github.com/Zettlr/Zettlr/commit/c64173d4947ad910f7560c400ca306511dea494f), but it was not complete.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
The source of the problem is the textarea, whose size and position must exactly match the actual displayed text.

### Current state
- The dimensions of the textarea do not match the actual displayed text.
- The vertical position of the textarea is in the middle of the parent element. (This is probably a Chromium bug.)
![image](https://user-images.githubusercontent.com/15438757/74590378-2a459e00-5051-11ea-9786-f62ef41e0d6c.png)

### Amendment
- Adjust the dimensions of the textarea.
- Change the shape of the parent div to work around a positioning bug in Chromium.
![image](https://user-images.githubusercontent.com/15438757/74590689-c1135a00-5053-11ea-9962-c37d89593aa1.png)

<!-- Please provide any testing system -->
## Tested On
 - OS and version:
    1. Windows 10 Home 1903 (+ Japanese Microsoft IME)
    2. Windows 10 Home 1903 (+ Microsoft Pinyin)
    3. Ubuntu Desktop 18.04 LTS (+ Mozc)
 - Zettlr version: Latest develop

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
