### PR TITLE
Vertical Tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.7.2
 
+- Vertical tabs option in Editor Preferences
+- Changed tab style to mirror the file tree style
+- Hitting Enter in the global search focuses the file tree, hitting Enter in the file tree focuses the editor.
+
 ## GUI and Functionality
 
 - The NSIS installer (Windows) now contains customized, branded images for the sidebar and header of the various pages visible during the setup process.

--- a/resources/less/geometry/document-tabs.less
+++ b/resources/less/geometry/document-tabs.less
@@ -1,17 +1,43 @@
 // Document Tab bar (over the editor)
 
 #document-tabs {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: @tabbar-height;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  flex-shrink: 0;
-  overflow-x: auto;
+
+  &.horizontal {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: @tabbar-height;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    flex-shrink: 0;
+    overflow-x: auto;
+
+    .document {
+      min-width: 200px;
+      .filename {
+        overflow-x: hidden;
+      }
+    }
+  }
+
+  &.vertical {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 25%;
+    height: auto;
+    display: block;
+    .document {
+      min-height: 30px;
+      .filename {
+        overflow-x: initial;
+      }
+    }
+  }
 
   // In case of an overflow, hide the scrollbar so that scrolling left/right
   // remains possible, but no thicc scrollbar in the way!
@@ -27,20 +53,20 @@
   .document {
     flex-grow: 1;
     position: relative;
-    min-width: 200px;
     line-height: @tabbar-height;
     overflow: hidden;
     padding-right: @tabbar-height; // Push the filename back
 
     .filename {
       white-space: nowrap;
-      overflow-x: hidden;
       display: inline-block;
+      line-height: @tile-height-min;
       position: absolute;
       left: 0px;
       top: 0px;
       right: @tabbar-height; // Don't overlay the close button
       padding-left: 2px;
+      padding-right: 2px;
     }
 
     // Mark modification status classically
@@ -49,13 +75,43 @@
     .close {
       position: absolute;
       right: 0px;
-      top: 0px;
+      top: 2px;
       width: @tabbar-height;
       height: @tabbar-height;
       line-height: @tabbar-height;
       text-align: center;
       border-radius: @tabbar-height;
       display: inline-block;
+    }
+  }
+
+  // The directory's resizable handler
+  &.vertical #tabs-resize {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0px;
+    width: 10px;
+    cursor: ew-resize;
+    z-index: 10;
+
+    &::after {
+      content: "";
+      position: absolute;
+      width: 6px;
+      height: calc(100% - 4px);
+    }
+
+    &::after {
+      border-radius:10px;
+      transition: 0.4s all ease;
+    }
+
+    &:hover {
+      &::after {
+        background-color: rgba(0, 0, 0, .4);
+        box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .25);
+      }
     }
   }
 }

