### PR TITLE
clarification new block math render CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 - **New Feature**: Zettlr is now able to open file attachments for citations in your files. Simply right-click a citation, go to "Open Attachment" and select the cite-key for which you want to open the file attachment. Got multiple? Here's how Zettlr chooses which one to open: All attachments are listed and then the PDF files are sorted on top of the list. Then, Zettlr will open whatever attachment is the first in the list.
 - **New Feature**: You now have an additional setting that allows you to determine if, and when, the filename will be automatically added to your link. "Never" means that the file name will never be added, "Only with ID" means that the file name will only be added, if the link is constructed using the ID, and "always" (the default) means that the file name will always be added, possibly duplicating it.
 - **New Feature**: NOT search operator. Now you can use an exclamation mark (!) before the term in your global search to exclude certain search terms. If any NOT-condition is satisfied, the file will no longer be considered a candidate. You can combine the NOT-operator with both exact matches (`!"an exact phrase"`) and single terms (`!word`).
+- **Changed markdown render behaviour**: Opening and closing double dollar tags `$$` for math block equations have to be on separate lines. Only white spaces can be on the line with `$$` otherwise block eqation is not rendered.  
+Before (in version 1.5.0) supported: `$$ equation $$`  
+Now required syntax:  
+    ```
+    $$  
+    equation(s)  
+    $$
+    ```
 - Added TypeScript syntax highlighting. Keywords: `typescript`, `ts`.
 - Added `Windows 32bit` build.
 - Switched from `showdown` to `turndown` for converting HTML to Markdown on pasting contents. This makes pasting HTML formatted text much better than prior. Thanks to @Zverik for implementing!


### PR DESCRIPTION
Added clarification for significant change in the required format for math block equation to render.

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Added clarification for significant change in the required format for math block equation to render. Before double dollar `$$` tags could be the same line with the equation. In this version have to be separate lines. I consider important to document this change in behaviour. 

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Added clarification in CHANGELOG.md
