### PR TITLE
Add minimal set of jQuery linting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
         "es6": true,
         "node": true
     },
+    "plugins": [
+        "jquery"
+    ],
     "extends": [
         "standard",
         "plugin:vue/vue3-recommended"
@@ -44,6 +47,19 @@
           },
           "svg": "any",
           "math": "any"
-        }]
+        }],
+        "jquery/no-ajax": 2,
+        "jquery/no-ajax-events": 2,
+        "jquery/no-animate": 2,
+        "jquery/no-bind": 2,
+        "jquery/no-fade": 2,
+        "jquery/no-load": 2,
+        "jquery/no-param": 2,
+        "jquery/no-serialize": 2,
+        "jquery/no-sizzle": 2,
+        "jquery/no-slide": 2,
+        "jquery/no-toggle": 2,
+        "jquery/no-when": 2,
+        "jquery/no-wrap": 2
     }
 }

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "eslint-config-standard": "^14.1.1",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jquery": "^1.5.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,6 +2987,11 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-jquery@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jquery/-/eslint-plugin-jquery-1.5.1.tgz#d6bac643acf9484ce76394e27e2b07baca06662e"
+  integrity sha512-L7v1eaK5t80C0lvUXPFP9MKnBOqPSKhCOYyzy4LZ0+iK+TJwN8S9gAkzzP1AOhypRIwA88HF6phQ9C7jnOpW8w==
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"


### PR DESCRIPTION
GitHub published this plugin when they migrated away from jQuery in
2018. It contains more rules that can be enabled gradually and it
recommends native alternatives.

Tested on: macOS 10.15.5


[GitHub's blog post](https://github.blog/2018-09-06-removing-jquery-from-github-frontend/)
