### PR TITLE
Add support for custom latex commands and autocompletion

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-plugin-render-math.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-math.js
@@ -128,7 +128,396 @@
         // Enable on-click closing of rendered Math elements.
         elem.onclick = (e) => { textMarker.clear() }
 
-        require('katex').render(myMarker.eq, elem, { throwOnError: false })
+        // TODO: Read from file
+        // const fs = require('fs')
+        // var customMacrosFile = 'D:\\Research\\A_Central\\Latex\\tex\\generic\\myMathHeader.json'
+        // let customMacros = new Map(JSON.parse(fs.readFileSync(customMacrosFile, { encoding: 'utf8' })))
+        require('katex').render(myMarker.eq, elem, {
+          throwOnError: false,
+          macros: {
+            // # Math commands
+            /*
+            \begin{thm}
+            \end{thm}
+            \begin{prop}
+            \end{prop}
+            \begin{lemma}
+            \end{lemma}
+            \begin{coro}
+            \end{coro}
+            \begin{defn}
+            \end{defn}
+            \begin{fact}
+            \end{fact}
+            \begin{remark}
+            \end{remark}
+            \begin{remarks}
+            \end{remarks}
+            \begin{example}
+            \end{example}
+            \begin{counterexample}
+            \end{counterexample}
+            \begin{proof}
+            \end{proof}
+
+            \begin{thmenumerate}
+            \end{thmenumerate}
+            */
+
+            '\\abs': '',
+            '\\norm': '',
+            '\\nnorm': '',
+            '\\normDot': '',
+            '\\equivClass': '',
+            '\\bracket': '',
+            '\\scalarProd': '',
+            '\\scalarProdDot': '',
+            '\\scalarProdR': '',
+            '\\poisson{left}{right}': '',
+            '\\poissonDot': '',
+            '\\commutator': '',
+            '\\commutatorDot': '',
+            '\\antiCommutator': '',
+            '\\LieBracket': '',
+            '\\LieBracketDot': '',
+            '\\dualPair{left}{right}': '',
+            '\\dualPairDot': '',
+            '\\dualPairR{left}{right}': '',
+            '\\dualPairRDot': '',
+            '\\LTwoDualPair{left}{right}': '',
+            '\\LTwoDualPairDot': '',
+            '\\LTwoNorm{}': '',
+            '\\wedgeLie': '',
+            '\\wedgeLieDot': '',
+            '\\wedgeDual': '',
+            '\\wedgeDualDot': '',
+            '\\wedgeldot': '',
+
+            '\\sslash': '',
+
+            '\\field': '',
+            '\\R': '',
+            '\\C': '',
+            '\\N': '',
+            '\\Z': '',
+            '\\Q': '',
+            '\\K': '',
+
+            '\\Hom': '',
+            '\\Aut': '',
+            '\\End': '',
+            '\\Tor': '',
+            '\\TorAb': '',
+            '\\Ext': '',
+            '\\ExtAb': '',
+
+            '\\sgn': '',
+            '\\pr': '',
+            '\\inc': '',
+            '\\tr': '',
+            '\\Sym': '',
+            '\\jet': '',
+            '\\divergence': '',
+            '\\ind': '',
+            '\\const': '',
+            '\\principalSymbol': '',
+
+            '\\ker': '',
+            '\\coker ': '',
+            '\\img ': '',
+            '\\coimg ': '',
+            '\\supp   ': '',
+            '\\vspan   ': '',
+            '\\id': '',
+            '\\one': '',
+            '\\ev': '',
+            '\\Ev': '',
+            '\\pb': '',
+            '\\pf': '',
+            '\\vol': '',
+
+            '\\inv': '',
+            '\\mult': '',
+            '\\comp': '',
+
+            '\\flux': '',
+
+            '\\fixPointSet': '',
+
+            '\\secondFundForm': '',
+
+            '\\fourierTransform': '',
+
+            '\\LieA': '',
+            '\\LieAEx': '',
+            '\\aCentralizer': '',
+            '\\aCenter': '',
+
+            '\\LeftTrans': '',
+            '\\RightTrans': '',
+            '\\centralizer': '',
+            '\\AdAction': '',
+            '\\CoAdAction': '',
+            '\\CoAdMAction': '',
+            '\\CoAdOrbit': '',
+            '\\adAction': '',
+            '\\CoadAction': '',
+            '\\CoadMAction': '',
+            '\\conjAction': '',
+
+            '\\contr': '',
+            '\\hatProduct': '',
+            '\\flow': '',
+            '\\tensorProd': '',
+            '\\externalTensor': '',
+
+            '\\SequenceSpace': '',
+
+            '\\TBundle': '',
+            '\\CotBundle': '',
+            '\\CotBundleProj': '',
+            '\\ExtBundle': '',
+            '\\SymBundle': '',
+            '\\DensityBundle': '',
+            '\\halfDensityBundle': '',
+            '\\VBundle': '',
+            '\\VDensityBundle': '',
+            '\\HBundle': '',
+            '\\NBundle': '',
+            '\\AdBundle': '',
+            '\\FrameBundle': '',
+            '\\SpinBundle': '',
+            '\\SpinorBundle': '',
+            '\\CoSpinorBundle': '',
+            '\\SpBundle': '',
+            '\\CoAdBundle': '',
+            '\\ConjBundle': '',
+            '\\AtBundle': '',
+            '\\JetBundle': '',
+            '\\JetSpace': '',
+            '\\pJetBundle': '',
+            '\\HomBundle': '',
+            '\\ConnBundle': '',
+            '\\UniEBundle': '',
+            '\\UniBBundle': '',
+            '\\KBundle': '',
+            '\\OrientationBundle': '',
+            '\\LinMapBundle': '',
+
+            '\\toInject': '',
+            '\\toSurject': '',
+
+            '\\LinMapSpace': '',
+            '\\GLinMapSpace': '',
+            '\\FlagSpace': '',
+            '\\LagSpace': '',
+            '\\FunctionSpace': '',
+            '\\sFunctionSpace': '',
+            '\\cFunctionSpace': '',
+            '\\ccFunctionSpace': '',
+            '\\scFunctionSpace': '',
+            '\\LFunctionSpace': '',
+            '\\LTwoFunctionSpace': '',
+            '\\HFunctionSpace': '',
+            '\\SectionSpace': '',
+            '\\sSectionSpace': '',
+            '\\scSectionSpace': '',
+            '\\cSectionSpace': '',
+            '\\psSectionSpace': '',
+            '\\FibreBundleModel': '',
+            '\\SectionSpaceAbb': '',
+            '\\SectionMapAbb': '',
+            '\\DiffOpSpace': '',
+            '\\PseudoDiffOpSpace': '',
+            '\\TestFunctionSpace': '',
+            '\\DistributionSpace': '',
+            '\\cDistributionSpace': '',
+            '\\CoNormalDistributionSpace': '',
+            '\\SchwartzSectionSpace': '',
+            '\\halfSchwartzSectionSpace': '',
+            '\\temperedDistributionSpace': '',
+            '\\locIntSectionSpace': '',
+            '\\BesovSectionSpace': '',
+            '\\locBesovSectionSpace': '',
+            '\\SymbolSpace': '',
+            '\\DiffFormSpace': '',
+            '\\clDiffFormSpace': '',
+            '\\clZDiffFormSpace': '',
+            '\\VectorFieldSpace': '',
+            '\\TensorFieldSpace': '',
+            '\\SymTensorFieldSpace': '',
+            '\\DensitySpace': '',
+            '\\cDensitySpace': '',
+            '\\MetricSpace': '',
+            '\\VolSpace': '',
+            '\\EmbeddingSpace': '',
+            '\\ImmersionSpace': '',
+            '\\DiffGroup': '',
+            '\\AutGroup': '',
+            '\\AutAlgebra': '',
+            '\\GauGroup': '',
+            '\\GauAlgebra': '',
+            '\\CoGauAlgebra': '',
+            '\\HamDiffGroup': '',
+            '\\HamVectorFields': '',
+            '\\ConnSpace': '',
+            '\\cenConnSpace': '',
+            '\\cenYMConnSpace': '',
+            '\\PathSpace': '',
+            '\\sPathSpace': '',
+            '\\psPathSpace': '',
+            '\\cPathSpace': '',
+            '\\LoopSpace': '',
+            '\\sLoopSpace': '',
+            '\\psLoopSpace': '',
+            '\\cLoopSpace': '',
+            '\\RepSpace': '',
+            '\\posSSymSpace': '',
+            '\\MatrixSpace': '',
+            '\\SiegelSpace': '',
+            '\\H': '',
+
+            '\\hor': '',
+            '\\Hol': '',
+
+            '\\UGroup': '',
+            '\\UAlgebra': '',
+            '\\SUGroup': '',
+            '\\SUAlgebra': '',
+            '\\PUGroup': '',
+            '\\OGroup': '',
+            '\\OAlgebra': '',
+            '\\SOGroup': '',
+            '\\SpinGroup': '',
+            '\\SpinRep': '',
+            '\\SLGroup': '',
+            '\\GLGroup': '',
+            '\\GLAlgebra': '',
+            '\\SLAlgebra': '',
+            '\\SpGroup': '',
+            '\\SpAlgebra': '',
+            '\\USpGroup': '',
+            '\\UTGroup': '',
+
+            '\\HolGroup': '',
+            '\\HolAlgebra': '',
+            '\\pJetGroup': '',
+            '\\pJetAlgebra': '',
+
+            '\\chernClass': '',
+            '\\stiefelWhitneyClass': '',
+            '\\pontryaginClass': '',
+            '\\JacTorus': '',
+
+            '\\fundamentalGroup': '',
+            '\\sChain': '',
+            '\\sCycles': '',
+            '\\sBoundaries': '',
+            '\\sHomology': '',
+            '\\sCochain': '',
+            '\\sCocycles': '',
+            '\\sCoboundaries': '',
+            '\\sCohomology': '',
+            '\\csCohomology': '',
+            '\\deRCohomology': '',
+            '\\cechCohomology': '',
+            '\\simplex': '',
+            '\\boundary': '',
+            '\\coboundary': '',
+
+            '\\per': '',
+
+            '\\intFibre': '',
+
+            '\\slashed': '',
+
+            '\\laplace': '',
+            '\\dAlambert': '',
+            '\\dif': '',
+            '\\Dif': '',
+            '\\difp': '',
+            '\\difpBar': '',
+            '\\diF': '',
+            '\\difDirac': '',
+            '\\difLog': '',
+            '\\difLie': '',
+
+            '\\difFrac': '',
+            '\\DifFrac': '',
+            '\\difpFrac': '',
+            '\\diFFrac': '',
+            '\\difFracAt': '',
+            '\\difpFracAt': '',
+
+            '\\defeq': '',
+
+            '\\set': '',
+            '\\setc': '',
+
+            '\\restr{function}{subset}': '',
+
+            '\\transversal': '',
+
+            '\\closureSet': '',
+            '\\interior': '',
+            '\\stratification': '',
+
+            '\\isomorph': '',
+            '\\T': '',
+
+            '\\tangent': '',
+            '\\cotangent': '',
+            '\\vtangent': '',
+            '\\tangentLeft': '',
+            '\\pJetProlongation': '',
+            '\\Hessian': '',
+
+            '\\hodgeStar': '',
+
+            '\\symplMatrix': '',
+
+            '\\lSemiProduct': '',
+            '\\rSemiProduct': '',
+
+            '\\intersect': '',
+            '\\bigIntersection': '',
+            '\\union': '',
+            '\\disjUnion': '',
+            '\\bigUnion': '',
+            '\\bigDisjUnion': '',
+            '\\normalSubgroupEq': '',
+
+            '\\normalizer': '',
+            '\\type': '',
+
+            '\\RP': '',
+            '\\CP': '',
+
+            '\\OpenBall': '',
+            '\\ClosedBall': '',
+
+            '\\I': '',
+            '\\imaginary': '',
+            '\\E': '',
+            '\\LeviCivita': '',
+            '\\Kronecker': '',
+
+            '\\curv': '',
+            '\\Ric': '',
+            '\\RicScalar': '',
+
+            '\\Matrix': '',
+            '\\smallMatrix': '',
+            '\\Vector': '',
+
+            '\\grad': '',
+
+            '\\singularPart': '',
+            '\\ext': '',
+
+            '\\ldot': ''
+          }
+        })
 
         // Now the marker has obviously changed
         textMarker.changed()


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
This is still work in progress. The aim is to allow using custom latex command and provide an autocompletion for latex commands.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
- For the autocompletion, I added support to read a cwl file, which enables support of [LaTeX-cwl](https://github.com/LaTeXing/LaTeX-cwl) (that's the only reasonably big library of Latex commands I know). In the end, it's just a text file where each line contains the command definition (e.g. `\implies` or `\sideset{left}{right}{symbol}`). 
- KaTeX supports custom commands which need to be passed via the `macros` option. Right now this is a hard coded array. The better way would be to let the user specify a javascript file defining the commands.

I need a bit of help with the overall structure. In particular, there are three things were I need input:
- What's the best way to make the autocompletion cwl file as well as the macro javascript file configurable? Some hard-coded path relative to Zettlr's install location, some %AppData% path or a preference option?
- As of now, the `cwl` file is read and parsed in the editor. This is probably not a good thing to do. Where should be the parsing done?
- How do I load a custom-specified javascript file (the macros) and access the variables defined therein? I tried `require(absolute path to js)` path this lead to a complete freeze. 

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Win 10
 - Zettlr version: dev

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
