### PR TITLE
Feature editor mode preferences (Normal,Vim,Emacs)

### DIFF
--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -286,6 +286,16 @@
             </label>
             <label for="pref-editor-direction-rtl">{{i18n "dialog.preferences.editor_setting.direction_rtl"}}</label>
           </div>
+          
+          <hr>
+          <div class="cb-group">
+            {{i18n "dialog.preferences.input_mode"}}
+            <select name="editor.inputMode">
+              <option value="default" {{#ifCond editor.inputMode '=' 'default'}}selected="selected"{{/ifCond}}>Normal</option>
+              <option value="vim" {{#ifCond editor.inputMode '=' 'vim'}}selected="selected"{{/ifCond}}>Vim</option>
+              <option value="emacs" {{#ifCond editor.inputMode '=' 'emacs'}}selected="selected"{{/ifCond}}>Emacs</option>
+            </select>
+          </div>
         </div>
         <div class="clear"></div>
       </div>

--- a/source/main/providers/config-provider.js
+++ b/source/main/providers/config-provider.js
@@ -185,6 +185,7 @@ class ConfigProvider extends EventEmitter {
         'enableTableHelper': true, // Enable the table helper plugin
         'indentUnit': 4, // The number of spaces to be added
         'countChars': false, // Set to true to enable counting characters instead of words
+        'inputMode': 'default', // Can be default, vim, emacs
         'boldFormatting': '**', // Can be ** or __
         'italicFormatting': '_', // Can be * or _
         'readabilityAlgorithm': 'dale-chall', // The algorithm to use with readability mode.

--- a/source/renderer/assets/codemirror/autoload.js
+++ b/source/renderer/assets/codemirror/autoload.js
@@ -16,6 +16,8 @@ require('codemirror/addon/edit/closebrackets')
 require('./continuelist.js')
 require('./indentlist.js')
 require('codemirror/keymap/sublime') // This will load the extra commands from SublimeText
+require('codemirror/keymap/vim') // This will load the extra commands from Vim
+require('codemirror/keymap/emacs') // This will load the extra commands from Emacs
 
 // 3. Display addons
 require('codemirror/addon/display/fullscreen')

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -773,6 +773,9 @@ class ZettlrEditor {
     this._cm.setOption('direction', global.config.get('editor.direction'))
     this._cm.setOption('rtlMoveVisually', global.config.get('editor.rtlMoveVisually'))
 
+    // Set input mode (vim, emacs, default (sublime))
+    this._cm.setOption('keyMap', global.config.get('editor.inputMode'))
+
     // Last but not least set the Zettelkasten options
     this._cm.setOption('zkn', global.config.get('zkn'))
 


### PR DESCRIPTION
This simply adds a UI element to the preferences (Editor) as a drop down list to change the codemirror editor mode, as pointed out by @nathanlesage in #200 . It works, but I need input on the things below.

Feedback especially needed on:
* **where to put it** in the window, since maybe putting it with the other boolean options is confusing. Should it be after the readability algorithm setting?
* **why label is not getting 'translated'**, I can't tell why this isn't working. I've provided translations for the 4 default language files (DE,GB,US,FR). I must be doing something stupid.

Will this new field get automatically picked up by translate.zettlr.com, or how do I have to add it?

To Do on a future PR?
* change visual cursor to block for vim in insert-mode. (I'm not too familiar with emacs, so don't know if it needs a cursor mode too).

Tested on Window 10:
I performed the following
* starting, setting mode=vim, saving, verifying mode, setting mode=normal, saving, verifying
* starting, setting mode=emacs, saving, verifying mode, setting mode=normal, saving, verifying
* starting, setting mode=vim, saving, closing, starting, verifying
* starting, setting mode=emacs, saving, closing, starting, verifying
* starting, setting mode=vim, saving, closing, starting, verifying, setting mode=normal, saving, verifying