### PR TITLE
Clarity icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node modules
 node_modules
 
+# Package Lock
+package-lock.json
+
 # Compiled releases
 release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
 - The font size of mathematics was decreased a bit to align it better with the size of normal text. Thanks to @tobiasdiez.
 - Support fenced code blocks surrounded by tildes (`~`) instead of backticks.
 - The About dialog of the application now also holds a tab with debug information about both the binary, the system, and the current environment.
+- Switched to using the [Clarity Design](https://clarity.design/icons) icon set where possible.
 
 ## Under the Hood
 

--- a/resources/less/geometry/attachments.less
+++ b/resources/less/geometry/attachments.less
@@ -36,12 +36,12 @@
         text-decoration:none;
         color:inherit;
         white-space:nowrap;
-
-        &::before {
-            font-family: @font-icon;
-            content: "\f285";
-            margin-right:5px;
-            display:inline-block;
+        svg {
+          width: 24px;
+          height: 24px;
+          margin-right: 4px;
+          vertical-align: bottom;
+          margin-bottom: -1px;
         }
     }
 

--- a/resources/less/geometry/attachments.less
+++ b/resources/less/geometry/attachments.less
@@ -10,8 +10,16 @@
     overflow-x:hidden;
 
     #open-dir-external {
-        font-family: @font-icon;
-        cursor:default;
+        padding: @button-margin;
+        border-radius: @border-radius;
+        display: inline-block;
+        width: @button-size;
+        height: @button-size;
+
+        clr-icon {
+            width: @button-icon-size;
+            height: @button-icon-size;
+        }
     }
 
     h1 {

--- a/resources/less/geometry/file-list.less
+++ b/resources/less/geometry/file-list.less
@@ -121,15 +121,12 @@
           left:0;
           bottom:0;
           right:0;
-          font-family: @font-icon;
-          font-size:@font-size-small * 0.8;
           text-align: right;
           margin:0;
 
-          .sortTime, .sortName {
-            padding:0 0.5em;
-            display:inline-block;
-            margin-top:0px; // Overwrite margin of the spans
+          .sortDirection, .sortType {
+            display: inline-block;
+            margin: 3px;
           }
         }
       }

--- a/resources/less/geometry/file-tree.less
+++ b/resources/less/geometry/file-tree.less
@@ -29,26 +29,6 @@
     #directories-dirs-header::before { content: '\f0f0'; }
     #directories-files-header::before { content: '\f0d6'; }
 
-    .collapse-indicator {
-      margin-right:3px;
-      display: inline-block;
-
-      &::before {
-        content: "\f48b";
-        font-family: @font-icon;
-        font-size: @font-size-small * 0.6; /* Bit smaller, those indicators are damned huge */
-        display:inline-block;
-        vertical-align: middle;
-        width:10px;
-        line-height:@ribbon-height;
-        overflow:hidden;
-      }
-
-      &.collapsed::before {
-        content: "\f488";
-      }
-    }
-
     .filename {
         line-height: @ribbon-height;
         padding:@ribbon-padding;
@@ -80,17 +60,6 @@
           margin-top: 0px; // Overwrite margin of the spans
         }
       }
-    }
-
-    .list-item.project > p.filename::before {
-        content: '\f6af';
-        font-family: @font-icon;
-        font-size: @font-size-small; /* Bit smaller, those indicators are damned huge */
-        margin-right:5px;
-        vertical-align: bottom;
-        display:inline-block;
-        position:relative;
-        text-align: text-bottom;
     }
 
     .list-item.dead-directory > p.filename::before {

--- a/resources/less/geometry/file-tree.less
+++ b/resources/less/geometry/file-tree.less
@@ -43,18 +43,9 @@
         position: absolute;
         top: 0px;
         right: 0px;
-        height: @ribbon-height;
-        font-family: @font-icon;
-        font-size: @font-size-small * 0.8;
-        line-height: 100%;
-        text-align: right;
-        margin:0;
 
-        .sortTime, .sortName {
-          padding: 5px;
-          line-height: @ribbon-height;
-          display: inline-block;
-          margin-top: 0px; // Overwrite margin of the spans
+        .sortDirection, .sortType {
+          margin: 5px 3px;
         }
       }
     }

--- a/resources/less/geometry/file-tree.less
+++ b/resources/less/geometry/file-tree.less
@@ -17,17 +17,14 @@
       vertical-align: bottom;
       margin-top: @ribbon-height/2;
 
-      &:before {
-          font-family: @font-icon;
-          font-size: @font-size-small * 0.8;
-          margin:0px 5px;
-          display:inline-block;
-          line-height:@ribbon-height;
+      clr-icon {
+        width: 12px;
+        height: 12px;
+        margin-left: 3px;
+        margin-right: 3px;
+        vertical-align: bottom;
       }
     }
-
-    #directories-dirs-header::before { content: '\f0f0'; }
-    #directories-files-header::before { content: '\f0d6'; }
 
     .filename {
         line-height: @ribbon-height;

--- a/resources/less/geometry/modal.less
+++ b/resources/less/geometry/modal.less
@@ -380,10 +380,17 @@
       overflow-y: auto;
 
       li.user-dict-item {
-        display: block;
+        display: flex;
+        align-items: center;
         cursor: pointer;
         margin: 0;
         padding: 5px;
+        span {
+          flex: 1 0 auto;
+        }
+        clr-icon {
+          flex: 0 1 auto;
+        }
       }
     }
 

--- a/resources/less/geometry/modal.less
+++ b/resources/less/geometry/modal.less
@@ -144,11 +144,6 @@
     // Special treatment for the open-file-buttons
     button.request-file {
       margin: 0;
-      line-height: 140%;
-      &:before {
-        font-family: @font-icon;
-        content: "\f41a";
-      }
     }
 
     // The inputs need to be smaller in size to let the request-file buttons

--- a/resources/less/geometry/modal.less
+++ b/resources/less/geometry/modal.less
@@ -160,6 +160,13 @@
       }
     }
 
+    // Style for buttons solely contain icons
+    button.icon {
+      display: inline-flex;
+      vertical-align: bottom;
+      min-height: 28px;
+    }
+
     // Why the .code-class? Because sometimes we have a small code area,
     // sometimes it's the only content of the dialog (in which case we
     // need to constrain its size in the geometry part)

--- a/resources/less/geometry/modal.less
+++ b/resources/less/geometry/modal.less
@@ -394,6 +394,10 @@
     .selected-dict {
       display: inline-block;
     }
+
+    .tag clr-icon {
+      vertical-align: text-bottom;
+    }
     // END dialog styles
   }
   // END modal styles

--- a/resources/less/geometry/modal.less
+++ b/resources/less/geometry/modal.less
@@ -141,19 +141,13 @@
       text-decoration:none;
     }
 
-    // Special treatment for the open-file-buttons
-    button.request-file {
-      margin: 0;
-    }
 
-    // The inputs need to be smaller in size to let the request-file buttons
-    // fit on the same line
-    div.file-select-group {
+    div.input-button-group {
       display: flex;
       margin-bottom: 1em;
       input {
         flex: 0 5 auto;
-        margin-bottom: 0; // Remove the standard margin and apply it to the box
+        margin: 0;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
       }
@@ -161,6 +155,8 @@
         flex: 0 1 auto;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
+        margin: 0;
+        display: inline-flex;
       }
     }
 

--- a/resources/less/geometry/popup.less
+++ b/resources/less/geometry/popup.less
@@ -354,10 +354,6 @@
   }
 
   .pomodoro p { font-size: 2em; }
-  .pomodoro .pomodoro-sound-indicator::before {
-    content: '\f181'; // icon-music
-    font-family: @font-icon;
-  }
 
   // Footnote edit popup
   .footnote-edit {

--- a/resources/less/geometry/popup.less
+++ b/resources/less/geometry/popup.less
@@ -278,9 +278,18 @@
       &::before {
         font-family: @font-icon;
         font-size:@font-size-small * 0.8;
-        padding-right:5px;
-        width:30px;
+        margin-right:13px;
+        margin-left:5px;
+        width: 20px;
         display:inline-block;
+      }
+
+      & clr-icon {
+          height: 20px;
+          width: 20px;
+          margin-top: -4px;
+          margin-right: 18px;
+          margin-bottom: -4px;
       }
     }
 
