### PR TITLE
Add composition check CJK IME when using search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed artefacts with spellchecking errors. Thanks to @ryota-abe for proposing the correct selector!
 - The Table Editor now remembers what the source table looked like and tries to recreate that when it applies the changes to the DOM.
 - Added verbose error reporting and improved the error handling during citeproc boot. Now, Zettlr will (a) remove error-throwing CiteKeys so that the rest of the library loads just fine and (b) display the exact errors as reported by citeproc-js so that users can immediately identify the bad keys and know where to look.
+- Fixed CJK IME input duplicating characters. This works for now, but it hinders auto-completion a bit due to how IME works.
 
 ## Under the Hood
 

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -56,7 +56,12 @@ class ZettlrToolbar {
      */
   _act () {
     // Activate search function.
+
+    let isComposing = false
+    this._searchbar[0].onkeyup = (e) => { isComposing = e.isComposing } // For checking composition state of IME, this event value is not available in jQuery keyEvents
+
     this._searchbar.on('keyup', (e) => {
+      if (isComposing) return // check CJk IME composing state
       if (e.which === 27) { // ESC
         this._searchbar.blur()
         this._searchbar.val('')


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Solves [#660](https://github.com/Zettlr/Zettlr/issues/660)
Check composing state(IME) during key event of search bar (zettlr-toolbar.js).
Append and select auto-complete only when a character is fully composed.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Take event.isComposing from key event and use it to check for composing state.
Using an actual DOM element is necessary because jQuery keyevent does not provide composing state.
![](https://i.imgur.com/twINxuF.gif)

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
Let me know if it needs an additional changes.

<!-- Please provide any testing system -->
Tested on: Windows 10 Home
