### PR TITLE
Fix issue #915

### DIFF
--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -47,23 +47,15 @@ $endif$
 % _italics_ will become underlines, which is not desirable.
 \usepackage[normalem]{ulem}
 
-% Pandoc uses includegraphics. But as some images may be too big, we have to
-% replace the command with another one that ensures proper scaling of images.
-% Therefore first save the old includegraphics command somewhere else.
-\let\oldincg\includegraphics
-
-% Create the imgwidth variable
-\newlength{\imgwidth}
-
-% Now renew the original includegraphics command to include some logic that
-% first determines the width of the image and then either scales it down or
-% retains it at original size (using the minof command). The centering is done
-% automatically by Pandoc.
-\renewcommand\includegraphics[1]{%
-    \settowidth{\imgwidth}{\oldincg{#1}}%
-    \setlength{\imgwidth}{\minof{\imgwidth}{\textwidth}}%
-    \oldincg[width=\imgwidth]{#1}%
-}
+% Image scaling code from pandoc default.latex template
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 
 % Now we also have to make sure that the figures Pandoc inserts are positioned
 % approximately where they are at. Therefore we have to overwrite the


### PR DESCRIPTION
Added image scaling from pandoc default latex template. Fixes issue #915


<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Replaces the image scaling code with code from pandoc default.latex

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Replaced image scaling with code from pandoc default.latex

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
Windows 10
