### PR TITLE
Decrease size of math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed artefacts with spellchecking errors. Thanks to @ryota-abe for proposing the correct selector!
 - The Table Editor now remembers what the source table looked like and tries to recreate that when it applies the changes to the DOM.
 - Added verbose error reporting and improved the error handling during citeproc boot. Now, Zettlr will (a) remove error-throwing CiteKeys so that the rest of the library loads just fine and (b) display the exact errors as reported by citeproc-js so that users can immediately identify the bad keys and know where to look.
+- The font size of mathematics was decreased a bit to align it better with the size of normal text. Thanks to @tobiasdiez. 
 
 ## Under the Hood
 

--- a/resources/less/geometry/editor.less
+++ b/resources/less/geometry/editor.less
@@ -80,30 +80,33 @@
       margin-bottom: 0px;
       padding-bottom: 0px;
     }
+
+    // Reduce font size of math a bit
+    .katex { font-size: 1.1em; }
   }
 
 
-  // CodeMirror fullscreen
-  .CodeMirror-fullscreen {
-    position: fixed !important; // Have to override another relative
-    top: @toolbar-height; left: 0; right: 0; bottom: 0;
-    height: auto;
-    z-index: 500;
+// CodeMirror fullscreen
+.CodeMirror-fullscreen {
+  position: fixed !important; // Have to override another relative
+  top: @toolbar-height; left: 0; right: 0; bottom: 0;
+  height: auto;
+  z-index: 500;
 
-    @media(min-width: 1301px) { margin-left: @editor-margin-fullscreen-xxl !important; }
-    @media(max-width: 1300px) { margin-left: @editor-margin-fullscreen-xl  !important; }
-    @media(max-width: 1100px) { margin-left: @editor-margin-fullscreen-lg  !important; }
-    @media(max-width: 1000px) { margin-left: @editor-margin-fullscreen-md  !important; }
-    @media(max-width:  800px) { margin-left: @editor-margin-fullscreen-sm  !important; }
+  @media(min-width: 1301px) { margin-left: @editor-margin-fullscreen-xxl !important; }
+  @media(max-width: 1300px) { margin-left: @editor-margin-fullscreen-xl  !important; }
+  @media(max-width: 1100px) { margin-left: @editor-margin-fullscreen-lg  !important; }
+  @media(max-width: 1000px) { margin-left: @editor-margin-fullscreen-md  !important; }
+  @media(max-width:  800px) { margin-left: @editor-margin-fullscreen-sm  !important; }
 
-    .CodeMirror-scroll {
-      @media(min-width: 1301px) { padding-right: @editor-margin-fullscreen-xxl !important; }
-      @media(max-width: 1300px) { padding-right: @editor-margin-fullscreen-xl  !important; }
-      @media(max-width: 1100px) { padding-right: @editor-margin-fullscreen-lg  !important; }
-      @media(max-width: 1000px) { padding-right: @editor-margin-fullscreen-md  !important; }
-      @media(max-width:  800px) { padding-right: @editor-margin-fullscreen-sm  !important; }
-    }
+  .CodeMirror-scroll {
+    @media(min-width: 1301px) { padding-right: @editor-margin-fullscreen-xxl !important; }
+    @media(max-width: 1300px) { padding-right: @editor-margin-fullscreen-xl  !important; }
+    @media(max-width: 1100px) { padding-right: @editor-margin-fullscreen-lg  !important; }
+    @media(max-width: 1000px) { padding-right: @editor-margin-fullscreen-md  !important; }
+    @media(max-width:  800px) { padding-right: @editor-margin-fullscreen-sm  !important; }
   }
+}
 
 // Define the readability classes
 .cm-readability-0   { background-color: hsv(100, 70%, 95%); color: #444444 !important; }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Decrease math font size from 1.21em to 1.1em.

Before
![image](https://user-images.githubusercontent.com/5037600/78424236-5a321a80-766c-11ea-8955-da0a160b97b2.png)

After
![image](https://user-images.githubusercontent.com/5037600/78424232-4b4b6800-766c-11ea-9549-7e30e5b0206f.png)


<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

<!-- Please provide any testing system -->
## Tested On
 - OS and version: Win 10
 - Zettlr version: latest

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
