### PR TITLE
Fix IME pop-up position again

### DIFF
--- a/resources/less/geometry/codemirror.less
+++ b/resources/less/geometry/codemirror.less
@@ -15,9 +15,8 @@
       font-size: inherit;
       line-height: inherit;
       height: 1.4375em !important;
-      top: 0 !important;
-      bottom: 0 !important;
-      margin: auto;
+      bottom: -1.4375em !important;
+      transform: scaleY(1.1);
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
This is a continuation of [this PR](https://github.com/Zettlr/Zettlr/pull/544) and [this commit](https://github.com/Zettlr/Zettlr/commit/8e27fc760d99a72ac965d24a2856e4c1cbe82637).
Fix the position of the IME popup so that it does not overlap with the typed text.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
In version 1.6.0, it looks like:
![image](https://user-images.githubusercontent.com/15438757/76701281-329e0100-6703-11ea-8d22-4438660a0ea5.png)

with this PR:
![image](https://user-images.githubusercontent.com/15438757/76701308-6da03480-6703-11ea-9321-0ad4f1417504.png)

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Windows 10 1903
 - Zettlr version: Latest develop

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
The key point is `transform: scaleY(1.1);`. This is a workaround to render the vertical position correctly. Without this, `bottom:` would be ignored 🤷‍♂ 