### PR TITLE
[FEATURE] Add new 'Zettel' by clicking on a newly generated ID - Round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
 - If there is a selection in the document, its contents fill up the global search field on focus, if the global search field does not have any contents.
 - Fixed wrong display of project property table of content evaluation level.
 - When linking files, Zettlr will now present you those files that match with at least one tag with the currently active file, making cross-linking of notes as easy as typing the link-start and hitting the arrow down-key. Bonus: It'll present you these options even if the files reside in a completely different root directory.
+- **New Feature** (By Halcyonquest) Adding preference under Zettelkasten section to allow users the option to create/open files instead of search/open when clicking on ZKN Links.
 
 ## Under the Hood
 

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -445,6 +445,14 @@
             </label>
             <label for="pref-link-never">{{i18n "dialog.preferences.zkn.link_behaviour_never"}}</label>
           </div>
+          <hr>
+          <div class="cb-group">
+            <label class="cb-toggle">
+              <input type="checkbox" name="zkn.createIfNotExists" value="yes" id="znCreateIfNotExists" {{#if zkn.createIfNotExists}}checked="checked"{{/if}}>
+              <div class="toggle"></div>
+            </label>
+            <label for="znCreateIfNotExists">{{i18n "dialog.preferences.zkn.create_if_not_exists"}}</label>
+          </div>
         </div>
       </div>
 

--- a/scripts/assets/gui-test-configs.js
+++ b/scripts/assets/gui-test-configs.js
@@ -73,7 +73,8 @@ module.exports = {
       'idGen': '%Y%M%D%h%m%s',
       'linkStart': '[[',
       'linkEnd': ']]',
-      'linkWithFilename': 'always' // can be always|never|withID
+      'linkWithFilename': 'always', // can be always|never|withID
+      'createIfNotExists': false
     },
     // Editor related stuff
     'editor': {

--- a/source/common/lang/de-DE.json
+++ b/source/common/lang/de-DE.json
@@ -329,7 +329,8 @@
                 "var_month": "Monat (f\u00fchrende Null)",
                 "var_second": "Sekunden (f\u00fchrende Null)",
                 "var_week_number": "Nummer der Woche (f\u00fchrende Null)",
-                "var_year": "Jahr (vierstellig)"
+                "var_year": "Jahr (vierstellig)",
+                "create_if_not_exists": "Wenn Sie auf einen ZKN-Link klicken, erstellen und/oder öffnen Sie eine Datei mit dem Linknamen anstelle der Suche"
             }
         },
         "statistics": {

--- a/source/common/lang/en-GB.json
+++ b/source/common/lang/en-GB.json
@@ -331,7 +331,8 @@
                 "var_month": "Month (leading zeroes)",
                 "var_second": "Seconds (leading zeroes)",
                 "var_week_number": "Week of the year (leading zeroes)",
-                "var_year": "Year (four digit)"
+                "var_year": "Year (four digit)",
+                "create_if_not_exists": "When clicking on a ZKN link, create and/or open file with link name instead of search"
             }
         },
         "statistics": {

--- a/source/common/lang/en-US.json
+++ b/source/common/lang/en-US.json
@@ -331,7 +331,8 @@
                 "var_month": "Month (leading zeroes)",
                 "var_second": "Seconds (leading zeroes)",
                 "var_week_number": "Week of the year (leading zeroes)",
-                "var_year": "Year (four digit)"
+                "var_year": "Year (four digit)",
+                "create_if_not_exists": "When selecting ZKN link, open or create file with that name instead of search"
             }
         },
         "statistics": {

--- a/source/common/lang/en-US.json
+++ b/source/common/lang/en-US.json
@@ -332,7 +332,7 @@
                 "var_second": "Seconds (leading zeroes)",
                 "var_week_number": "Week of the year (leading zeroes)",
                 "var_year": "Year (four digit)",
-                "create_if_not_exists": "When selecting ZKN link, open or create file with that name instead of search"
+                "create_if_not_exists": "When clicking on a ZKN link, create and/or open file with link name instead of search"
             }
         },
         "statistics": {

--- a/source/common/lang/fr-FR.json
+++ b/source/common/lang/fr-FR.json
@@ -335,7 +335,8 @@
                 "var_month": "Mois (sur 2 chiffres)",
                 "var_second": "Secondes (sur 2 chiffres)",
                 "var_week_number": "Semaine de l\u2019ann\u00e9e (avec z\u00e9ro au d\u00e9but si n\u00e9cessaire)",
-                "var_year": "Ann\u00e9e (sur 4 chiffres)"
+                "var_year": "Ann\u00e9e (sur 4 chiffres)",
+                "create_if_not_exists": "Lorsque vous cliquez sur un lien ZKN, créez et/ou ouvrez un fichier avec le nom du lien au lieu de rechercher"
             }
         },
         "statistics": {

--- a/source/common/validation.json
+++ b/source/common/validation.json
@@ -16,6 +16,7 @@
    "zkn.linkStart": "required|string|default:",
    "zkn.linkEnd": "required|string|default:",
    "zkn.idGen": "required|string|min:3|default:",
+   "zkn.createIfNotExists": "required|boolean|default:false",
    "attachmentExtensions": "optional|array",
    "pandoc": "optional|string|min:6|default:",
    "xelatex": "optional|string|min:7|default:",

--- a/source/main/commands/force-open.js
+++ b/source/main/commands/force-open.js
@@ -15,6 +15,7 @@
 
 const path = require('path')
 const ZettlrCommand = require('./zettlr-command')
+const FileNew = require('./file-new')
 const FILETYPES = require('../../common/data.json').filetypes
 
 class ForceOpen extends ZettlrCommand {
@@ -29,7 +30,8 @@ class ForceOpen extends ZettlrCommand {
     * @return {Boolean} Whether the file was successfully deleted.
     */
   async run (evt, arg) {
-    let filename = arg
+    let filename = arg.filename
+    let create = arg.create
     // First try the ID
     let file = this._app.getFileSystem().findExact(filename, 'id')
     // No luck? Then try the name property
@@ -46,6 +48,11 @@ class ForceOpen extends ZettlrCommand {
           if (file) break
         }
       }
+    }
+
+    if (!file && create) {
+      let dir = this._app.getCurrentDir()
+      new FileNew(this._app).run('', { 'name': filename, 'hash': dir.hash })
     }
 
     // If any of this has worked,

--- a/source/main/modules/fsal/fsal-directory.js
+++ b/source/main/modules/fsal/fsal-directory.js
@@ -247,6 +247,7 @@ module.exports = {
     let file = await FSALFile.parse(fullPath, cache, dirObject)
     dirObject.children.push(file)
     sortChildren(dirObject)
+    return file
   },
   'sort': async function (dirObject, method) {
     // If the caller omits the method, it should remain unchanged

--- a/source/main/providers/config-provider.js
+++ b/source/main/providers/config-provider.js
@@ -173,7 +173,8 @@ class ConfigProvider extends EventEmitter {
         'idGen': '%Y%M%D%h%m%s',
         'linkStart': '[[',
         'linkEnd': ']]',
-        'linkWithFilename': 'always' // can be always|never|withID
+        'linkWithFilename': 'always', // can be always|never|withID
+        'createIfNotExists': false
       },
       // Editor related stuff
       'editor': {

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -266,6 +266,7 @@ class PreferencesDialog extends ZettlrDialog {
     cfg['checkForBeta'] = (data.find(elem => elem.name === 'checkForBeta') !== undefined)
     cfg['enableRMarkdown'] = (data.find(elem => elem.name === 'enableRMarkdown') !== undefined)
     cfg['newFileDontPrompt'] = (data.find(elem => elem.name === 'newFileDontPrompt') !== undefined)
+    cfg['zkn.createIfNotExists'] = (data.find(elem => elem.name === 'zkn.createIfNotExists') !== undefined)
 
     // Display checkboxes
     cfg['display.renderCitations'] = (data.find(elem => elem.name === 'display.renderCitations') !== undefined)

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -488,9 +488,15 @@ class ZettlrRenderer {
   autoSearch (term, forceOpen = false) {
     // Also initiate a search to be run accordingly for any files that
     // might reference the file.
-    this._toolbar.setSearch(term)
-    this.beginSearch(term)
-    if (forceOpen) this._ipc.send('force-open', term)
+    let create = global.config.get('zkn.createIfNotExists')
+    if (!create) {
+      this._toolbar.setSearch(term)
+      this.beginSearch(term)
+    }
+
+    if (forceOpen || create) {
+      this._ipc.send('force-open', { 'filename': term, 'create': create })
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
This PR resolves Issue 178 related to creating or opening Zettels when clicking on the link.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Current functionality is that when you press `Alt-Click` on a ZKN link the text of the link is put into the search bar and a search is performed.

With this PR, a new checkbox preference is added on the Zettelkasten tab of the preferences screen which reads:
> When clicking on a ZKN link, create and/or open file with link name instead of search

If that option is turned on, when a ZKN link is clicked, Zettlr will search for a file with exactly that name. If one is found, that file is opened. If it is not found, a new file will be created in the same directory and that new file will be opened.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
I made an attempt at translating the text in the language files (I just pasted whatever Google Translate spit out), so that may need some revision.

**There is currently another PR #775 that I would like to close in favor of this one.**

Also wanted to point out that even though I added the text in the language file, I wasn't able to get them to render. Please let me know what I'm missing.

<!-- Please provide any testing system -->
Tested on: Windows 10, MacOS Catalina