### PR TITLE
Adding Common Lisp and Scheme syntax highlighting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
     - **SystemVerilog**: `systemverilog`/`sv`
     - **VHDL**: `vhdl`/`vhd`
     - **Tcl**: `tcl`
+    - **CommonLisp**: `clisp`/`commonlisp`
+    - **Scheme**: `scheme`
 - Fix the colours of the heatmap search list.
 - Fixed a logical error in the detection of remote changes of attachment files.
 - Fenced code blocks, delimited by three backticks have a customizable box background. The colour (and different styles) can be customized by targeting the `code-block-line`-CSS class.

--- a/source/common/data.json
+++ b/source/common/data.json
@@ -299,6 +299,14 @@
       "text/x-tcl": {
         "mode": "tcl",
         "selectors": [ "tcl" ]
+      },
+      "text/x-scheme": {
+        "mode": "scheme",
+        "selectors": [ "scheme" ]
+      },
+      "text/x-common-lisp": {
+        "mode": "commonlisp",
+        "selectors": [ "clisp", "commonlisp" ]
       }
     }
 }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Added Common Lisp and Scheme to the list of languages with syntax highlighting.

Source:

https://codemirror.net/mode/scheme/index.html

https://codemirror.net/mode/commonlisp/index.html

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
- Modified the `highlightingModes` map to enable the highlighting.
- Appended to release notes.

<!-- Please provide any testing system -->
#### Tested on:

OS: Linux Mint Tara
Window Manager: i3 window manager on X.org

![screenshot](https://user-images.githubusercontent.com/1109359/84380202-96ea3700-ac04-11ea-80b8-151af622864a.png)

- Tested syntax highlighting worked after applying the changes.
- Unit tests were successful.
