### PR TITLE
updated regex for codefence to commonMark spec

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -26,7 +26,7 @@ const highlightingModes = require('../../../common/data').highlightingModes;
     let codeModes = []
 
     for (let [ mimeType, highlightingMode ] of Object.entries(highlightingModes)) {
-      let openRegex = new RegExp('```\\s*(' + highlightingMode.selectors.join('|') + ')')
+      let openRegex = new RegExp('```\\s*(' + highlightingMode.selectors.join('|') + ')\\b')
       codeModes.push({
         open: openRegex,
         close: '```',

--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -26,7 +26,7 @@ const highlightingModes = require('../../../common/data').highlightingModes;
     let codeModes = []
 
     for (let [ mimeType, highlightingMode ] of Object.entries(highlightingModes)) {
-      let openRegex = new RegExp('```\s*(' + highlightingMode.selectors.join('|') + ')')
+      let openRegex = new RegExp('```\\s*(' + highlightingMode.selectors.join('|') + ')')
       codeModes.push({
         open: openRegex,
         close: '```',

--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -26,7 +26,7 @@ const highlightingModes = require('../../../common/data').highlightingModes;
     let codeModes = []
 
     for (let [ mimeType, highlightingMode ] of Object.entries(highlightingModes)) {
-      let openRegex = new RegExp('```(' + highlightingMode.selectors.join('|') + ')$')
+      let openRegex = new RegExp('```\s*(' + highlightingMode.selectors.join('|') + ')')
       codeModes.push({
         open: openRegex,
         close: '```',


### PR DESCRIPTION
It is sometimes useful to stash extra information in the empty space of a codefence `info-string`. Some specs, like CommonMark allow for this, and specifically show such examples of the [`info-string`](https://spec.commonmark.org/0.29/#info-string). A couple tools listed below make great use of this feature, and I'd love to use it in Zettlr. This small change to the regex is all that is required to match CommonMark and allow 1) spacing before the language identifier 2) unmatched material after the language identifier.

* VSCode Markdown Enhanced Preview [code-chunks](https://shd101wyy.github.io/markdown-preview-enhanced/#/code-chunk)
* my own tool
* there was another but I can't remember/find it right now

Proposed Behavioral Change:
Old Syntax Allowed
\`\`\`js
Old Syntax Disallowed
\`\`\`   js
Old Syntax Disallowed
\`\`\`js  custom:property anything...
New Syntax Allowed
\`\`\` js  custom:property anything...

I tried to test this but couldn't. I followed the developer instructions and just get a white window for my branch and also the develop branch. Other people are submitting PRs so I assume there's some magical incantation I just don't know about to get Zettlr to run correctly. Hopefully someone can test this (and update the developer instructions?) Windows 10, npm.

Zettlr is awesome; it's my favorite MD editor! Thanks for all the hard work.