@@ -291,27 +300,7 @@
     #header-formatting.markdownHeading5::before { content: "H5"; }
     #header-formatting.markdownHeading6::before { content: "H6"; }
 
-    .markdownBlockquote::before         { content: '\f328'; }
-    .markdownLink::before               { content: "\f022"; }
-    .markdownImage::before              { content: "\22b7"; }
-    .markdownCode::before               { content: "\f743"; }
-    .markdownComment::before            { content: "\f068"; }
-    .markdownMakeOrderedList::before    { content: "\f4c3"; }
-    .markdownMakeUnorderedList::before  { content: "\f4c2"; }
-    .markdownMakeTaskList::before       { content: "\f310"; }
-    .markdownInsertTable::before        { content: "\f4e3"; }
-    .markdownDivider::before            { content: "\f1cc"; }
     .insertFootnote::before             { content: "\f1eb"; }
-
-    .markdownBold {
-      font-weight:bold;
-      &::before { content: "\f1f4"; }
-    }
-
-    .markdownItalic {
-      font-style:italic;
-      &::before { content: "\f1f5"; }
-    }
 
     .removeFootnote::before {
       content: "\f1eb";

--- a/resources/less/geometry/toolbar.less
+++ b/resources/less/geometry/toolbar.less
@@ -19,36 +19,26 @@
       &:focus { outline: 0; }
     }
 
+
     .button {
-        flex-grow:0.1;
+        flex-grow: 0.1;
         outline: 0;
-        display:inline-block;
-        width:@button-size;
-        margin:@button-margin;
-        border-radius:@border-radius; // Control the radius with the margin var
-        text-align:center;
-        line-height:@button-size;
-        font-family: @font-icon;
-        font-size:@font-size-small * 0.8;
+        display: inline-block;
+        width: @button-size;
+        height: @button-size;
+        margin: @button-margin;
+        border-radius: @border-radius; // Control the radius with the margin var
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        & clr-icon {
+            width: @button-icon-size;
+            height: @button-icon-size;
+        }
 
         &:first-child { margin-left:@toolbar-margin * 2; }
         &:last-child { margin-right:@toolbar-margin * 2; }
-
-        &.menu-popup::before         { content: "\f127"; }
-        &.dir-open::before           { content: "\f73e"; }
-        &.file-new::before           { content: "\002b"; }
-        &.stats::before              { content: "\f6b8"; }
-        &.tag-cloud::before          { content: "\f482"; }
-        &.preferences::before        { content: "\f00f"; }
-        &.file-save::before          { content: "\f0c8"; }
-        &.file-delete::before        { content: "\f0ce"; }
-        &.file-rename::before        { content: "\f5d4"; }
-        &.formatting::before         { content: "\f4e8"; }
-        &.find::before               { content: "\f0c5"; }
-        &.readability::before        { content: "\f295"; }
-        &.share::before              { content: "\f16c"; }
-        &.show-toc::before           { content: "\f68c"; }
-        &.toggle-attachments::before { content: "\f285"; } // Alternative: '\f284' and '\f286'
 
         // Pomodoro meter
         &.pomodoro {

--- a/resources/less/geometry/variables.less
+++ b/resources/less/geometry/variables.less
@@ -20,6 +20,7 @@
 @tabbar-height:         25px;
 
 @button-size:           @toolbar-height - 10px; // these are the margin
+@button-icon-size:      @button-size - 8px;
 @button-margin:         5px; // Top+Bottom -> 10px
 @searchbar-height:      30px;
 

--- a/resources/less/theme-berlin/dark/attachments.less
+++ b/resources/less/theme-berlin/dark/attachments.less
@@ -7,10 +7,11 @@
     color:var(--grey-0);
 
     #open-dir-external {
-        color:var(--grey-6);
+        fill: var(--grey-0);
+        transition: @mode-transition background-color ease;
 
         &:hover {
-            color:var(--grey-2);
+            background-color: var(--grey-6);
         }
     }
 }

--- a/resources/less/theme-berlin/dark/file-list.less
+++ b/resources/less/theme-berlin/dark/file-list.less
@@ -38,7 +38,7 @@
         background-color:var(--grey-8);
         color: var(--c-primary-shade);
 
-        .sorter .sortTime, .sorter .sortName {
+        .sorter .sortDirection, .sorter .sortType {
           background-color: var(--grey-8);
           &:hover { color: var(--grey-2); }
         }

--- a/resources/less/theme-berlin/dark/file-tree.less
+++ b/resources/less/theme-berlin/dark/file-tree.less
@@ -38,7 +38,7 @@
         }
       }
 
-      .sorter .sortTime, .sorter .sortName {
+      .sorter .sortDirection, .sorter .sortType {
         color: white;
         background-color:var(--grey-6);
         &:hover { color: var(--grey-1); }

--- a/resources/less/theme-berlin/dark/popup.less
+++ b/resources/less/theme-berlin/dark/popup.less
@@ -6,6 +6,11 @@
     border-color: var(--popup-dark-shade);
     color:var(--popup-dark-text);
 
+    & clr-icon svg path {
+        stroke: var(--popup-dark-text);
+        fill: var(--popup-dark-text);
+    }
+
     button {
         background-color: var(--popup-dark-color);
         color: var(--popup-dark-text);

--- a/resources/less/theme-berlin/dark/toolbar.less
+++ b/resources/less/theme-berlin/dark/toolbar.less
@@ -9,6 +9,11 @@
         &:not(.pomodoro):hover {
             background-color: var(--grey-6);
         }
+
+        & clr-icon svg path {
+            stroke: var(--popup-dark-text);
+            fill: var(--popup-dark-text);
+        }
     }
 
     .searchbar {

--- a/resources/less/theme-berlin/light/attachments.less
+++ b/resources/less/theme-berlin/light/attachments.less
@@ -7,4 +7,10 @@
       cursor: pointer;
       text-decoration: underline;
     }
+    #open-dir-external {
+        transition: @mode-transition background-color ease;
+        &:hover {
+            background-color: var(--grey-2);
+        }
+    }
 }

--- a/resources/less/theme-berlin/light/file-list.less
+++ b/resources/less/theme-berlin/light/file-list.less
@@ -29,7 +29,7 @@
       transition: @mode-transition background-color ease;
       color:var(--c-primary);
 
-      .sorter .sortTime, .sorter .sortName {
+      .sorter .sortDirection, .sorter .sortType {
         background-color:var(--grey-1);
         &:hover { color:var(--grey-5); }
       }

--- a/resources/less/theme-berlin/light/file-tree.less
+++ b/resources/less/theme-berlin/light/file-tree.less
@@ -69,7 +69,7 @@
           font-size: @font-size-small * 0.8; // Even smaller
         }
 
