### PR TITLE
Fix Table of Contents

### DIFF
--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -14,6 +14,9 @@
  *
  * END HEADER
  */
+require('jquery-ui/ui/data')
+require('jquery-ui/ui/scroll-parent')
+require('jquery-ui/ui/version')
 require('jquery-ui/ui/widget')
 require('jquery-ui/ui/widgets/mouse')
 require('jquery-ui/ui/widgets/sortable')


### PR DESCRIPTION
This addresses a regresssion introduced in #1057: Table of Contents
allows navigating in the document again.

Tested on: macOS 10.15.5 with `yarn test-gui`
