### PR TITLE
Use RequireJS to locate CodeMirror

### DIFF
--- a/source/renderer/assets/codemirror/continuelist.js
+++ b/source/renderer/assets/codemirror/continuelist.js
@@ -11,9 +11,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/indentlist.js
+++ b/source/renderer/assets/codemirror/indentlist.js
@@ -12,9 +12,9 @@
 // Additional fix: Different paths to CodeMirror
  (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../../node_modules/codemirror/lib/codemirror"));
+    mod(require("codemirror/lib/codemirror"));
   else if (typeof define == "function" && define.amd) // AMD
-    define(["../../../node_modules/codemirror/lib/codemirror"], mod);
+    define(["codemirror/lib/codemirror"], mod);
   else // Plain browser env
     mod(CodeMirror);
  })(function(CodeMirror) {

--- a/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-multiplex.js
@@ -5,9 +5,9 @@ const highlightingModes = require('../../../common/data').highlightingModes;
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-mode-readability.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-readability.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-mode-spellchecker.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-spellchecker.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-mode-zkn.js
+++ b/source/renderer/assets/codemirror/zettlr-mode-zkn.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-autocorrect.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-autocorrect.js
@@ -47,9 +47,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-foldcode-helper.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-foldcode-helper.js
@@ -10,9 +10,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-footnotes.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-footnotes.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-markdown-codeblock-classes.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-markdown-codeblock-classes.js
@@ -4,9 +4,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-markdown-header-classes.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-markdown-header-classes.js
@@ -4,9 +4,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-markdown-shortcuts.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-markdown-shortcuts.js
@@ -8,9 +8,9 @@ const { clipboard } = require('electron');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-citations.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-citations.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-h-tags.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-h-tags.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-iframes.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-iframes.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-links.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-links.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-math.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-math.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-mermaid.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-mermaid.js
@@ -5,9 +5,9 @@ const mermaid = require('mermaid')
 
 ;(function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-tables.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-tables.js
@@ -5,9 +5,9 @@ const Table = require('../../util/table-helper.js');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-tasks.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-tasks.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-select-word.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-select-word.js
@@ -3,9 +3,9 @@
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }

--- a/source/renderer/assets/codemirror/zettlr-plugin-wysiwyg.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-wysiwyg.js
@@ -5,9 +5,9 @@ const showdown = require('showdown');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
-    mod(require('../../../node_modules/codemirror/lib/codemirror'))
+    mod(require('codemirror/lib/codemirror'))
   } else if (typeof define === 'function' && define.amd) { // AMD
-    define(['../../../node_modules/codemirror/lib/codemirror'], mod)
+    define(['codemirror/lib/codemirror'], mod)
   } else { // Plain browser env
     mod(CodeMirror)
   }


### PR DESCRIPTION
Utilising RequireJS for imports means that these files will not rely on
the two package.js structure. This enables easier migration to webpack
in the future.

Relates to #1055.

Tested on: macOS 10.15.6
