### PR TITLE
Add support for subIDs

### DIFF
--- a/source/common/util/find-object.js
+++ b/source/common/util/find-object.js
@@ -23,7 +23,15 @@ module.exports = function findObject (tree, prop, val, traverse) {
   // Is the tree even defined?
   if (!tree) return undefined
   // First let's see if we can shortcut
-  if (!Array.isArray(tree) && tree.hasOwnProperty(prop) && tree[prop] === val) return tree
+  if (!Array.isArray(tree) && tree.hasOwnProperty(prop)) {
+    if(!Array.isArray(tree[prop]) && tree[prop] === val) {
+      return tree
+    }
+    if(Array.isArray(tree[prop]) && tree[prop].includes(val)) {
+      // The property is of type Array (e.g. subIDs)
+      return tree
+    }
+  }
 
   // Now search the tree
   let ret

--- a/source/common/util/find-object.js
+++ b/source/common/util/find-object.js
@@ -24,10 +24,10 @@ module.exports = function findObject (tree, prop, val, traverse) {
   if (!tree) return undefined
   // First let's see if we can shortcut
   if (!Array.isArray(tree) && tree.hasOwnProperty(prop)) {
-    if(!Array.isArray(tree[prop]) && tree[prop] === val) {
+    if (!Array.isArray(tree[prop]) && tree[prop] === val) {
       return tree
     }
-    if(Array.isArray(tree[prop]) && tree[prop].includes(val)) {
+    if (Array.isArray(tree[prop]) && tree[prop].includes(val)) {
       // The property is of type Array (e.g. subIDs)
       return tree
     }

--- a/source/main/commands/force-open.js
+++ b/source/main/commands/force-open.js
@@ -53,6 +53,10 @@ class ForceOpen extends ZettlrCommand {
         }
       }
     }
+    // Still no luck? Try the subIDs property
+    if(!file) {
+      file = this._app.getFileSystem().findExact(filename, 'subIDs')
+    }
 
     // If any of this has worked,
     if (file != null) {

--- a/source/main/commands/force-open.js
+++ b/source/main/commands/force-open.js
@@ -54,7 +54,7 @@ class ForceOpen extends ZettlrCommand {
       }
     }
     // Still no luck? Try the subIDs property
-    if(!file) {
+    if (!file) {
       file = this._app.getFileSystem().findExact(filename, 'subIDs')
     }
 

--- a/source/main/modules/fsal/fsal-file.js
+++ b/source/main/modules/fsal/fsal-file.js
@@ -68,6 +68,7 @@ function metadata (fileObject) {
     'hash': fileObject.hash,
     'ext': fileObject.ext,
     'id': fileObject.id,
+    'subIDs': fileObject.subIDs,
     'tags': fileObject.tags,
     'type': fileObject.type,
     'wordCount': fileObject.wordCount,
@@ -106,6 +107,7 @@ async function parseFile (filePath, cache, parent = null) {
     'hash': hash(filePath),
     'ext': path.extname(filePath),
     'id': '', // The ID, if there is one inside the file.
+    'subIDs' : [], // All IDs found inside the file's contents, excluding the first ID
     'tags': [], // All tags that are to be found inside the file's contents.
     'type': 'file',
     'wordCount': 0,
@@ -244,6 +246,20 @@ function parseFileContents (file, content) {
   } else {
     file.id = '' // Remove the file id again
   }
+
+  // Read subIDs
+  file.subIDs = [] // Reset subIDs
+  while ((match = idRE.exec(mdWithoutCode)) != null) {
+    if (mdWithoutCode.substr(match.index - linkStart.length, linkStart.length) !== linkStart) {
+      if ((match[1] !== file.id) && (match[1].substr(-(linkEnd.length)) !== linkEnd)) {
+        // Store found ID (if different from first ID) in subIDs
+        file.subIDs.push(match[1])
+      } 
+    }
+  }
+
+  // Remove duplicates
+  file.subIDs = [...new Set(file.subIDs)]
 }
 
 async function searchFile (fileObject, terms) {

--- a/source/main/modules/fsal/fsal-file.js
+++ b/source/main/modules/fsal/fsal-file.js
@@ -107,7 +107,7 @@ async function parseFile (filePath, cache, parent = null) {
     'hash': hash(filePath),
     'ext': path.extname(filePath),
     'id': '', // The ID, if there is one inside the file.
-    'subIDs' : [], // All IDs found inside the file's contents, excluding the first ID
+    'subIDs': [], // All IDs found inside the file's contents, excluding the first ID
     'tags': [], // All tags that are to be found inside the file's contents.
     'type': 'file',
     'wordCount': 0,
@@ -254,7 +254,7 @@ function parseFileContents (file, content) {
       if ((match[1] !== file.id) && (match[1].substr(-(linkEnd.length)) !== linkEnd)) {
         // Store found ID (if different from first ID) in subIDs
         file.subIDs.push(match[1])
-      } 
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Allow multiple IDs inside a file. The first ID is the "main" ID, while all other IDs are considered "subIDs". When a link to a subID is clicked, the corresponding file, in which that subID is defined, is opened.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
I added an array `subIDs` to the file descriptor. Then I extened the file parser to also read any subID into `subIDs`. When an internal link is clicked, in addition to `id` and `name`, `subIDs` is matched to find the target file. Further, I had to modify `findObject()` slightly to support `prop`s of type Array.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
With this PR, we can have multiple IDs inside a file. This can be useful, for example when we want to link to a specific heading. Or any other part of a file.

In the current version of this PR, we have to first insert the ID at the location of our choice, then copy it, and paste it between `[[ ]]` in the file from where we want to link to that ID.

<!-- Please provide any testing system -->
Tested on: Linux Mint 19.2
