### PR TITLE
Allows ARM64 Builds on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,17 @@ jobs:
         with:
           name: Zettlr-${{ steps.pkg.outputs.version }}.exe
           path: ./release/Zettlr-${{ steps.pkg.outputs.version }}.exe
+      - name: Build Windows NSIS installer arm64
+        if: matrix.os == 'windows-latest' # Only if the job runs on Windows
+        # Make sure to sign the windows installer using the corresponding SSL EV.
+        run: CSC_LINK=${{ secrets.WIN_CERT }}  CSC_KEY_PASSWORD=${{ secrets.WIN_CERT_PASS }} npm run release:win-arm
+        shell: bash # I'm sorry PowerShell, but I'm not rewriting code for you.
+      - name: Cache Windows release arm64
+        if: matrix.os == 'windows-latest' # Only if the job runs on Windows
+        uses: actions/upload-artifact@v1
+        with:
+          name: Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe
+          path: ./release/Zettlr-${{ steps.pkg.outputs.version }}.exe
       # MACOS ================================================================
       - name: Build macOS DMG file
         if: matrix.os == 'macos-latest' # Only if the job runs on macOS
@@ -156,6 +167,11 @@ jobs:
         with:
           name: Zettlr-${{ steps.pkg.outputs.version }}.exe
           path: .
+      - name: Download the Windows arm64 asset
+        uses: actions/download-artifact@v1
+        with:
+          name: Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe
+          path: .
       - name: Download the macOS asset
         uses: actions/download-artifact@v1
         with:
@@ -186,6 +202,7 @@ jobs:
       - name: Generate SHA256 checksums
         run: |
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}.exe" > "SHA256SUMS.txt"
+          sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe" > "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}.dmg" >> "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-amd64.deb" >> "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-x86_64.rpm" >> "SHA256SUMS.txt"
@@ -215,6 +232,17 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./Zettlr-${{ steps.pkg.outputs.version }}.exe
           asset_name: Zettlr-${{ steps.pkg.outputs.version }}.exe
+          asset_content_type: application/x-msdownload
+
+
+      - name: Upload Windows arm64 asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe
+          asset_name: Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe
           asset_content_type: application/x-msdownload
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Generate SHA256 checksums
         run: |
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}.exe" > "SHA256SUMS.txt"
-          sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe" > "SHA256SUMS.txt"
+          sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-arm64.exe" >> "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}.dmg" >> "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-amd64.deb" >> "SHA256SUMS.txt"
           sha256sum "Zettlr-${{ steps.pkg.outputs.version }}-x86_64.rpm" >> "SHA256SUMS.txt"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "productName": "Zettlr",
     "npmRebuild": false,
     "copyright": "Zettlr is licensed under GNU GPL v3.",
-    "compression": "maximum",
     "fileAssociations": [
       {
         "ext": "md",
@@ -99,7 +98,8 @@
         "deb",
         "rpm"
       ],
-      "artifactName": "Zettlr-${version}-${arch}.${ext}", "synopsis": "Markdown editor",
+      "artifactName": "Zettlr-${version}-${arch}.${ext}",
+      "synopsis": "Markdown editor",
       "category": "Office",
       "icon": "resources/icons/png",
       "desktop": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:quick": "electron-builder --dir",
     "release:this": "electron-builder",
     "release:mac": "electron-builder --mac --publish \"never\"",
-    "release:win": "electron-builder --win --publish \"never\"",
+    "release:win": "electron-builder --win --x64 --ia32 --publish \"never\"",
+    "release:win-arm": "electron-builder --win --ia32 --arm64 --publish \"never\"",
     "release:linux": "electron-builder --linux --publish \"never\"",
     "less": "gulp less",
     "handlebars": "gulp handlebars",
@@ -40,6 +41,7 @@
     "productName": "Zettlr",
     "npmRebuild": false,
     "copyright": "Zettlr is licensed under GNU GPL v3.",
+    "compression": "maximum",
     "fileAssociations": [
       {
         "ext": "md",
@@ -79,11 +81,7 @@
       "target": [
         {
           "target": "nsis",
-          "arch": [
-            "x64",
-            "ia32",
-            "arm64"
-          ]
+          "arch": []
         }
       ],
       "artifactName": "Zettlr-${version}-${arch}.${ext}",
@@ -101,8 +99,7 @@
         "deb",
         "rpm"
       ],
-      "artifactName": "Zettlr-${version}-${arch}.${ext}",
-      "synopsis": "Markdown editor",
+      "artifactName": "Zettlr-${version}-${arch}.${ext}", "synopsis": "Markdown editor",
       "category": "Office",
       "icon": "resources/icons/png",
       "desktop": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
           "target": "nsis",
           "arch": [
             "x64",
-            "ia32"
+            "ia32",
+            "arm64"
           ]
         }
       ],
@@ -135,7 +136,7 @@
       "allowToChangeInstallationDirectory": true,
       "uninstallDisplayName": "Uninstall ${productName}",
       "installerHeader": "resources/NSIS/NSISinstallerHeader.bmp",
-      "installerSidebar": "resources/NSISinstallerSidebar.bmp"
+      "installerSidebar": "resources/NSIS/NSISinstallerSidebar.bmp"
     },
     "deb": {
       "priority": "optional",


### PR DESCRIPTION
<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

Adds an ARM64 target for windows.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
- Adds ARM64 to the NSIS config.
- Fixes a resource location that was incorrect for windows builds.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
Installs correctly from the installer when tested on an ARM windows build.

<!-- Please provide any testing system -->
Tested on: Windows 10 Home on Surface Pro X

Fixes #890 
