### PR TITLE
Filename in link

### DIFF
--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -165,8 +165,8 @@ class ZettlrEditor {
               let linkPref = global.config.get('zkn.linkWithFilename')
               // Prepare the text to insert, removing the ID if found in the filename
               let text = completion.displayText
-              if (completion.id && text.indexOf(completion.id) >= 0) {
-                text = text.replace(completion.id, '').trim()
+              if (text.startsWith(completion.text)) {
+                text = text.slice(completion.text.length).trim()
               }
               // In case the whole filename consists of the ID, well.
               // Then, have your ID duplicated.


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

If a `[[link]]` format is used the autocomplete now places the filename/title within the link like `[[link|filename]]`,rather than placing it after the link like `[[link]] filename`.

If the user changed the link start and end to something other than `[[` and `]]` the filename will be added behind the link instead.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

I changed the on autocomplete callback so the behaviour described above is achieved. 

I also changed the click event listener of the editor so it removes the filename from the autosearch term.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

The reason I propose this change is because it would result in somewhat less ambigious links, making it clearer what text correctly describes the content of the file being linked. (Eg. `[[202004202053]] apple pie` vs `[[202004202053|apple]] pie` or `[[202004202053|apple pie]]`.) And because it would make it easier for someone exporting the notes to html (or some other format) to transform the internal links to proper links with anchor text. (Eg. `[[202004202053|link to notes]]` to `<a href="202004202053.html">link to notes</a>`.)

Due to the changes to the click event listener if the link contains multiple `|` (for example if the filename or id contains a `|`) then it will strip away part of the link and do a search on a part of the link rather than directly going to the file. I figured this was an acceptable trade off since using `|` in either filenames or ids is rather uncommon. (I tried to implement the use of an escape character like `\` but that trips up editor a bit.)

<!-- Please provide any testing system -->
Tested on: Archlinux
