### PR TITLE
Fix both filename and title being added to internal link autcomplete.

### DIFF
--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -165,8 +165,8 @@ class ZettlrEditor {
               let linkPref = global.config.get('zkn.linkWithFilename')
               // Prepare the text to insert, removing the ID if found in the filename
               let text = completion.displayText
-              if (completion.id && text.indexOf(completion.id) >= 0) {
-                text = text.replace(completion.id, '').trim()
+              if (text.startsWith(completion.text)) {
+                text = text.slice(completion.text.length).trim()
               }
               // In case the whole filename consists of the ID, well.
               // Then, have your ID duplicated.


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x ] I documented all behaviour as far as I could do.
  - [ x] I target the develop-branch, and *not* the master branch.
  - [x ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

When automatically adding a filename/title to a link Zettlr will now only add either the title or the filename and not both. (It would previously add both if the file didn't have an id based filename.)

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Changed the code that strips the link text from the start of the link description when the link is id-based to always strip the link even if it's not id-based.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: Archlinux
