### PR TITLE
updated multiplex regex to correctly match the whole line

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -26,7 +26,7 @@ const highlightingModes = require('../../../common/data').highlightingModes;
     let codeModes = []
 
     for (let [ mimeType, highlightingMode ] of Object.entries(highlightingModes)) {
-      let openRegex = new RegExp('```\\s*(' + highlightingMode.selectors.join('|') + ')\\b')
+      let openRegex = new RegExp('```\\s*(' + highlightingMode.selectors.join('|') + ')\\b.*$')
       codeModes.push({
         open: openRegex,
         close: '```',


### PR DESCRIPTION
There was something nagging me about this - that the text after the language keyword wasn't being styled. In [discussion with Nathan](https://forum.zettlr.com/discussion/140/code-discussion-how-to-apply-styles-to-arbitrary-patterns#latest) I realized I was being an idiot and merely needed to update the regex again. So here's that fix.

Old Regex Example:
```
```\s*(python|sh)\b
```

New Regex Example:
```
```\s*(python|sh)\b.*$
```