### PR TITLE
 Fix to show search result in sidebar even for a single file

### DIFF
--- a/resources/vue/sidebar.vue
+++ b/resources/vue/sidebar.vue
@@ -84,7 +84,7 @@
           <template v-else-if="getDirectoryContents.length === 1">
             <file-item
               v-for="item in getDirectoryContents"
-              v-bind:obj="item"
+              v-bind:obj="item.props"
               v-bind:key="item.hash"
             >
           </file-item>


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
If the result of global search contains only a single file, nothing appears in the sidebar.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Fix to show single file in sidebar.

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Windows 10 Home 1903
 - Zettlr version: Latest develop

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
Not reproduced in v1.5.0