-        .sorter .sortTime, .sorter .sortName {
+        .sorter .sortDirection, .sorter .sortType {
           color: var(--grey-4);
           background-color:var(--grey-1);
           &:hover { color: var(--grey-8); }

--- a/resources/less/theme-berlin/modal.less
+++ b/resources/less/theme-berlin/modal.less
@@ -168,11 +168,7 @@
             position: relative;
             border-bottom: 1px solid var(--grey-2);
 
-            &::after {
-              content: "\00d7";
-              position: absolute;
-              right: 5px;
-              font-weight: bold;
+            clr-icon {
               color: var(--red-5);
             }
 

--- a/resources/less/theme-berlin/modal.less
+++ b/resources/less/theme-berlin/modal.less
@@ -88,15 +88,6 @@
           &:hover, &:focus { background-color: var(--c-primary); color: var(--bg-primary); }
         }
 
-        // This class can be used for the combination of a label with an input
-        // text and a button (e.g. to reset). If applied to the parent container
-        // it will change the appearance of these three elements.
-        .form-inline-buttons {
-          label { display: block; margin-bottom:0.2em; }
-          input[type="text"] { width: 80%; margin:0; }
-          button, a.button { margin:0; }
-        }
-
         // The wrapper for the preferences submit & cancel buttons
         .prefs-submit-group { clear: both; }
 

--- a/resources/templates/dialog/pdf-preferences.handlebars
+++ b/resources/templates/dialog/pdf-preferences.handlebars
@@ -16,7 +16,7 @@
                 <input type="text" name="pdf.keywords" if="pdf.keywords" value="{{pdf.keywords}}" placeholder="{{i18n "dialog.preferences.pdf.keywords"}}">
                 <hr>
                 <label for="textpl">{{i18n "dialog.preferences.pdf.textpl"}}</label>
-                <div class="file-select-group">
+                <div class="input-button-group">
                   <input type="text" name="pdf.textpl" id="textpl" value="{{pdf.textpl}}">
                   <button type="button" class="request-file"
                   data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"

--- a/resources/templates/dialog/pdf-preferences.handlebars
+++ b/resources/templates/dialog/pdf-preferences.handlebars
@@ -22,7 +22,7 @@
                   data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
                   data-request-name="TeX Template File"
                   data-request-ext="tex"
-                  data-request-target="#textpl"></button>
+                  data-request-target="#textpl"><clr-icon shape="file"></clr-icon></button>
                 </div>
             </div>
             <!-- Page layout -->

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -692,7 +692,8 @@
             {{#each userDictionary}}
             <li class="user-dict-item">
               <input type="hidden" value="{{this}}" name="userDictionary">
-              {{this}}
+              <span>{{this}}</span>
+              <clr-icon shape="times"></clr-icon>
             </li>
             {{/each}}
           </ul>

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -807,7 +807,7 @@
               </tbody>
             </table>
           </div>
-          <button id="add-autocorrect-key"><clr-icon shape="plus"></clr-icon></button>
+          <button id="add-autocorrect-key" class="icon"><clr-icon shape="plus"></clr-icon></button>
           </div>
       </div>
 

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -767,7 +767,7 @@
                   <td>
                     <div class="form-inline-buttons">
                       <input type="text" name="autoCorrectValues[]" value="{{ value }}">
-                      <button class="autocorrect-remove-row">&times;</button>
+                      <button class="autocorrect-remove-row"><clr-icon shape="times"></clr-icon></button>
                     </div>
                   </td>
                 </tr>

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -775,7 +775,7 @@
               </tbody>
             </table>
           </div>
-          <button id="add-autocorrect-key">+</button>
+          <button id="add-autocorrect-key"><clr-icon shape="plus"></clr-icon></button>
           </div>
       </div>
 

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -337,7 +337,7 @@
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
             data-request-name="CSL JSON or BibTex"
             data-request-ext="json,bib"
-            data-request-target="#cslLibrary"></button>
+            data-request-target="#cslLibrary"><clr-icon shape="file"></clr-icon></button>
           </div>
           <label for="cslStyle">{{i18n "dialog.preferences.project.csl_style"}}</label>
           <div class="file-select-group">
@@ -346,7 +346,7 @@
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
             data-request-name="Citation Style Language File"
             data-request-ext="csl"
-            data-request-target="#cslStyle"></button>
+            data-request-target="#cslStyle"><clr-icon shape="file"></clr-icon></button>
           </div>
         </div>
       </div>

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -355,7 +355,7 @@
           </div>
           <hr>
           <label for="cslLibrary">{{i18n "dialog.preferences.citation_database"}}</label>
-          <div class="file-select-group">
+          <div class="input-button-group">
             <input type="text" name="export.cslLibrary" id="cslLibrary" value="{{export.cslLibrary}}">
             <button type="button" class="request-file"
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
@@ -364,7 +364,7 @@
             data-request-target="#cslLibrary"><clr-icon shape="file"></clr-icon></button>
           </div>
           <label for="cslStyle">{{i18n "dialog.preferences.project.csl_style"}}</label>
-          <div class="file-select-group">
+          <div class="input-button-group">
             <input type="text" name="export.cslStyle" id="cslStyle" value="{{export.cslStyle}}">
             <button type="button" class="request-file"
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
@@ -379,19 +379,27 @@
 
       <!-- Zettelkasten options -->
       <div id="prefs-tabs-zkn">
-        <div class="box-left form-inline-buttons">
+        <div class="box-left">
           <label for="pref-zkn-free-id">{{i18n "dialog.preferences.zkn.id_label"}}</label>
-          <input type="text" id="pref-zkn-free-id" value="{{zkn.idRE}}" name="zkn.idRE">
-          <button type="button" id="reset-id-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_id"}}"><clr-icon shape="refresh"></clr></button>
+          <div class="input-button-group">
+            <input type="text" id="pref-zkn-free-id" value="{{zkn.idRE}}" name="zkn.idRE">
+            <button type="button" id="reset-id-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_id"}}"><clr-icon shape="refresh"></clr></button>
+          </div>
           <label for="pref-zkn-free-linkstart">{{i18n "dialog.preferences.zkn.linkstart_label"}}</label>
-          <input type="text" id="pref-zkn-free-linkstart" value="{{zkn.linkStart}}" name="zkn.linkStart">
-          <button type="button" id="reset-linkstart-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkstart"}}"><clr-icon shape="refresh"></clr></button>
+          <div class="input-button-group">
+            <input type="text" id="pref-zkn-free-linkstart" value="{{zkn.linkStart}}" name="zkn.linkStart">
+            <button type="button" id="reset-linkstart-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkstart"}}"><clr-icon shape="refresh"></clr></button>
+          </div>
           <label for="pref-zkn-free-linkend">{{i18n "dialog.preferences.zkn.linkend_label"}}</label>
-          <input type="text" id="pref-zkn-free-linkend" value="{{zkn.linkEnd}}" name="zkn.linkEnd">
-          <button type="button" id="reset-linkend-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkend"}}"><clr-icon shape="refresh"></clr></button>
+          <div class="input-button-group">
+            <input type="text" id="pref-zkn-free-linkend" value="{{zkn.linkEnd}}" name="zkn.linkEnd">
+            <button type="button" id="reset-linkend-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkend"}}"><clr-icon shape="refresh"></clr></button>
+          </div>
           <label for="pref-zkn-id-gen">{{i18n "dialog.preferences.zkn.id_generator_label"}}</label>
-          <input type="text" id="pref-zkn-id-gen" value="{{zkn.idGen}}" name="zkn.idGen">
-          <button type="button" id="reset-id-generator" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_generator"}}"><clr-icon shape="refresh"></clr></button>
+          <div class="input-button-group">
+            <input type="text" id="pref-zkn-id-gen" value="{{zkn.idGen}}" name="zkn.idGen">
+            <button type="button" id="reset-id-generator" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_generator"}}"><clr-icon shape="refresh"></clr></button>
+          </div>
           <hr>
           <p>
             <button type="button" id="generate-id">{{i18n "dialog.preferences.zkn.test_id_generator"}}</button>
