### PR TITLE
PowerShell syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
     - **Tcl**: `tcl`
     - **CommonLisp**: `clisp`/`commonlisp`
     - **Scheme**: `scheme`
+    - **PowerShell**: `powershell`
 - Fix the colours of the heatmap search list.
 - Fixed a logical error in the detection of remote changes of attachment files.
 - Fenced code blocks, delimited by three backticks have a customizable box background. The colour (and different styles) can be customized by targeting the `code-block-line`-CSS class.

--- a/source/common/data.json
+++ b/source/common/data.json
@@ -307,6 +307,10 @@
       "text/x-common-lisp": {
         "mode": "commonlisp",
         "selectors": [ "clisp", "commonlisp" ]
+      },
+      "application/x-powershell": {
+        "mode": "powershell",
+        "selectors": [ "powershell" ]
       }
     }
 }


### PR DESCRIPTION

## Description

Added [PowerShell syntax highlighting](https://codemirror.net/mode/powershell/index.html).

## Changes

- Modified the `highlightingModes` map to enable the highlighting.
- Added to the CHANGELOG in the appropriate location.

## Additional information

Tested on: macOS 10.15.5, yarn 1.22.4, node 14.5.0

<img width="1000" alt="Screen Shot 2020-07-01 at 3 55 43 PM" src="https://user-images.githubusercontent.com/161960/86286759-0d030d80-bbb5-11ea-849c-6bbfdb4f8e51.png">

  - [X] I documented all behaviour as far as I could do.
  - [X] I target the develop-branch, and *not* the master branch.
  - [X] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [X] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [X] I have added an entry to the CHANGELOG.md.
  - [X] I matched my code-style to the repository (as far as possible).
  - [X] I do agree that my code will be published under the GNU GPL v3 license.
  - [X] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [X] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

