### PR TITLE
Improve readability of search results inside inline code blocks

### DIFF
--- a/resources/less/geometry/codemirror.less
+++ b/resources/less/geometry/codemirror.less
@@ -51,8 +51,10 @@
   }
 
   .search-result {
-    background-color: yellow;
+    background-color: yellow !important;
     color: black !important;
+    border-radius: 0px !important;
+    padding-right: 0px !important;
   }
 
   .cm-table {


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
This PR fixes the readability of highlighted search results which are inside _inline_ code blocks.
The following picture shows the situation before (search for "ipsum do"):

![zettlr-before](https://user-images.githubusercontent.com/18646029/84579863-e5006580-add1-11ea-9fa9-a0e4de199133.png)

With this PR, results inside _inline_ code also get properly highlighted:

![zettlr-after](https://user-images.githubusercontent.com/18646029/84579924-6bb54280-add2-11ea-97e8-b8bbd57133cf.png)



<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Modified class `search-result` in _codemirror.less_:
- Added the `!important` attribute to `background-color` to make sure it overrides the background of the inline code
- Force `border-radius` to be 0
- Force `padding-right` to be 0

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: Linux Mint 19.2