@@ -784,12 +792,12 @@
                 {{#each autoCorrectReplacements }}
                 <tr>
                   <td>
-                    <div class="form-inline-buttons">
+                    <div class="input-button-group">
                       <input type="text" name="autoCorrectKeys[]" value="{{ key }}">
                     </div>
                   </td>
                   <td>
-                    <div class="form-inline-buttons">
+                    <div class="input-button-group">
                       <input type="text" name="autoCorrectValues[]" value="{{ value }}">
                       <button class="autocorrect-remove-row"><clr-icon shape="times"></clr-icon></button>
                     </div>
@@ -863,7 +871,7 @@
           <label for="pandocCommand">
             {{i18n "dialog.preferences.pandoc_command"}}
           </label>
-          <div class="form-inline-buttons">
+          <div class="input-button-group">
             <input type="text" id="pandocCommand" name="pandocCommand" placeholder="pandoc &quot;$infile$&quot; -f markdown $outflag$ $tpl$ $toc$ $tocdepth$ $citeproc$ $standalone$ --pdf-engine=xelatex --mathjax -o &quot;$outfile$&quot;" value="{{ pandocCommand }}">
             <button type="button" id="reset-pandoc-command" data-tippy-content="{{i18n "dialog.preferences.reset_pandoc_command"}}"><clr-icon shape="refresh"></clr></button>
           </div>

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -358,16 +358,16 @@
         <div class="box-left form-inline-buttons">
           <label for="pref-zkn-free-id">{{i18n "dialog.preferences.zkn.id_label"}}</label>
           <input type="text" id="pref-zkn-free-id" value="{{zkn.idRE}}" name="zkn.idRE">
-          <button type="button" id="reset-id-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_id"}}">&#9003;</button>
+          <button type="button" id="reset-id-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_id"}}"><clr-icon shape="refresh"></clr></button>
           <label for="pref-zkn-free-linkstart">{{i18n "dialog.preferences.zkn.linkstart_label"}}</label>
           <input type="text" id="pref-zkn-free-linkstart" value="{{zkn.linkStart}}" name="zkn.linkStart">
-          <button type="button" id="reset-linkstart-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkstart"}}">&#9003;</button>
+          <button type="button" id="reset-linkstart-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkstart"}}"><clr-icon shape="refresh"></clr></button>
           <label for="pref-zkn-free-linkend">{{i18n "dialog.preferences.zkn.linkend_label"}}</label>
           <input type="text" id="pref-zkn-free-linkend" value="{{zkn.linkEnd}}" name="zkn.linkEnd">
-          <button type="button" id="reset-linkend-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkend"}}">&#9003;</button>
+          <button type="button" id="reset-linkend-regex" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_linkend"}}"><clr-icon shape="refresh"></clr></button>
           <label for="pref-zkn-id-gen">{{i18n "dialog.preferences.zkn.id_generator_label"}}</label>
           <input type="text" id="pref-zkn-id-gen" value="{{zkn.idGen}}" name="zkn.idGen">
-          <button type="button" id="reset-id-generator" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_generator"}}">&#9003;</button>
+          <button type="button" id="reset-id-generator" data-tippy-content="{{i18n "dialog.preferences.zkn.reset_default_generator"}}"><clr-icon shape="refresh"></clr></button>
           <hr>
           <p>
             <button type="button" id="generate-id">{{i18n "dialog.preferences.zkn.test_id_generator"}}</button>
@@ -841,7 +841,7 @@
           </label>
           <div class="form-inline-buttons">
             <input type="text" id="pandocCommand" name="pandocCommand" placeholder="pandoc &quot;$infile$&quot; -f markdown $outflag$ $tpl$ $toc$ $tocdepth$ $citeproc$ $standalone$ --pdf-engine=xelatex --mathjax -o &quot;$outfile$&quot;" value="{{ pandocCommand }}">
-            <button type="button" id="reset-pandoc-command" data-tippy-content="{{i18n "dialog.preferences.reset_pandoc_command"}}">&#9003;</button>
+            <button type="button" id="reset-pandoc-command" data-tippy-content="{{i18n "dialog.preferences.reset_pandoc_command"}}"><clr-icon shape="refresh"></clr></button>
           </div>
           <span class="info">Variables: $citeproc$, $format$, $infile$, $indir$, $outfile$, $outflag$, $standalone$, $toc$, $tocdepth$, $tpl$</span>
         </div>

--- a/resources/templates/dialog/project-properties.handlebars
+++ b/resources/templates/dialog/project-properties.handlebars
@@ -27,7 +27,7 @@
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
             data-request-name="TeX Template File"
             data-request-ext="tex"
-            data-request-target="#textpl"></button>
+            data-request-target="#textpl"><clr-icon shape="file"></clr-icon></button>
           </div>
         </div>
         <div class="box-right">
@@ -62,7 +62,7 @@
               data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
               data-request-name="Citation Style Language File"
               data-request-ext="csl"
-              data-request-target="#cslStyle"></button>
+              data-request-target="#cslStyle"><clr-icon shape="file"></clr-icon></button>
           </div>
           <div class="clearfix"></div>
         </div>

--- a/resources/templates/dialog/project-properties.handlebars
+++ b/resources/templates/dialog/project-properties.handlebars
@@ -21,7 +21,7 @@
           <input type="text" name="pdf.keywords" if="pdf.keywords" value="{{pdf.keywords}}" placeholder="{{i18n "dialog.preferences.pdf.keywords"}}">
           <hr>
           <label for="textpl">{{i18n "dialog.preferences.pdf.textpl"}}</label>
-          <div class="file-select-group">
+          <div class="input-button-group">
             <input type="text" name="pdf.textpl" id="textpl" value="{{pdf.textpl}}">
             <button type="button" class="request-file"
             data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"
@@ -56,7 +56,7 @@
           </select>
           <hr>
           <label for="cslStyle">{{i18n "dialog.preferences.project.csl_style"}}</label>
-          <div class="file-select-group">
+          <div class="input-button-group">
             <input type="text" name="cslStyle" id="cslStyle" value="{{cslStyle}}">
             <button type="button" class="request-file"
               data-tippy-content="{{i18n "dialog.preferences.choose_file"}}"

