### PR TITLE
Support saving as JPEG in Insert Image from Clipboard dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - The application now uses `app.getVersion()` instead of requiring the `package.json`-file (thanks to @Aigeruth for implementing).
 - CodeMirror is now required directly within the plugins and is independent of the location of `node_modules`.
 - Zettlr is now also available for ARM64 Windows (thanks to @smitec for implementing).
+- Insert Image from Clipboard saves as JPEG when the 'jpg' file extension is specified.
 
 # 1.7.1
 

--- a/source/main/commands/save-image-from-clipboard.js
+++ b/source/main/commands/save-image-from-clipboard.js
@@ -41,9 +41,15 @@ class SaveImage extends ZettlrCommand {
     if (targetFile === '') return global.ipc.notify(trans('system.error.no_allowed_chars'))
     if (!activeFile) return global.ipc.notify(trans('system.error.fnf_message'))
 
-    // Now check the extension of the name (some users may
-    // prefer to choose to provide it already)
-    if (path.extname(targetFile) !== '.png') targetFile += '.png'
+    // PNG is the default file format.
+    let fileFormat = 'png'
+    // Now check the file extension. Set the file format to JPEG if the
+    // extension is 'jpg', or add 'png' missing.
+    if (path.extname(targetFile).toLowerCase() === '.jpg') {
+      fileFormat = 'jpg'
+    } else if (path.extname(targetFile).toLowerCase() !== '.png') {
+      targetFile += '.png'
+    }
 
     // Now resolve the path correctly, taking into account a potential relative
     // path the user has chosen.
@@ -102,7 +108,9 @@ class SaveImage extends ZettlrCommand {
 
     global.log.info(`Saving image ${targetFile} at ${imagePath} ...`)
 
-    fs.writeFile(imagePath, image.toPNG(), (err) => {
+    let imageData = (fileFormat === 'jpg') ? image.toJPEG(85) : image.toPNG()
+
+    fs.writeFile(imagePath, imageData, (err) => {
       if (err) return global.ipc.notify(trans('system.error.could_not_save_image'))
       // Insert a relative path instead of an absolute one
       let pathToInsert = path.relative(path.dirname(activeFile.path), imagePath)


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description

When `save-image-from-clipboard` is called with a file name ending with a 'jpg' extension, then the file will be saved as a JPEG image. PNG remains the default format. This is the bare minimum change. Help text should be added to the dialog to make this feature more clear, could be handled in this PR or separately.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Adds a file extension check to `main/commands/save-image-from-clipboard.js` to allow saving as JPG.

Example logs:
```
Preparing to save: 20200709110510.md; filepath: /home/user/zettelkasten
Saving image as: /home/user/zettelkasten/b3367857ad1f2c65b9a3a63a923dd68d2.jpg
```

<!-- Please provide any testing system -->
Tested on: Ubuntu 20.04 / Mint 20

For #1127 