### PR TITLE
Use app.getVersion()

### DIFF
--- a/source/main/commands/update-check.js
+++ b/source/main/commands/update-check.js
@@ -16,11 +16,12 @@ const ZettlrCommand = require('./zettlr-command')
 const got = require('got')
 const semver = require('semver')
 const showdown = require('showdown')
+const { app } = require('electron')
 
 const { trans } = require('../../common/lang/i18n.js')
 
 const REPO_URL = require('../../common/data.json').repo_url
-const CUR_VER = require('../../package.json').version
+const CUR_VER = app.getVersion()
 
 class UpdateCheck extends ZettlrCommand {
   constructor (app) {

--- a/source/main/providers/config-provider.js
+++ b/source/main/providers/config-provider.js
@@ -29,7 +29,7 @@ const isDir = require('../../common/util/is-dir')
 const isDictAvailable = require('../../common/util/is-dict-available')
 const { getLanguageFile } = require('../../common/lang/i18n')
 const COMMON_DATA = require('../../common/data.json')
-const ZETTLR_VERSION = require('../../package.json').version
+const ZETTLR_VERSION = app.getVersion()
 
 // Suppress notifications on modification of the following settings
 const SUPPRESS_NOTIFICATION = [

--- a/source/renderer/dialog/about.js
+++ b/source/renderer/dialog/about.js
@@ -13,6 +13,7 @@
  * END HEADER
  */
 
+const { remote } = require('electron')
 const ZettlrDialog = require('./zettlr-dialog.js')
 const { trans } = require('../../common/lang/i18n')
 const formatDate = require('../../common/util/format-date')
@@ -37,7 +38,7 @@ class AboutDialog extends ZettlrDialog {
 
   preInit (data) {
     process.getCPUUsage() // First call returns null, so we have to call it twice
-    data.version = require('../../package.json').version
+    data.version = remote.app.getVersion()
     data.uuid = global.config.get('uuid')
 
     // Debug info: Versions, argv, env, and overall process uptime


### PR DESCRIPTION
This allows accessing the version number independently from the
package.json file. It is important as the source/package.json is not
present in a non-two package.json setup.

Tested on: macOS 15.15.6

Related to #1055 