--- a/resources/less/geometry/editor.less
+++ b/resources/less/geometry/editor.less
@@ -101,6 +101,7 @@
 .CodeMirror-fullscreen {
   position: fixed !important; // Have to override another relative
   margin-top: 0px !important; // Normally 25px for tab bar, but not in distraction free
+  margin-right: 0 !important;
   top: @toolbar-height;
   left: 0;
   right: 0;

--- a/resources/less/theme-berlin/dark/document-tabs.less
+++ b/resources/less/theme-berlin/dark/document-tabs.less
@@ -1,17 +1,22 @@
 // Document tabs styling
 
 #document-tabs {
-  border-bottom: 1px solid #666;
-  color: var(--grey-1);
+  background-color: var(--grey-7);
+  color:white;
+  box-shadow: inset 14px 2px 54px -23px rgba(0,0,0,0.75);
 
   .document {
-    &:hover { background-color: var(--grey-6); }
+    border-top-color: var(--grey-4);
+
+    &:hover { 
+      background-color: var(--grey-6) !important; 
+      p.filename { color: white !important; }
+    }
 
     &.active { background-color: var(--grey-6); }
 
     .close {
       &:hover {
-        transform: rotate(90deg);
         fill: var(--red-0);
       }
     }

--- a/resources/less/theme-berlin/light/document-tabs.less
+++ b/resources/less/theme-berlin/light/document-tabs.less
@@ -2,28 +2,43 @@
 // Document Tab bar (over the editor)
 
 #document-tabs {
-  border-bottom: 1px solid #ddd;
+  background-color: var(--bg-preview);
+  transition: @mode-transition background-color ease;
+  font-size: @font-size-small;
+  box-shadow: inset 14px 2px 54px -23px rgba(0,0,0,0.25);
 
   .document {
-    transition: 0.2s background-color ease;
+    border-bottom:1px solid var(--grey-2);
+    border-left: 5px solid transparent;
 
     .filename { padding-left: 8px; }
 
-    &:hover { background-color: rgb(200, 200, 210); }
-
-    &.active {
-      background-color: var(--c-primary);
-      // Let's use LESS to output a contrast color (white or black depending on
-      // the theme's primary colour)
-      color: contrast(@c-primary);
+    &:hover { 
+      background-color:var(--grey-0) !important;
+      p.filename { color: var(--grey-7) !important; }
     }
 
-    .close {
-      transition: 0.1s all ease;
-      &:hover {
-        transform: rotate(90deg);
-        path { fill: var(--red-0); }
-      }
+    &.active {
+      background-color: var(--grey-2);
+      border-left: 5px solid var(--c-primary);
+    }
+  }
+
+  &.horizontal .document .close {
+    transition: 0.1s all ease;
+    &:hover {
+      transform: rotate(90deg);
+      path { fill: var(--red-0); }
+    }
+  }
+
+  &.vertical .document .close {
+    opacity: 0;
+    transition: 0.1s all ease;
+    &:hover {
+      opacity: 1;
+      background-color: var(--grey-2);
+      path { fill: var(--red-0); }
     }
   }
 }

--- a/resources/less/theme-bielefeld/theme-main.less
+++ b/resources/less/theme-bielefeld/theme-main.less
@@ -72,6 +72,9 @@ body {
   #editor {
     background-color: var(--beige-0);
     // We only need to change the editor's font
+  }
+
+  #editor > :not(#document-tabs) {
     font-family: @font-liberation;
   }
 
@@ -84,6 +87,11 @@ body {
   }
 
   #sidebar #sidebar-resize { background-color: var(--beige-0); }
+
+  #document-tabs {
+    background-color: var(--beige-1);
+  }
+
 }
 
 // Exchange the colour of the preview image in the display settings to accomodate

