### PR TITLE
Fix Magic Quotes quick-select behaviour

### DIFF
--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -723,8 +723,8 @@
           <button class="mq-select" data-primary="0" data-secondary="0">{{ i18n "dialog.preferences.autocorrect.quick_select_none_label" }}</button>
           <button class="mq-select" data-primary="1" data-secondary="1">{{  i18n "dialog.preferences.app_lang.en-GB" }}</button>
           <button class="mq-select" data-primary="3" data-secondary="3">{{  i18n "dialog.preferences.app_lang.de-DE" }}</button>
-          <button class="mq-select" data-primary="11" data-secondary="9">{{  i18n "dialog.preferences.app_lang.fr-FR" }}</button>
-          <button class="mq-select" data-primary="13" data-secondary="13">{{  i18n "dialog.preferences.app_lang.ja-JP" }}</button>
+          <button class="mq-select" data-primary="11" data-secondary="10">{{  i18n "dialog.preferences.app_lang.fr-FR" }}</button>
+          <button class="mq-select" data-primary="13" data-secondary="14">{{  i18n "dialog.preferences.app_lang.ja-JP" }}</button>
         </div>
         <div class="box-right">
           {{!-- Replacement Table --}}


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Index fixes were missing when [adding German secondary guillemets](https://github.com/Zettlr/Zettlr/commit/c199e81853998498d5340337f612110c34740186).

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
French and Japanese secondary MagicQuotes are now correct. 

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Windows 10 Home 1903
 - Zettlr version: Latest develop

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