--- a/resources/templates/dialog/tag-cloud.handlebars
+++ b/resources/templates/dialog/tag-cloud.handlebars
@@ -4,7 +4,7 @@
     <p><input type="text" id="filter-tags" placeholder="{{i18n "dialog.filter_tags"}}"></p>
     <p>
         {{#each tags}}
-        <span class="tag" data-tag="#{{ text }}">{{ text }} <small>{{ count }}&times;</small></span>
+        <span class="tag" data-tag="#{{ text }}">{{ text }} <small>{{ count }}<clr-icon shape="times"></clr-icon></small></span>
         {{/each}}
     </p>
     <button id="abort">{{i18n "dialog.button.close"}}</button>

--- a/resources/templates/dialog/tags-preferences.handlebars
+++ b/resources/templates/dialog/tags-preferences.handlebars
@@ -15,7 +15,7 @@
               {{/each}}
             </div>
         </div>
-        <button type="button" id="addTagLine">+</button>
+        <button type="button" id="addTagLine"><clr-icon shape="plus"></clr-icon></button>
         <button type="submit" id="pref-save">{{i18n "dialog.button.save"}}</button>
         <button id="abort">{{i18n "dialog.button.cancel"}}</button>
     </form>

--- a/resources/templates/dialog/tags-preferences.handlebars
+++ b/resources/templates/dialog/tags-preferences.handlebars
@@ -15,7 +15,7 @@
               {{/each}}
             </div>
         </div>
-        <button type="button" id="addTagLine"><clr-icon shape="plus"></clr-icon></button>
+        <button type="button" id="addTagLine" class="icon"><clr-icon shape="plus"></clr-icon></button>
         <button type="submit" id="pref-save">{{i18n "dialog.button.save"}}</button>
         <button id="abort">{{i18n "dialog.button.cancel"}}</button>
     </form>

--- a/resources/templates/popup/format.handlebars
+++ b/resources/templates/popup/format.handlebars
@@ -7,21 +7,21 @@
     <span class="markdownHeading5">#</span>
     <span class="markdownHeading6">#</span>
   </a>
-  <a href="#" class="markdownBold">{{i18n 'gui.formatting.bold'}}</a>
-  <a href="#" class="markdownItalic">{{i18n 'gui.formatting.italic'}}</a>
-  <a href="#" class="markdownCode">{{i18n 'gui.formatting.code'}}</a>
-  <a href="#" class="markdownComment">{{i18n 'gui.formatting.comment'}}</a>
+  <a href="#" class="markdownBold"><clr-icon shape="bold"></clr-icon>{{i18n 'gui.formatting.bold'}}</a>
+  <a href="#" class="markdownItalic"><clr-icon shape="italic"></clr-icon>{{i18n 'gui.formatting.italic'}}</a>
+  <a href="#" class="markdownCode"><clr-icon shape="code-alt"></clr-icon>{{i18n 'gui.formatting.code'}}</a>
+  <a href="#" class="markdownComment"><clr-icon shape="code"></clr-icon>{{i18n 'gui.formatting.comment'}}</a>
   <hr>
-  <a href="#" class="markdownLink">{{i18n 'gui.formatting.link'}}</a>
-  <a href="#" class="markdownImage">{{i18n 'gui.formatting.image'}}</a>
+  <a href="#" class="markdownLink"><clr-icon shape="link"></clr-icon>{{i18n 'gui.formatting.link'}}</a>
+  <a href="#" class="markdownImage"><clr-icon shape="image"></clr-icon>{{i18n 'gui.formatting.image'}}</a>
   <hr>
-  <a href="#" class="markdownBlockquote">{{i18n 'gui.formatting.blockquote'}}</a>
-  <a href="#" class="markdownMakeOrderedList">{{i18n 'gui.formatting.ol'}}</a>
-  <a href="#" class="markdownMakeUnorderedList">{{i18n 'gui.formatting.ul'}}</a>
-  <a href="#" class="markdownMakeTaskList">{{i18n "gui.formatting.tasklist"}}</a>
-  <a href="#" class="markdownInsertTable">{{i18n 'gui.formatting.insert_table'}}</a>
+  <a href="#" class="markdownBlockquote"><clr-icon shape="block-quote"></clr-icon>{{i18n 'gui.formatting.blockquote'}}</a>
+  <a href="#" class="markdownMakeOrderedList"><clr-icon shape="number-list"></clr-icon>{{i18n 'gui.formatting.ol'}}</a>
+  <a href="#" class="markdownMakeUnorderedList"><clr-icon shape="bullet-list"></clr-icon>{{i18n 'gui.formatting.ul'}}</a>
+  <a href="#" class="markdownMakeTaskList"><clr-icon shape="checkbox-list"></clr-icon>{{i18n "gui.formatting.tasklist"}}</a>
+  <a href="#" class="markdownInsertTable"><clr-icon shape="table"></clr-icon>{{i18n 'gui.formatting.insert_table'}}</a>
   <hr>
-  <a href="#" class="markdownDivider">{{i18n 'gui.formatting.divider'}}</a>
+  <a href="#" class="markdownDivider"><clr-icon shape="minus"></clr-icon>{{i18n 'gui.formatting.divider'}}</a>
   <a href="#" class="insertFootnote">{{i18n 'gui.formatting.footnote'}}</a>
   <a href="#" class="removeFootnote">{{i18n 'gui.formatting.remove_footnote'}}</a>
 </div>

--- a/resources/templates/popup/pomodoro-settings.handlebars
+++ b/resources/templates/popup/pomodoro-settings.handlebars
@@ -4,7 +4,7 @@
   <input type="number" class="pomodoro-long" value="{{duration_long}}" name="long" min="1" max="100" required>
   {{!-- pomodoro.mute --}}
   <div class="pomodoro-sound-container">
-    <span class="pomodoro-sound-indicator"></span>
+    <clr-icon shape="music-note" class="is-solid"></clr-icon>
     <span id="pomodoro-volume-level">{{ volume }}%</span>
   </div>
   <input type="range" id="pomodoro-volume-range" name="volume" min="0" max="100" value="{{volume}}">

--- a/resources/vue/file-item.vue
+++ b/resources/vue/file-item.vue
@@ -25,7 +25,12 @@
     v-on:dragend.stop="stopDragging"
     >
     <p class="filename">{{ basename }}</p>
-    <Sorter v-if="isDirectory" v-show="hover" v-bind:sorting="obj.sorting"></Sorter>
+    <Sorter
+      v-if="isDirectory"
+      v-show="hover"
+      v-bind:sorting="obj.sorting"
+      v-on:sort-change="sort">
+    </Sorter>
     <tag-list v-bind:tags="getTags" v-if="!isDirectory"></tag-list>
     <template v-if="fileMeta">
       <div class="meta">
@@ -174,20 +179,11 @@
             global.ipc.send('dir-select', this.obj.hash)
           }
         },