--- a/resources/less/theme-bordeaux/theme-main.less
+++ b/resources/less/theme-bordeaux/theme-main.less
@@ -99,9 +99,11 @@ body {
     #sidebar #sidebar-resize { background-color: #002b36; }
 
     #editor .CodeMirror,
-    #file-list div.container div.list-item p.filename { color: #839496; }
+    #file-list div.container div.list-item p.filename,
+    #document-tabs
+    { color: #839496; }
 
-    #file-list {
+    #file-list, #document-tabs {
       background-color: #073642;
 
       div.list-item { border-bottom: 1px solid #586e75; }

--- a/resources/less/theme-frankfurt/theme-main.less
+++ b/resources/less/theme-frankfurt/theme-main.less
@@ -68,7 +68,7 @@ body {
   /**
    * Change editor font only.
    */
-  #editor {
+  #editor > :not(#document-tabs) {
     font-family: @font-crimson;
     font-size: 1.5em;
   }

--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -262,6 +262,14 @@
             </label>
             <label for="countChars">{{i18n "dialog.preferences.count_chars"}}</label>
           </div>
+          <div class="cb-group">
+            <label class="cb-toggle">
+              <input type="checkbox" name="editor.verticalTabs" value="yes" id="verticalTabs" {{#if editor.verticalTabs}}checked="checked"{{/if}}>
+              <div class="toggle"></div>
+            </label>
+            <label for="verticalTabs">Vertical Tabs</label>
+            {{!-- <label for="tabsOrientation">{{i18n "dialog.preferences.tabsOrientation"}}</label> --}}
+          </div>
 
           {{!-- RTL support options --}}
           <hr>

--- a/resources/vue/sidebar.vue
+++ b/resources/vue/sidebar.vue
@@ -490,7 +490,7 @@ module.exports = {
      */
     navigate: function (evt) {
       // Only capture arrow movements
-      if (![ 'ArrowDown', 'ArrowUp' ].includes(evt.key)) return
+      if (![ 'ArrowDown', 'ArrowUp', 'Enter' ].includes(evt.key)) return
       evt.stopPropagation()
       evt.preventDefault()
 
@@ -528,6 +528,9 @@ module.exports = {
             global.editor.announceTransientFile(list[index].hash)
             global.ipc.send('file-get', list[index].hash)
           }
+          break
+        case 'Enter':
+          global.cm.focus()
           break
       }
     },

--- a/source/main/providers/config-provider.js
+++ b/source/main/providers/config-provider.js
@@ -186,6 +186,7 @@ class ConfigProvider extends EventEmitter {
         'indentUnit': 4, // The number of spaces to be added
         'countChars': false, // Set to true to enable counting characters instead of words
         'inputMode': 'default', // Can be default, vim, emacs
+        'verticalTabs': true, // vertical or horizontal tabs
         'boldFormatting': '**', // Can be ** or __
         'italicFormatting': '_', // Can be * or _
         'readabilityAlgorithm': 'dale-chall', // The algorithm to use with readability mode.

--- a/source/renderer/assets/index.htm
+++ b/source/renderer/assets/index.htm
@@ -47,7 +47,9 @@
 
         <!-- Three: The editor itself -->
         <div id="editor">
-          <div id="document-tabs"></div>
+          <div id="document-tabs">
+            <div id="tabs-resize"></div>
+          </div>
             <textarea id="cm-text" style="display:none;" placeholder=""></textarea>
         </div>
 

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -285,6 +285,8 @@ class PreferencesDialog extends ZettlrDialog {
     cfg['editor.rtlMoveVisually'] = (data.find(elem => elem.name === 'editor.rtlMoveVisually') !== undefined)
     cfg['zkn.autoCreateLinkedFiles'] = (data.find(elem => elem.name === 'zkn.autoCreateLinkedFiles') !== undefined)
 
+    cfg['editor.verticalTabs'] = (data.find(elem => elem.name === 'editor.verticalTabs') !== undefined)
+
     cfg['watchdog.activatePolling'] = (data.find(elem => elem.name === 'watchdog.activatePolling') !== undefined)
 
     // Extract selected dictionaries

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -50,10 +50,10 @@ module.exports = class EditorTabs {
 
       this._currentlyDragging.ondrag = (evt) => {
         // Immediately sort everything correctly.
-        // Take the absolute X coord, and then make it relative:
-        // 1. Substract the left offset (the sidebar)
+        // Take the absolute X/Y coord, and then make it relative:
+        // 1. Substract the X/Y offset (the sidebar)
         // 2. Move the position to the beginning of the element
-        // 3. Take the current scrollLeft value into account
+        // 3. Take the current scrollLeft/Top value into account
         let currentElementPositionX = evt.clientX - this._cursorOffsetX - this._tabbarLeft + this._div.scrollLeft
         let currentElementPositionY = evt.clientY - this._cursorOffsetY - this._tabbarTop + this._div.scrollTop
         for (let elem of this._currentlyDragging.parentElement.childNodes) {
@@ -75,6 +75,7 @@ module.exports = class EditorTabs {
       let newHashes = []
       // Now get the correct list of hashes
       for (let elem of this._currentlyDragging.parentElement.childNodes) {
+        // #tabs-resize is a sibling of the .document elements
         if(elem.id !== 'tabs-resize') {
           newHashes.push(parseInt(elem.dataset['hash'], 10))
         }
@@ -90,17 +91,16 @@ module.exports = class EditorTabs {
     // For those non-macOS users (boo!)
     this._div.onwheel = (evt) => { this._div.scrollLeft += evt.deltaY }
 
+    // Resize vertical tabs
     this.tabsResize = (evt) => {
       const width = (this.width - evt.clientX) + 'px'
       this._div.style.width = width
       document.getElementsByClassName('CodeMirror')[0].style.marginRight = width
     }
-
     this.tabsStopResize = (evt) => {
       document.removeEventListener('mousemove', this.tabsResize)
       document.removeEventListener('mouseup', this.tabsStopResize)
     }
-
     this._resizer.onmousedown = (evt) => {
       document.addEventListener('mousemove', this.tabsResize)
       document.addEventListener('mouseup', this.tabsStopResize)
@@ -139,7 +139,7 @@ module.exports = class EditorTabs {
     this._tippyInstances = []
 
     this._div.innerHTML = '<div id="tabs-resize"></div>'
-    // Need to reattach handlers after clearing innerHTML
+    // Need to reattach resize handlers after clearing innerHTML
     this._resizer = document.getElementById('tabs-resize')
     this._resizer.onmousedown = (evt) => {
       document.addEventListener('mousemove', this.tabsResize)

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -58,13 +58,13 @@ module.exports = class EditorTabs {
         let currentElementPositionY = evt.clientY - this._cursorOffsetY - this._tabbarTop + this._div.scrollTop
         for (let elem of this._currentlyDragging.parentElement.childNodes) {
           if (elem === this._currentlyDragging) continue // No inception, please
-          if (!global.config.get('editor.verticalTabs') 
-              && elem.offsetLeft > currentElementPositionX) {
+          if (!global.config.get('editor.verticalTabs') &&
+              elem.offsetLeft > currentElementPositionX) {
             elem.parentElement.insertBefore(this._currentlyDragging, elem)
             break
           }
-          if (global.config.get('editor.verticalTabs') 
-              && elem.offsetTop > currentElementPositionY) {
+          if (global.config.get('editor.verticalTabs') &&
+              elem.offsetTop > currentElementPositionY) {
             elem.parentElement.insertBefore(this._currentlyDragging, elem)
             break
           }
@@ -76,7 +76,7 @@ module.exports = class EditorTabs {
       // Now get the correct list of hashes
       for (let elem of this._currentlyDragging.parentElement.childNodes) {
         // #tabs-resize is a sibling of the .document elements
-        if(elem.id !== 'tabs-resize') {
+        if (elem.id !== 'tabs-resize') {
           newHashes.push(parseInt(elem.dataset['hash'], 10))
         }
       }
@@ -106,12 +106,12 @@ module.exports = class EditorTabs {
       document.addEventListener('mouseup', this.tabsStopResize)
     }
 
-  // Listen to Cmd/Ctrl+[0-9] events on the window
-  window.addEventListener('keydown', (e) => {
-    let darwinCmd = process.platform === 'darwin' && e.metaKey
-    let otherCtrl = process.platform !== 'darwin' && e.ctrlKey
+    // Listen to Cmd/Ctrl+[0-9] events on the window
+    window.addEventListener('keydown', (e) => {
+      let darwinCmd = process.platform === 'darwin' && e.metaKey
+      let otherCtrl = process.platform !== 'darwin' && e.ctrlKey
 
-    if (!darwinCmd && !otherCtrl) return
+      if (!darwinCmd && !otherCtrl) return
 
       if ([ '1', '2', '3', '4', '5', '6', '7', '8', '9' ].includes(e.key)) {
         e.stopPropagation()

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -494,17 +494,6 @@ class ZettlrBody {
   }
 
   /**
-    * Open a new dialog for displaying the global search.
-    * @return {void}       Nothing to return.
-    */
-  displayGlobalSearch () {
-    if (this._currentDialog !== null) return // Only one dialog at a time
-    this._currentDialog = new GlobalSearchDialog()
-    this._currentDialog.init().open()
-    this._currentDialog.on('afterClose', (e) => { this._currentDialog = null })
-  }
-
-  /**
     * Open a new dialog for displaying the preferences.
     * @param  {Object} prefs An object containing all current config variables
     * @return {void}       Nothing to return.

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -116,8 +116,8 @@ class ZettlrBody {
       let isDarwin = $('body').hasClass('darwin')
       let cmdOrCtrl = (isDarwin && event.metaKey) || (!isDarwin && event.ctrlKey)
 
-      let focusEditorShortcut = (cmdOrCtrl && event.shiftKey && event.key === 'e')
-      let focusSidebarShortcut = (cmdOrCtrl && event.shiftKey && event.key === 't')
+      let focusEditorShortcut = (cmdOrCtrl && event.shiftKey && (event.key === 'e' || event.key === 'E'))
+      let focusSidebarShortcut = (cmdOrCtrl && event.shiftKey && (event.key === 't' || event.key === 'T'))
       if (focusEditorShortcut) { // Cmd/Ctrl+Shift+E
         // Obviously, focus the editor
         this._renderer.getEditor().getEditor().focus()
@@ -491,6 +491,17 @@ class ZettlrBody {
       this._currentPopup.close()
       this._currentPopup = null
     })
+  }
+
+  /**
+    * Open a new dialog for displaying the global search.
+    * @return {void}       Nothing to return.
+    */
+  displayGlobalSearch () {
+    if (this._currentDialog !== null) return // Only one dialog at a time
+    this._currentDialog = new GlobalSearchDialog()
+    this._currentDialog.init().open()
+    this._currentDialog.on('afterClose', (e) => { this._currentDialog = null })
   }
 
   /**

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -166,6 +166,7 @@ class ZettlrEditor {
       continuelistModes: [ 'markdown', 'markdown-zkn' ],
       extraKeys: generateKeymap(this)
     })
+    global.cm = this._cm
 
     // Set up the helper classes with the CM instance
     this._searcher.setInstance(this._cm)
@@ -600,6 +601,8 @@ class ZettlrEditor {
       }
     }
 
+    // if (flag === 'new-file') this._cm.focus()
+
     // I know that I will make this mistake in the future, so here's why we
     // don't swap the file.content property during this: Because there's a
     // different function to do so. Use it! Don't monkey path _swapFiles. NO
@@ -643,7 +646,7 @@ class ZettlrEditor {
     // Same for the main process
     global.ipc.send('set-active-file', { 'hash': this._currentHash })
 
-    this._cm.focus() // DEBUG Check for side effects
+    // this._cm.focus() // DEBUG Check for side effects
   }
 
   /**
@@ -941,6 +944,18 @@ class ZettlrEditor {
 
     // Last but not least set the Zettelkasten options
     this._cm.setOption('zkn', global.config.get('zkn'))
+
+    if(global.config.get('editor.verticalTabs')) {
+      $('#document-tabs').addClass('vertical')
+      $('#document-tabs').removeClass('horizontal')
+      document.getElementById('document-tabs').style.removeProperty('width')
+      this._cm.getWrapperElement().style.marginRight = '25%'
+    } else {
+      $('#document-tabs').addClass('horizontal')
+      $('#document-tabs').removeClass('vertical')
+      document.getElementById('document-tabs').style.removeProperty('width')
+      this._cm.getWrapperElement().style.marginRight = '0'
+    }
 
     // Fire the renderers in order to apply potential changed styles and settings
     this._fireRenderers()

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -948,7 +948,7 @@ class ZettlrEditor {
     this._cm.setOption('zkn', global.config.get('zkn'))
 
     // Set the tab orientation
-    if(global.config.get('editor.verticalTabs')) {
+    if (global.config.get('editor.verticalTabs')) {
       $('#document-tabs').addClass('vertical')
       $('#document-tabs').removeClass('horizontal')
       document.getElementById('document-tabs').style.removeProperty('width')

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -601,6 +601,7 @@ class ZettlrEditor {
       }
     }
 
+    // Always focusing CodeMirror breaks file-list arrow navigation
     // if (flag === 'new-file') this._cm.focus()
 
     // I know that I will make this mistake in the future, so here's why we
@@ -646,6 +647,7 @@ class ZettlrEditor {
     // Same for the main process
     global.ipc.send('set-active-file', { 'hash': this._currentHash })
 
+    // Always focusing CodeMirror breaks file-list arrow navigation
     // this._cm.focus() // DEBUG Check for side effects
   }
 
@@ -945,6 +947,7 @@ class ZettlrEditor {
     // Last but not least set the Zettelkasten options
     this._cm.setOption('zkn', global.config.get('zkn'))
 
+    // Set the tab orientation
     if(global.config.get('editor.verticalTabs')) {
       $('#document-tabs').addClass('vertical')
       $('#document-tabs').removeClass('horizontal')

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -80,8 +80,8 @@ class ZettlrToolbar {
         this._renderer.exitSearch()
       } else if (e.key === 'Enter') {
         this._renderer.beginSearch(this._searchbar.val())
-        //Focus the file-list for immediate arrow navigation
-        $('#file-list').focus() 
+        // Focus the file-list for immediate arrow navigation
+        $('#file-list').focus()
       } else {
         this._applyAutocomplete()
       }

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -80,7 +80,8 @@ class ZettlrToolbar {
         this._renderer.exitSearch()
       } else if (e.key === 'Enter') {
         this._renderer.beginSearch(this._searchbar.val())
-        this._searchbar.select() // Select everything in the area.
+        // this._searchbar.select() // Select everything in the area.
+        $('#file-list').focus()
       } else {
         this._applyAutocomplete()
       }

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -80,8 +80,8 @@ class ZettlrToolbar {
         this._renderer.exitSearch()
       } else if (e.key === 'Enter') {
         this._renderer.beginSearch(this._searchbar.val())
-        // this._searchbar.select() // Select everything in the area.
-        $('#file-list').focus()
+        //Focus the file-list for immediate arrow navigation
+        $('#file-list').focus() 
       } else {
         this._applyAutocomplete()
       }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

Instead of only having tabs horizontally across the top, the tabs can be stacked vertically on the right side of the editor, with the same styling as the file list.  This is set by a toggle in Editor Preferences.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

- Vertical Tabs: tabs are stacked on the right, with resizing like the file list sidebar and dragging like the horizontal tab list
- Editor Preferences: toggle for vertical tabs
- Styles: Tabs are now same style as the file list in both vertical and horizontal orientations.
- Themes: All themes (light and dark) work with vertical tabs, and now have the same style as the file list.

Somewhat unrelated but probably not worthy of another pull request:
- Ctrl-Shift-T/E to focus tree/editor were not working on my machine, so that is fixed as well.
- This was caused by another issue that was always focusing CodeMirror, but broke the keyboard shortcuts.
- Now, hitting Enter while focused on the global search will focus the file tree and hitting Enter while focused on the file tree (maybe after arrow navigation) will focus the editor.  It feels very natural in practice.
- Unfortunately, this means that the editor is not immediately focused after creating a new file, but the kb shortcut can be used.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: Ubuntu 20.20 