### PR TITLE
[Codemirror] Util function for parentheses detection in links/images paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## GUI and Functionality
 
 - Fixed a bug causing Export Project to fail.
+- Fixed parentheses detection in links and images paths.
 
 # 1.7.2
 

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
@@ -12,6 +12,9 @@
 })(function (CodeMirror) {
   'use strict'
 
+  const path = require('path')
+  const parenthesisDetection = require('../../util/parenthesis-detection')
+
   // GENERAL PLUGIN VARIABLES
 
   // Image detection regex
@@ -21,8 +24,6 @@
   // Holds the currently rendered images
   var imageMarkers = []
   var currentDocID = null
-
-  const path = require('path')
 
   // This variable holds a base64 encoded placeholder image.
   var img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5PURAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggeDC8lR+xuCgAABkNJREFUeNrt3V2IXGcdx/Hfo2va7oIoiq3mwoJgtLfdFUVj2UDUiiBooWJ9oZRYIVdqz8aAFBHZlPMEYi5WqkGK70aKbyi1iC5VsBeOLzeNpN7Yi4reKglpCHu8yC7IsrvObGYnM7Ofz11yzmTO/p/lm3N2zs6U5eXlLgD70MuMABBAAAEEEEAAAQSYRjM7bLuU5EKSYkzAhOqS3JVkbtAAXjh58uSC+QGT7NSpU39IsjDoJbAzP2AabNsyPwME9i0BBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAgJtuxggm3+rq6qFer2cQo3WlaZoXjEEAucl6vd5SkodMYqT+agQugRkPLxnByF0yAgEEEEAAAQQQQAABBBBAAAEEGANuhN4//pPkVNd1/zaK7ZVSXpHkZJLXmYYAMj0uHz9+/NbZ2dllo9hZrfV5AXQJzJRZWVn5qin0dyJoBAIIIIAAAggggACTz6vA/F+11jcm+UKSTyY58D+bnkzy5aZp/mJKOANk6rRteyzJ35Ic2xS/JLkvyZ9qrd82KQSQqYtfKeXcFuHb/D308bZtv2tiCCDTctl7sJTylX73L6U8UGu9x+QQQKbBI0nmBnzM14wNAWQafGYXj3nL6urqIaNDANmXer3eO00BAWRiXb58+UumgACyL83Ozj6628eura09PcxjqbUu1Fr/ZVUQQEbp/C4e848TJ068OOTj+HmS291riAAySo8lWRvkAV3XfW7IZ3+/SnL7+h8fqLX6+SICyN5rmubPSb43wEMuLi0tfX+I8ftwkqObvld/amUQQEYVwY91XddPBC82TTO021/WX4T5zhabXltr/bGVQQAZiaWlpY8muSfJc1tsvtp13f3DjF+SrKysHEly2zabP9i27dusDMPg3WDo50zwmfXL0oNJ3ptcf7V3/QWP88N8rlrrg0me2Ok/7VLK01YFAWTUIXxxL//9Wut8kl4fu7661rraNM2iVcElMNPiZ0m6Pvc9XGs9bGQIIBOv1vpYkjek/09km0nya5NDABnXqD1Va32ij/2OJvn8Lp7iwPq9giCAjFX8ziW5N8mDtdZfbrff+i0vN/JbHkfbtn2PiSOAjEv8vp7rb6G/4X211t9ste/KysrBJHfcyPOVUtwgjQAyNvH71BabjtRaf7dp3y8meWgIT3vbdoEFAWQk2rZ9ZJv4bTi8EcFa65uTfHaIT3+k1vohq8Ag3AfIsM78Hi6l9POW+IdrrU8l+UaSVw75MH5oJXAGyMjjl8E+D+TeJHtxD99MrfVZK4IAMqr4HUvy+Bgd0jtcCiOA7Lm2bd+f5Fz6v3l5VH509erVb1ohBJC9OvN7dynlJ+N6fGfPnn2TVUIA2ZP4JfltkgNjfJjvqrV+xGohgAzzsvfuJJPy62c/uHbt2jNWDQFkGPG7s5Ty+yS3TMoxnzlzZtbKIYDc6GXvnaWUP05S/NYttG17vxVEANl1/JJcTPKaSTz+Usr5tm3vsJIIIANZW1v7e5JnJ/DMb3MEf2E1EUAGcvr06ZeSvH4KvpS7a62fsKIIIP1e+j5fSjk0RV/St2qtb7WybPBmCGwXv8eTvD39fUjRJHnU6iKA7Khpmk9P6Zc2b3VxCQwIoBEAAggggAACCCCAAAIIIIBMoK5pmn8aQ1/WjGB/cCP0/vGqWuuTSa6MvLxdl1z/3JBu4+9KKeM6p5cn+YBvFwFkutya5L6b8cRjHDtcAgMIIIAAAggggAACCCCAAAIIIOPgFiMYuTkjmHxuhJ4C8/Pzba/Xa01ipK4kecEYBJCbbHFx8eLi4qJBgEtgAAEEEEAAAQQQQAABBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBNAJAAAEEEEAAAQQQQAABBBBAAAEEEEAAAaYggJ3xAFNg25aV5eXl7TZeSnIhSTE/YILjd1eSua02zuzwwLkkC+YH7MdLYAABBBBAAAEEEECAifVfoVk7QcTH/rgAAAAASUVORK5CYII='
@@ -106,6 +107,12 @@
         // Now get the precise beginning of the match and its end
         let curFrom = { 'line': i, 'ch': match.index }
         let curTo = { 'line': i, 'ch': match.index + match[0].length }
+
+        // The regex will need a little help if an image path contains closing parentheses
+        url = parenthesisDetection(url, line, curTo)
+
+        // If something went wrong, parenthesisDetection returns ''. Do not render.
+        if (url === '') continue
 
         let cur = cm.getCursor('from')
         if (cur.line === curFrom.line && cur.ch >= curFrom.ch && cur.ch <= curTo.ch + 1) {

--- a/source/renderer/util/parenthesis-detection.js
+++ b/source/renderer/util/parenthesis-detection.js
@@ -1,0 +1,67 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Parenthesis detection in paths
+ * CVM-Role:        Utility
+ * Maintainer:
+ * License:         GNU GPL v3
+ *
+ * Description:     Helps with parenthesis-detection in links/images rendering
+ *
+ * END HEADER
+ */
+
+/**
+ * Helps with parenthesis-detection in links/images rendering
+ * @param  {string} url     The currently detected url
+ * @param  {number} line    The currently active line
+ * @param  {object} curTo   The currently detected end of the link
+ * @return {string}         The full url
+ */
+module.exports = function parenthesisDetection (url, line, curTo) {
+  // The age-old problem of parenthesis-detection. In links & images rendering,
+  // regular expression will not match all parentheses, if a link contains these,
+  // so what we need is to go through the URL, and, if it contains opening parentheses
+  // we need a matching pair of these, so we'll have to go through it one by one.
+
+  // Known limitations:
+  // 1. A link must always contain a matching pair
+  //    → a path like 'path(likethis' will not work.
+  // 2. Multiples parentheses must be enclosed in each other
+  //    → a path like 'link(first)(second)' will not work.
+
+  // As we will go to to the final parenthesis in []()
+  // we must count in the very first parenthesis too!
+  let openingParentheses = 1
+  let closingParentheses = 0
+
+  if (url !== '') {
+    for (let i = 0; i < url.length; i++) {
+      if (url.charAt(i) === '(') openingParentheses++
+      if (url.charAt(i) === ')') closingParentheses++
+    }
+
+    if (openingParentheses > closingParentheses) {
+      // If we're here, we most certainly have a non-closed parenthesis in a link
+      let leftOvers = openingParentheses - closingParentheses
+
+      // curTo.ch is currently located after the first closing parenthesis,
+      // so we move it one character back
+      curTo.ch--
+
+      while (curTo.ch < line.length) {
+        let currentChar = line.charAt(curTo.ch)
+        curTo.ch++
+        if (currentChar === ')') leftOvers--
+        if (leftOvers === 0) break
+        url += currentChar
+      }
+
+      // If we were unable to fully resolve all parentheses, abort.
+      if (leftOvers > 0) return ''
+    }
+  }
+
+  return url
+}


### PR DESCRIPTION
## Description
Images with parentheses in their path weren't rendering properly.
In response to https://github.com/Zettlr/Zettlr/pull/1096#issuecomment-663783451, I used & adapted the existing parentheses-detection code (used for links rendering), so it can be used both for links and images.

## Changes
- created the renderer util function `parenthesisDetection` to handle parentheses detection in links and images
- it uses the original parentheses detection code from `zettlr-plugin-render-links.js`, fixing an issue where the first closing parenthesis in the path was skipped
    - indeed `[link](https://www.google.com/search?q=(inside)outside)` 
    - was rendered as a link to `https://www.google.com/search?q=(insideoutside)`)
- `zettlr-plugin-render-links.js` has been adapted to use `parenthesisDetection`
- `parenthesisDetection` has been added to `zettlr-plugin-render-images.js` so images also support paths with parentheses

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
It has the following limitations:
1. A link must always contain a matching pair
→ a path like `path(likethis` will not work.

2. Multiples parentheses must be enclosed in each other
→ a path like `link(first)(second)` will not work.

I still think percent-encoding parentheses (`%28` `%29`) in the code, when links & images are inserted would be safer. See how an editor like Brackets will percent-encode spaces as `%20` in autocompleted paths.
That being said, HTML is not Markdown and it might indeed impede readability.

**TODO**: 

- [ ] when the cursor is on an image and the code is shown, syntax highlighting is not applied properly to the end of the image code. I suppose code rendering is using the regex only and not benefiting from the parenthesis detection in image rendering. But where is it, then?

<!-- Please provide any testing system -->
Tested on: Windows 10
