### PR TITLE
Fix broken citation rendering

### DIFF
--- a/source/renderer/assets/codemirror/zettlr-plugin-render-citations.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-citations.js
@@ -57,7 +57,7 @@
 
       // Run through all links on this line
       while ((match = citationRE.exec(line)) != null) {
-        let citation = match[1] || match[2]
+        let citation = match[1] || match[3]
 
         // Now get the precise beginning of the match and its end
         let curFrom = { 'line': i, 'ch': match.index }


### PR DESCRIPTION
<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

Previously, in-text citations consisting of only an `@` (not surrounded by [brackets]) didn't render at all -- they just completely disappeared after the cursor was no longer on top of them.

![Kapture 2020-07-15 at 23 33 16](https://user-images.githubusercontent.com/443070/87635274-9f49fc00-c6f3-11ea-9836-6474e4573ae3.gif)

Turns out this was because we [recently introduced another capture group in the `citationRE`](https://github.com/Zettlr/Zettlr/commit/b1513e2fa3d05c026760bc21c302076a9a828947#diff-1ca6a5f8f19ef9ca9a775b923bc11084L18-R19) -- so we have to skip that capture group when referring to it later on.

## Changes

Refer to the correct capture group when attempting to pull the citation out of the provided regular expression.

## Additional information

I didn't add anything to the changelog since the bug this fixes was introduced after the most recent release.

<!-- Please provide any testing system -->
Tested on: MacOS Catalina 10.15.4 (19E287)