### PR TITLE
Changed 'four' to 'five' for number of themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With Zettlr, writing professional texts is easy and motivating: Whether you are 
 - Available in over a dozen languages
 - Tight and ever-growing **integration with your favourite reference manager** (such as Zotero or JabRef)
 - **Cite with Zettlr** using `citeproc` and your existing literature database
-- Four **themes and dark mode support**
+- Five **themes and dark mode support**
 - File-agnostic writing: Enjoy **full control over your own files**
 - Keep all your notes and texts **in one place** — searchable and accessible
 - **Code highlighting** for many languages


### PR DESCRIPTION
## Description
Zettlr 1.7.1 now has five themes instead of four (🎉) so the project's README needed updating.

## Changes
I updated the number of themes mentioned in the README from 'four' to 'five'.
