### PR TITLE
Remove tippy.js from global scope

### DIFF
--- a/resources/vue/sidebar.vue
+++ b/resources/vue/sidebar.vue
@@ -149,7 +149,7 @@
 // Please do not ask me why I have to explicitly use the "default" property
 // of some modules, but not others. The vue-loader is a mess when used with
 // ES6 CommonJS-modules in a exports/require-environment.
-// const tippy = require('tippy.js').default
+const tippy = require('tippy.js').default
 const findObject = require('../../source/common/util/find-object.js')
 const { trans } = require('../../source/common/lang/i18n.js')
 const TreeItem = require('./tree-item.vue').default
@@ -476,7 +476,7 @@ module.exports = {
 
       // Create instances for all elements without already existing
       // tippy-instances.
-      window.tippy('#sidebar [data-tippy-content]', {
+      tippy('#sidebar [data-tippy-content]', {
         delay: 100,
         arrow: true,
         duration: 100,

--- a/source/renderer/assets/index.htm
+++ b/source/renderer/assets/index.htm
@@ -32,8 +32,6 @@
 
     <!-- Load tippy.js -->
     <link rel="stylesheet" href="../../node_modules/tippy.js/dist/tippy.css">
-    <script src="../../node_modules/@popperjs/core/dist/umd/popper.min.js"></script>
-    <script type="text/javascript" src="../../node_modules/tippy.js/dist/tippy.umd.js"></script>
 
     <!-- Finally load the app. It will load automatically. -->
     <script type="text/javascript" src="../main.js"></script>

--- a/source/renderer/dialog/zettlr-dialog.js
+++ b/source/renderer/dialog/zettlr-dialog.js
@@ -14,7 +14,7 @@
  * END HEADER
  */
 
-// const tippy = require('tippy.js/dist/tippy-bundle.cjs.js').default
+const tippy = require('tippy.js').default
 const EventEmitter = require('events')
 const makeTemplate = require('../../common/zettlr-template.js')
 const { clipboard } = require('electron')
@@ -214,7 +214,7 @@ class ZettlrDialog extends EventEmitter {
     })
 
     // Tippify all elements with the respective attribute
-    global.tippy(this._modal[0].querySelectorAll('[data-tippy-content]'), {
+    tippy(this._modal[0].querySelectorAll('[data-tippy-content]'), {
       delay: 100,
       arrow: true,
       duration: 100

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -14,6 +14,7 @@
 
 const { trans } = require('../../common/lang/i18n')
 const path = require('path')
+const tippy = require('tippy.js').default
 // Left the localize/localise here in order to confuse future generations.
 const localizeNumber = require('../../common/util/localise-number')
 
@@ -134,7 +135,7 @@ module.exports = class EditorTabs {
     }
 
     // After synchronising, enable the tippy
-    this._tippyInstances = global.tippy('#document-tabs .document', {
+    this._tippyInstances = tippy('#document-tabs .document', {
       delay: [ 1000, null ], // Show after 1s, hide normally
       allowHTML: true, // There is HTML in the contents
       placement: 'bottom' // Prefer to display it on the bottom

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -18,6 +18,7 @@ const hash = require('../common/util/hash')
 const popup = require('./zettlr-popup.js')
 const showdown = require('showdown')
 const Turndown = require('joplin-turndown')
+const tippy = require('tippy.js').default
 const countWords = require('../common/util/count-words')
 const EditorTabs = require('./util/editor-tabs')
 const turndownGfm = require('joplin-turndown-plugin-gfm')
@@ -1067,7 +1068,7 @@ class ZettlrEditor {
 
     // Now we either got a match or an empty fnref. So create a tippy
     // instance
-    global.tippy(element[0], {
+    tippy(element[0], {
       'content': fnref,
       allowHTML: true,
       onHidden (instance) {

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -13,6 +13,7 @@
  * END HEADER
  */
 
+const tippy = require('tippy.js').default
 const localiseNumber = require('../common/util/localise-number')
 const { trans } = require('../common/lang/i18n')
 
@@ -153,7 +154,7 @@ class ZettlrToolbar {
     })
 
     // Tippify all elements with the respective attribute.
-    global.tippy('#toolbar [data-tippy-content]', {
+    tippy('#toolbar [data-tippy-content]', {
       delay: 100,
       arrow: true,
       duration: 100


### PR DESCRIPTION
This is related to #1055.

## Changes

Use tippy.js through imports instead of global scope to make it more explicit and easier to understand.

## Additional information

Tested on: macOS
