### PR TITLE
SPDX: clarify used license

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "git://github.com/Zettlr/Zettlr.git"
     },
     "version": "1.6.0",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "description": "A powerful Markdown editor for researchers.",
     "main": "./source/main.js",
     "scripts": {

--- a/source/package.json
+++ b/source/package.json
@@ -11,7 +11,7 @@
     },
     "version": "1.6.0",
     "description": "A powerful Markdown Editor with integrated tree view",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "main": "main.js",
     "dependencies": {
         "@zettlr/citr": "^1.1.0",


### PR DESCRIPTION
"GPL-3.0" has been deprecated as a License identifier since the
release of version 3.0 of the SPDX specification[1].

This patch updates the package.json files with the now correct
"GPL-3.0-only", reflecting that this project is licensed with GPL
version 3, without an 'or later' clause.

[1] https://spdx.org/licenses/

<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
