### PR TITLE
Disable github spice for markdown

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-mode-zkn.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-zkn.js
@@ -30,7 +30,7 @@
     */
   CodeMirror.defineMode('markdown-zkn', function (config, parserConfig) {
     var yamlMode = CodeMirror.getMode(config, 'yaml')
-    var mdMode = CodeMirror.getMode(config, { name: 'gfm', highlightFormatting: true })
+    var mdMode = CodeMirror.getMode(config, { name: 'gfm', highlightFormatting: true, gitHubSpice: false })
 
     var markdownZkn = {
       startState: function () {


### PR DESCRIPTION
## Description

Disabled `gitHubSpice` for the github-flavoured markdown. Fixes #558.

## Changes

Basically just flipped one flag for the GFM initialization. This prevents formatting "user#NNN" and sha codes like links: zettlr doesn't parse these links anyway.

## Tested On
 - OS and version: Fedora Linux 30
 - Zettlr version: 1.6.0 beta5