### PR TITLE
Middle Mouse closes Editor Tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,6 +520,7 @@ This release contains several breaking changes to 1.6 due to heavy internal refa
 - The full path to an attachment will now be shown on mouse over.
 - You can now turn off the dialog asking you to load remote changes into the editor by checking the corresponding checkbox in the preferences or in the dialog.
 - The file list now shows the full filename after a 1 second delay if you keep your mouse over the name of a file.
+- You can middle mouse click on editor-tabs to close them.
 
 ### Fixes
 

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -102,7 +102,6 @@ module.exports = class EditorTabs {
   }
 
   syncFiles (files, openFile) {
-    console.log(`[TABS] Synching ${files.length} files`)
     // First reset the whole tab bar
     for (let instance of this._tippyInstances) {
       instance.destroy()

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -29,7 +29,10 @@ module.exports = class EditorTabs {
     this._tippyInstances = []
 
     // Listen to the important events
-    this._div.onclick = (event) => { this._onClick(event) }
+    this._div.onclick = (event) => this._onClick(event)
+    // Listen for non-primary clicks
+    this._div.onauxclick = (event) => this._onClick(event)
+
     this._div.ondragstart = (evt) => {
       // The user has initated a drag operation, so we need some variables
       // we'll be accessing throughout the drag operation: The currently
@@ -99,6 +102,7 @@ module.exports = class EditorTabs {
   }
 
   syncFiles (files, openFile) {
+    console.log(`[TABS] Synching ${files.length} files`)
     // First reset the whole tab bar
     for (let instance of this._tippyInstances) {
       instance.destroy()
@@ -200,7 +204,12 @@ module.exports = class EditorTabs {
 
     // If given, call the callback
     if (this._intentCallback) {
-      this._intentCallback(hash, (closeIntent) ? 'close' : 'select')
+      // middle mouse click closes tab
+      if (event.type === 'auxclick' && event.button === 1) {
+        this._intentCallback(hash, 'close')
+      } else {
+        this._intentCallback(hash, (closeIntent) ? 'close' : 'select')
+      }
     }
   }
 
@@ -214,7 +223,6 @@ module.exports = class EditorTabs {
   _makeElement (file, active = false, clean = true, transient = false) {
     // First determine the display title (either filename or frontmatter title)
     let displayTitle = file.name
-    if (file.firstHeading && global.config.get('display.useFirstHeadings')) displayTitle = file.firstHeading
     if (file.frontmatter && file.frontmatter.title) displayTitle = file.frontmatter.title
 
     // Then create the document div

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -29,9 +29,9 @@ module.exports = class EditorTabs {
     this._tippyInstances = []
 
     // Listen to the important events
-    this._div.onclick = (event) => this._onClick(event)
+    this._div.onclick = (event) => { this._onClick(event) }
     // Listen for non-primary clicks
-    this._div.onauxclick = (event) => this._onClick(event)
+    this._div.onauxclick = (event) => { this._onClick(event) }
 
     this._div.ondragstart = (evt) => {
       // The user has initated a drag operation, so we need some variables
@@ -203,12 +203,9 @@ module.exports = class EditorTabs {
 
     // If given, call the callback
     if (this._intentCallback) {
-      // middle mouse click closes tab
-      if (event.type === 'auxclick' && event.button === 1) {
-        this._intentCallback(hash, 'close')
-      } else {
-        this._intentCallback(hash, (closeIntent) ? 'close' : 'select')
-      }
+      // determine if a middle (wheel) click
+      let middleClick = (event.type === 'auxclick' && event.button === 1)
+      this._intentCallback(hash, (middleClick || closeIntent) ? 'close' : 'select')
     }
   }
 

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -222,6 +222,7 @@ module.exports = class EditorTabs {
   _makeElement (file, active = false, clean = true, transient = false) {
     // First determine the display title (either filename or frontmatter title)
     let displayTitle = file.name
+    if (file.firstHeading && global.config.get('display.useFirstHeadings')) displayTitle = file.firstHeading
     if (file.frontmatter && file.frontmatter.title) displayTitle = file.frontmatter.title
 
     // Then create the document div


### PR DESCRIPTION
## Description
Adds ability to close tabs with middle-mouse click.  This is the same behavior that exists on google chrome, visual studio code, and a number of other programs.

## Changes
- Attached onauxclick function onto the tab element
- Added logic to notice if "auxclick" and button is 1 (middle mouse) are clicked when doing click action and then attempt to close tab.

## Additional information
Tested on: Windows 10