-        toggleSorting: function (type) {
-          let newSorting = 'name-up'
-          if (type === 'name') {
-            if (this.obj.sorting === 'name-up') newSorting = 'name-down'
-          } else if (type === 'time') {
-            if (this.obj.sorting === 'time-up') {
-              newSorting = 'time-down'
-            } else {
-              newSorting = 'time-up'
-            }
-          }
-
-          // Request to re-sort this directory
-          global.ipc.send('dir-sort', { 'hash': this.obj.hash, 'type': newSorting })
+        /**
+         * Request to re-sort this directory
+         */
+        sort: function (sorting) {
+          global.ipc.send('dir-sort', { 'hash': this.obj.hash, 'type': sorting })
         },
         beginDragging: function (event) {
           if (event.ctrlKey || event.altKey) {

--- a/resources/vue/sidebar.vue
+++ b/resources/vue/sidebar.vue
@@ -30,7 +30,9 @@
     <div id="component-container">
       <div id="file-tree" ref="directories" v-on:click="selectionListener">
         <template v-if="$store.state.items.length > 0">
-          <div id="directories-files-header" v-show="getFiles.length > 0">{{ fileSectionHeading }}</div>
+          <div id="directories-files-header" v-show="getFiles.length > 0">
+            <clr-icon shape="file"></clr-icon>{{ fileSectionHeading }}
+          </div>
             <tree-item
               v-for="item in getFiles"
               v-bind:obj="item"
@@ -38,7 +40,9 @@
               v-bind:depth="0"
             >
             </tree-item>
-            <div id="directories-dirs-header" v-show="getDirectories.length > 0">{{ dirSectionHeading }}</div>
+            <div id="directories-dirs-header" v-show="getDirectories.length > 0">
+              <clr-icon shape="tree-view"></clr-icon>{{ dirSectionHeading }}
+            </div>
             <tree-item
               v-for="item in getDirectories"
               v-bind:obj="item"

--- a/resources/vue/sorter.vue
+++ b/resources/vue/sorter.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="sorter">
-    <span class="sortName" v-on:click.stop="toggleSorting('name')">
-      <span v-html="sortingNameIcon"></span>
+    <clr-icon
+      class="sortType"
+      v-on:click.stop="toggleType()"
+      v-bind:shape="type">
       <!-- Same line to remove the nbsp added by Chrome -->
-    </span><span class="sortTime" v-on:click.stop="toggleSorting('time')">
-      <span v-html="sortingTimeIcon"></span>
-    </span>
+    </clr-icon><clr-icon
+      class="sortDirection"
+      v-on:click.stop="toggleDirection()"
+      shape="sort-by"
+      v-bind:flip="flip"></clr-icon>
   </div>
 </template>
 
@@ -16,13 +20,24 @@ module.exports = {
   ],
   name: 'sorter',
   computed: {
-    sortingNameIcon: function () { return (this.sorting === 'name-up') ? '&#xf1c2;' : '&#xf1c1;' },
-    sortingTimeIcon: function () { return (this.sorting === 'time-up') ? '&#xf1c3;' : '&#xf1c4;' }
+    type: function () { return this.sorting.startsWith('time') ? 'clock' : 'text' },
+    flip: function () { return this.sorting.endsWith('up') ? 'vertical' : '' }
   },
   methods: {
-    toggleSorting: function (type) {
-      this.$parent.toggleSorting(type)
-    }
+    toggleType: function () {
+      if (this.sorting.startsWith('time')) {
+        this.$emit('sort-change', this.sorting.replace('time', 'name'))
+      } else {
+        this.$emit('sort-change', this.sorting.replace('name', 'time'))
+      }
+    },
+    toggleDirection: function () {
+      if (this.sorting.endsWith('up')) {
+        this.$emit('sort-change', this.sorting.replace('up', 'down'))
+      } else {
+        this.$emit('sort-change', this.sorting.replace('down', 'up'))
+      }
+    },
   }
 }
 </script>

--- a/resources/vue/tree-item.vue
+++ b/resources/vue/tree-item.vue
@@ -33,7 +33,8 @@
       v-on:mouseleave="hover=false"
     >
       <p class="filename" v-bind:data-hash="obj.hash">
-        <span v-show="hasChildren" v-on:click.stop="toggleCollapse" v-bind:class="indicatorClass"></span>
+        <clr-icon v-show="obj.project" shape="blocks-group" class="is-solid"></clr-icon>
+        <clr-icon v-show="hasChildren" v-on:click.stop="toggleCollapse" v-bind:shape="indicatorShape"></clr-icon>
         {{ obj.name }}<span v-if="hasDuplicateName" class="dir">&nbsp;({{ dirname }})</span>
       </p>
       <Sorter v-if="isDirectory && combined" v-show="hover" v-bind:sorting="obj.sorting"></Sorter>
@@ -147,9 +148,9 @@ module.exports = {
       return this.combined ? this.obj.children : this.obj.children.filter(e => e.type !== 'file')
     },
     /**
-     * Returns the correct indicator class (necessary for the indicator CSS content property)
+     * Returns the correct indicator shape
      */
-    indicatorClass: function () { return this.collapsed ? 'collapse-indicator collapsed' : 'collapse-indicator' },
+    indicatorShape: function () { return this.collapsed ? 'caret right' : 'caret down' },
     /**
      * Returns the amount of padding that should be applied, based on the depth
      */

--- a/resources/vue/tree-item.vue
+++ b/resources/vue/tree-item.vue
@@ -37,7 +37,12 @@
         <clr-icon v-show="hasChildren" v-on:click.stop="toggleCollapse" v-bind:shape="indicatorShape"></clr-icon>
         {{ obj.name }}<span v-if="hasDuplicateName" class="dir">&nbsp;({{ dirname }})</span>
       </p>
-      <Sorter v-if="isDirectory && combined" v-show="hover" v-bind:sorting="obj.sorting"></Sorter>
+      <Sorter
+        v-if="isDirectory && combined"
+        v-show="hover"
+        v-bind:sorting="obj.sorting"
+        v-on:sort-change="sort">
+      </Sorter>
     </div>
     <div
       v-if="hasSearchResults"
@@ -208,22 +213,10 @@ module.exports = {
      */
     toggleCollapse: function (event) { this.collapsed = !this.collapsed },
     /**
-     * Toggles the sorting of the item, if it's a directory
+     * Request to re-sort this directory
      */
-    toggleSorting: function (type) {
-      let newSorting = 'name-up'
-      if (type === 'name' && this.obj.sorting === 'name-up') {
-        newSorting = 'name-down'
-      } else if (type === 'time') {
-        if (this.obj.sorting === 'time-up') {
-          newSorting = 'time-down'
-        } else {
-          newSorting = 'time-up'
-        }
-      }
-
-      // Request to re-sort this directory
-      global.ipc.send('dir-sort', { 'hash': this.obj.hash, 'type': newSorting })
+    sort: function (sorting) {
+      global.ipc.send('dir-sort', { 'hash': this.obj.hash, 'type': sorting })
     },
     /**
      * Initiates a drag movement and inserts the correct data

--- a/source/package.json
+++ b/source/package.json
@@ -14,6 +14,7 @@
     "license": "GPL-3.0",
     "main": "main.js",
     "dependencies": {
+        "@clr/icons": "^3.1.2",
         "@zettlr/citr": "^1.1.0",
         "adm-zip": "^0.4.14",
         "archiver": "^4.0.1",

--- a/source/renderer/assets/icons/clarity-custom/LICENSE
+++ b/source/renderer/assets/icons/clarity-custom/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2018 VMware, Inc.				
+
+The MIT license (the "License") set forth below applies to all parts of the clarity-assets project.  You may not use this file except in compliance with the License.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/source/renderer/assets/icons/clarity-custom/code-alt.svg
+++ b/source/renderer/assets/icons/clarity-custom/code-alt.svg
@@ -1,0 +1,5 @@
+<svg version="1.1" width="36" height="36"  viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>code-line</title>
+    <path d="M13.71,12.59a1,1,0,0,0-1.39-.26L5.79,16.78a1,1,0,0,0,0,1.65l6.53,4.45a1,1,0,1,0,1.13-1.65L8.13,17.61,13.45,14A1,1,0,0,0,13.71,12.59Z" class="clr-i-outline clr-i-outline-path-1"></path><path d="M30.21,16.78l-6.53-4.45A1,1,0,1,0,22.55,14l5.32,3.63-5.32,3.63a1,1,0,0,0,1.13,1.65l6.53-4.45a1,1,0,0,0,0-1.65Z" class="clr-i-outline clr-i-outline-path-2"></path>
+    <rect x="0" y="0" width="36" height="36" fill-opacity="0"/>
+</svg>

--- a/source/renderer/assets/icons/clarity-custom/file-ext.svg
+++ b/source/renderer/assets/icons/clarity-custom/file-ext.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
+   preserveAspectRatio="xMidYMid meet"
+   id="svg8"
+   sodipodi:docname="file-ext.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>file-line</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1028"
+     id="namedview10"
+     showgrid="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:zoom="10.680556"
+     inkscape:cx="6.1181478"
+     inkscape:cy="31.87355"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid865"
+       dotted="false" />
+  </sodipodi:namedview>
+  <title
+     id="title2">file-line</title>
+  <path
+     class="clr-i-outline clr-i-outline-path-1"
+     d="M21.89,4H7.83A1.88,1.88,0,0,0,6,5.91V30.09A1.88,1.88,0,0,0,7.83,32H28.17A1.88,1.88,0,0,0,30,30.09V11.92Zm-.3,2.49,6,5.9h-6ZM8,30V6H20v8h8V30Z"
+     id="path4" />
+  <rect
+     x="0"
+     y="0"
+     width="36"
+     height="36"
+     fill-opacity="0"
+     id="rect6" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:monospace;-inkscape-font-specification:monospace;letter-spacing:-0.25px;word-spacing:0px;writing-mode:lr-tb;fill:#000000;fill-opacity:1;stroke:none"
+     x="8.226531"
+     y="25.598957"
+     id="text841"><tspan
+       sodipodi:role="line"
+       x="8.226531"
+       y="25.598957"
+       id="tspan843">EXT</tspan></text>
+</svg>

--- a/source/renderer/assets/icons/clarity-custom/indented-view-list.svg
+++ b/source/renderer/assets/icons/clarity-custom/indented-view-list.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="view-list-line-alt.svg"
+   id="svg22"
+   preserveAspectRatio="xMidYMid meet"
+   viewBox="0 0 36 36"
+   height="36"
+   width="36"
+   version="1.1">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>view-list-line</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg22"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="17.901829"
+     inkscape:cx="13.858299"
+     inkscape:zoom="30.209173"
+     inkscape:snap-smooth-nodes="true"
+     showgrid="true"
+     id="namedview24"
+     inkscape:window-height="1028"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff">
+    <inkscape:grid
+       dotted="true"
+       id="grid857"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <title
+     id="title2">view-list-line</title>
+  <rect
+     id="rect4"
+     height="2"
+     width="2"
+     y="8"
+     x="2"
+     class="clr-i-outline clr-i-outline-path-1" />
+  <path
+     id="path6"
+     d="M7,10H31a1,1,0,0,0,0-2H7a1,1,0,0,0,0,2Z"
+     class="clr-i-outline clr-i-outline-path-2" />
+  <rect
+     id="rect8"
+     height="2"
+     width="2"
+     y="14"
+     x="8"
+     class="clr-i-outline clr-i-outline-path-3" />
+  <path
+     sodipodi:nodetypes="sssss"
+     id="path10"
+     d="M 31,14 H 13 c -1.333333,0 -1.333333,2 0,2 h 18 c 1.333333,0 1.333333,-2 0,-2 z"
+     class="clr-i-outline clr-i-outline-path-4" />
+  <rect
+     id="rect12"
+     height="2"
+     width="2"
+     y="20"
+     x="14"
+     class="clr-i-outline clr-i-outline-path-5" />
+  <path
+     sodipodi:nodetypes="sssss"
+     id="path14"
+     d="M 31,20 H 19 c -1.333333,0 -1.333333,2 0,2 h 12 c 1.333333,0 1.333333,-2 0,-2 z"
+     class="clr-i-outline clr-i-outline-path-6" />
+  <rect
+     id="rect16"
+     height="2"
+     width="2"
+     y="26"
+     x="8"
+     class="clr-i-outline clr-i-outline-path-7" />
+  <path
+     sodipodi:nodetypes="sssss"
+     id="path18"
+     d="M 31,26 H 13 c -1.333333,0 -1.333333,2 0,2 h 18 c 1.333333,0 1.333333,-2 0,-2 z"
+     class="clr-i-outline clr-i-outline-path-8" />
+  <rect
+     id="rect20"
+     fill-opacity="0"
+     height="36"
+     width="36"
+     y="0"
+     x="0" />
+</svg>

--- a/source/renderer/assets/index.htm
+++ b/source/renderer/assets/index.htm
@@ -11,6 +11,8 @@
     <link rel="stylesheet" href="../../node_modules/codemirror/lib/codemirror.css">
     <!-- KaTeX CSS file -->
     <link rel="stylesheet" href="../../node_modules/katex/dist/katex.min.css">
+    <!-- Clarity CSS files -->
+    <link rel="stylesheet" href="../../node_modules/@clr/icons/clr-icons.min.css">
     <!-- Generated CSS output for the vue components -->
     <link rel="stylesheet" href="./vue/sidebar.css">
 

--- a/source/renderer/assets/toolbar/toolbar.json
+++ b/source/renderer/assets/toolbar/toolbar.json
@@ -6,7 +6,8 @@
           "context": [ "win32" ],
           "command": "win-menu",
           "content": "{ 'x': 15, 'y': 15 }",
-          "title": "toolbar.show_menu"
+          "title": "toolbar.show_menu",
+          "icon": "bars"
         },
         {
             "role": "button",

--- a/source/renderer/assets/toolbar/toolbar.json
+++ b/source/renderer/assets/toolbar/toolbar.json
@@ -13,35 +13,40 @@
             "class": "dir-open",
             "command": "dir-open",
             "content": "{}",
-            "title": "toolbar.dir_open"
+            "title": "toolbar.dir_open",
+            "icon": "folder-open"
         },
         {
             "role": "button",
             "class":  "file-new",
             "command": "file-new",
             "content": "{}",
-            "title": "toolbar.file_new"
+            "title": "toolbar.file_new",
+            "icon": "file"
         },
         {
             "role": "button",
             "class": "stats",
             "command": "show-stats",
             "content": "{}",
-            "title": "toolbar.stats"
+            "title": "toolbar.stats",
+            "icon": "line-chart"
         },
         {
           "role": "button",
           "class": "tag-cloud",
           "command": "show-tag-cloud",
           "content": "{}",
-          "title": "toolbar.tag_cloud"
+          "title": "toolbar.tag_cloud",
+          "icon": "tags"
         },
         {
             "role": "button",
             "class": "preferences",
             "command": "open-preferences",
             "content": "{}",
-            "title": "toolbar.preferences"
+            "title": "toolbar.preferences",
+            "icon": "cog"
         },
         {
             "role": "searchbar"
@@ -54,49 +59,56 @@
             "class": "share",
             "command": "export",
             "content": "{}",
-            "title": "toolbar.share"
+            "title": "toolbar.share",
+            "icon": "export"
         },
         {
             "role": "button",
             "class": "file-rename",
             "command": "file-rename",
             "content": "{}",
-            "title": "toolbar.file_rename"
+            "title": "toolbar.file_rename",
+            "icon": "pencil"
         },
         {
             "role": "button",
             "class": "file-delete",
             "command": "file-delete",
             "content": "{}",
-            "title": "toolbar.file_delete"
+            "title": "toolbar.file_delete",
+            "icon": "trash"
         },
         {
             "role": "button",
             "class": "formatting",
             "command": "formatting",
             "content": "{}",
-            "title": "toolbar.formatting"
+            "title": "toolbar.formatting",
+            "icon": "text"
         },
         {
             "role": "button",
             "class": "show-toc",
             "command": "toc",
             "content": "{}",
-            "title": "toolbar.show_toc"
+            "title": "toolbar.show_toc",
+            "icon": "indented-view-list"
         },
         {
             "role": "button",
             "class": "find",
             "command": "file-find",
             "content": "{}",
-            "title": "toolbar.find"
+            "title": "toolbar.find",
+            "icon": "search"
         },
         {
           "role": "button",
           "class": "readability",
           "command": "toggle-readability",
           "content": "{}",
-          "title": "toolbar.readability"
+          "title": "toolbar.readability",
+          "icon": "eye"
         },
         {
             "role": "file-info",
@@ -111,7 +123,8 @@
             "class": "toggle-attachments",
             "command": "toggle-attachments",
             "content": "{}",
-            "title": "toolbar.toggle_attachments"
+            "title": "toolbar.toggle_attachments",
+            "icon": "attachment"
         }
 
     ]

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -200,8 +200,8 @@ class PreferencesDialog extends ZettlrDialog {
     $('#add-autocorrect-key').click(function (e) {
       e.stopPropagation()
       e.preventDefault()
-      let keyCol = $('<td>').html('<div class="form-inline-buttons"><input type="text" name="autoCorrectKeys[]"></div>')
-      let valCol = $('<td>').html('<div class="form-inline-buttons"><input type="text" name="autoCorrectValues[]"> <button class="autocorrect-remove-row"><clr-icon shape="times"></clr-icon></button></div>')
+      let keyCol = $('<td>').html('<div class="input-button-group"><input type="text" name="autoCorrectKeys[]"></div>')
+      let valCol = $('<td>').html('<div class="input-button-group"><input type="text" name="autoCorrectValues[]"> <button class="autocorrect-remove-row"><clr-icon shape="times"></clr-icon></button></div>')
       let row = $('<tr>').append(keyCol, valCol)
       $('#autocorrect-key-container').append(row)
     })

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -201,7 +201,7 @@ class PreferencesDialog extends ZettlrDialog {
       e.stopPropagation()
       e.preventDefault()
       let keyCol = $('<td>').html('<div class="form-inline-buttons"><input type="text" name="autoCorrectKeys[]"></div>')
-      let valCol = $('<td>').html('<div class="form-inline-buttons"><input type="text" name="autoCorrectValues[]"> <button class="autocorrect-remove-row">&times;</button></div>')
+      let valCol = $('<td>').html('<div class="form-inline-buttons"><input type="text" name="autoCorrectValues[]"> <button class="autocorrect-remove-row"><clr-icon shape="times"></clr-icon></button></div>')
       let row = $('<tr>').append(keyCol, valCol)
       $('#autocorrect-key-container').append(row)
     })

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -188,12 +188,12 @@ module.exports = class EditorTabs {
     nameSpan.innerText = displayTitle
 
     // Also enable closing of the document
-    let closeSpan = document.createElement('span')
-    closeSpan.classList.add('close')
-    closeSpan.innerHTML = '&times;'
+    let closeIcon = document.createElement('clr-icon')
+    closeIcon.classList.add('close')
+    closeIcon.setAttribute('shape', 'window-close')
 
     doc.appendChild(nameSpan)
-    doc.appendChild(closeSpan)
+    doc.appendChild(closeIcon)
 
     // In case there's a writing target, append that as well
     if (file.target) {

--- a/source/renderer/util/icons.js
+++ b/source/renderer/util/icons.js
@@ -1,0 +1,45 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Clarity icons helper
+ * CVM-Role:        Utility
+ * Maintainer:      Wieke Kanters
+ * License:         GNU GPL v3
+ *
+ * Description:     This module loads the clarity library and adds custom icons.
+ *
+ * END HEADER
+ */
+
+const clarityIcons = require('@clr/icons').ClarityIcons
+require('@clr/icons/shapes/all-shapes')
+const fs = require('fs')
+const path = require('path')
+
+function loadCustomIcons (dir) {
+  fs.readdir(dir, { withFileTypes: true }, (err, list) => {
+    if (err) throw err
+    list.forEach(x => {
+      if (x.isDirectory()) {
+        loadCustomIcons(path.join(dir, x.name))
+      } else if (x.isFile()) {
+        let ext = path.extname(x.name)
+        if (ext && ext.toLowerCase() === '.svg') {
+          fs.readFile(path.join(dir, x.name), (err, data) => {
+            if (err) throw err
+            let icon = {}
+            icon[path.basename(x.name, ext)] = data.toString()
+            clarityIcons.add(icon)
+          })
+        }
+      }
+    })
+  })
+}
+
+module.exports = {
+  loadCustomIcons: function () {
+    loadCustomIcons(path.join(__dirname, '../assets/icons'))
+  }
+}

--- a/source/renderer/util/load-icons.js
+++ b/source/renderer/util/load-icons.js
@@ -14,32 +14,25 @@
 
 const clarityIcons = require('@clr/icons').ClarityIcons
 require('@clr/icons/shapes/all-shapes')
-const fs = require('fs')
+const fs = require('fs').promises
 const path = require('path')
 
 function loadCustomIcons (dir) {
-  fs.readdir(dir, { withFileTypes: true }, (err, list) => {
-    if (err) throw err
-    list.forEach(x => {
+  return fs.readdir(dir, { withFileTypes: true })
+    .then(list => Promise.all(list.map(x => {
       if (x.isDirectory()) {
-        loadCustomIcons(path.join(dir, x.name))
+        return loadCustomIcons(path.join(dir, x.name))
       } else if (x.isFile()) {
         let ext = path.extname(x.name)
         if (ext && ext.toLowerCase() === '.svg') {
-          fs.readFile(path.join(dir, x.name), (err, data) => {
-            if (err) throw err
+          return fs.readFile(path.join(dir, x.name)).then(data => {
             let icon = {}
             icon[path.basename(x.name, ext)] = data.toString()
             clarityIcons.add(icon)
           })
         }
       }
-    })
-  })
+    })))
 }
 
-module.exports = {
-  loadCustomIcons: function () {
-    loadCustomIcons(path.join(__dirname, '../assets/icons'))
-  }
-}
+module.exports = () => loadCustomIcons(path.join(__dirname, '../assets/icons'))

--- a/source/renderer/zettlr-attachments.js
+++ b/source/renderer/zettlr-attachments.js
@@ -16,6 +16,9 @@
 const { shell } = require('electron')
 
 const { trans } = require('../common/lang/i18n.js')
+const clarityIcons = require('@clr/icons').ClarityIcons
+
+const path = require('path')
 
 const FILETYPES_IMG = [
   '.jpg',
@@ -45,8 +48,6 @@ class ZettlrAttachments {
     $('body').append(this._container)
     this._open = false
     this._attachments = []
-
-    this.refresh()
 
     this._act() // Activate both the directory toggle and the link
   }
@@ -84,7 +85,9 @@ class ZettlrAttachments {
     } else {
       this._attachments = this._renderer.getCurrentDir().attachments
       for (let a of this._attachments) {
-        let link = $('<a>').text(a.name)
+        let svg = clarityIcons.get('file-ext')
+          .replace('EXT', path.extname(a.path).slice(1, 4))
+        let link = $('<a>').html(svg + a.name)
           .attr('data-link', a.path)
           .attr('data-hash', a.hash)
           .attr('title', a.path) // Make sure the user can always see the full title

--- a/source/renderer/zettlr-attachments.js
+++ b/source/renderer/zettlr-attachments.js
@@ -36,7 +36,7 @@ class ZettlrAttachments {
   constructor (parent) {
     this._renderer = parent
     this._container = $('<div>').prop('id', 'attachments').css('display', 'none')
-    this._container.html(`<h1>${trans('gui.attachments')} <small id="open-dir-external" title="${trans('gui.attachments_open_dir')}">&#xf332;</small></h1>`)
+    this._container.html(`<h1>${trans('gui.attachments')} <clr-icon shape="folder" class="is-solid" id="open-dir-external" title="${trans('gui.attachments_open_dir')}"></clr-icon></h1>`)
     this._fileContainer = $('<div>').prop('id', 'files')
     this._bibliographyContainer = $('<div>').prop('id', 'bibliography')
     this._container.append(this._fileContainer)

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -31,7 +31,7 @@ const loadI18nRenderer = require('../common/lang/load-i18n-renderer')
 
 const reconstruct = require('./util/reconstruct-tree')
 
-const icons = require('./util/icons')
+const loadicons = require('./util/load-icons')
 
 const path = require('path')
 
@@ -81,7 +81,6 @@ class ZettlrRenderer {
         this.beginSearch(term)
       }
     }
-    setTimeout(() => icons.loadCustomIcons(), 0)
   }
 
   /**
@@ -127,6 +126,9 @@ class ZettlrRenderer {
 
     // Here we can init actions and stuff to be done after the startup has finished
     setTimeout(() => { this.poll() }, POLL_TIME) // Poll every POLL_TIME seconds
+
+    // Load the clarity icon modules and add custom icons
+    setTimeout(() => loadicons(), 0)
   }
 
   /**

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -31,6 +31,8 @@ const loadI18nRenderer = require('../common/lang/load-i18n-renderer')
 
 const reconstruct = require('./util/reconstruct-tree')
 
+const icons = require('./util/icons')
+
 const path = require('path')
 
 // Pull the poll-time from the data
@@ -79,6 +81,7 @@ class ZettlrRenderer {
         this.beginSearch(term)
       }
     }
+    setTimeout(() => icons.loadCustomIcons(), 0)
   }
 
   /**

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -127,8 +127,9 @@ class ZettlrRenderer {
     // Here we can init actions and stuff to be done after the startup has finished
     setTimeout(() => { this.poll() }, POLL_TIME) // Poll every POLL_TIME seconds
 
-    // Load the clarity icon modules and add custom icons
-    setTimeout(() => loadicons(), 0)
+    // Load the clarity icon modules, add custom icons and then refresh
+    // attachments (because it requires custom icons to be loaded).
+    setTimeout(() => loadicons().then(() => this._attachments.refresh()), 0)
   }
 
   /**

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -207,6 +207,9 @@ class ZettlrToolbar {
         child.html('<svg width="20" height="20" viewBox="-1 -1 2 2"><circle class="pomodoro-meter" cx="0" cy="0" r="1" shape-rendering="geometricPrecision"></circle><path d="" fill="" class="pomodoro-value" shape-rendering="geometricPrecision"></path></svg>')
       }
       if (elem.title) child.attr('data-tippy-content', trans(elem.title))
+      if (elem.icon && typeof elem.icon === 'string') {
+        child.html(`<clr-icon shape="${elem.icon}"></clr-icon>`)
+      }
       this._div.append(child)
     }
   }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Adoption of the clarity icon set. Changed existing icons to icons from this set where possible. See issue #719.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Replaced these icons:

* All buttons in the toolbar except pomodoro timer button.
* All buttons, except headers, footnote and remove footnote, in the formatting menu.
* Open directory button in attachments panel.
* Request file, reset field, remove autocorrect, add autocorrect buttons in pdf preferences, project preferences and preferences screens.
* Add button in tags screen.
* Project icon and open/collapse carret in file tree.
* Music note in pomodor timer panel.
* Close button of tabs.

Added a icons utility that is called by the renderer, it loads the clarity module and adds custom icons. Various places where html was being created in javascript where changed (for toolbar, attachment, autocorrect, tabs, filetree icons).

Oh I also added a little hover effect to the open directory button in the attachment pane, so it's a bit more consistent with the other buttons in the application.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

I tested by building and running the app-image. I don't have the means of testing it on windows or mac platforms. I wasn't sure where to place the call to `loadCustomIcons` I ended up putting it at the end of the renderer constructor.

<!-- Please provide any testing system -->
Tested on: Archlinux
