### PR TITLE
Add syntax highlighting for (System)Verilog, VHDL and Tcl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
     - **Julia**: `julia`/`jl`
     - **Turtle**: `turtle`/`ttl`
     - **SPARQL**: `sparql`
+    - **Verilog**: `verilog`/`v`
+    - **SystemVerilog**: `systemverilog`/`sv`
+    - **VHDL**: `vhdl`/`vhd`
+    - **Tcl**: `tcl`
 - Fix the colours of the heatmap search list.
 - Fixed a logical error in the detection of remote changes of attachment files.
 - Fenced code blocks, delimited by three backticks have a customizable box background. The colour (and different styles) can be customized by targeting the `code-block-line`-CSS class.

--- a/source/common/data.json
+++ b/source/common/data.json
@@ -283,6 +283,22 @@
       "application/sparql-query": {
         "mode": "sparql",
         "selectors": ["sparql"]
+      },
+      "text/x-verilog": {
+        "mode": "verilog",
+        "selectors": [ "verilog", "v" ]
+      },
+      "text/x-systemverilog": {
+        "mode": "verilog",
+        "selectors": [ "systemverilog", "sv" ]
+      },
+      "text/x-vhdl": {
+        "mode": "vhdl",
+        "selectors": [ "vhdl", "vhd" ]
+      },
+      "text/x-tcl": {
+        "mode": "tcl",
+        "selectors": [ "tcl" ]
       }
     }
 }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Enable Codemirror modes for Verilog, SystemVerilog, VHDL and Tcl.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Added the corresponding entries in `source/common/data.json`.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: Linux Mint 19.2
