### PR TITLE
Tag case insensitivity and hyphenation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,10 +19,6 @@
         "ecmaVersion": 2018
     },
     "rules": {
-        "space-before-function-paren": [
-            2,
-            "always"
-        ],
         // The following rule-changes to JSStandard Coding Style are tradition,
         // as they were included with the default configuration of Atom's ESLint
         // plugin, so we'll keep them here for the time being.
@@ -30,48 +26,28 @@
         "quote-props": "off",
         "no-prototype-builtins": "off",
         "dot-notation": "off",
-        "array-bracket-spacing": [
-            2,
-            "always",
-            {
-                "objectsInArrays": false,
-                "singleValue": false
-            }
-        ],
+        "array-bracket-spacing": [ 2, "always", {
+            "objectsInArrays": false,
+            "singleValue": false
+        } ],
         // Here follow vue-styles. While the short form is recommended
         // I tend to value verbose code. At least for now, discussion is
         // well received.
-        "vue/v-bind-style": [
-            "error",
-            "longform"
-        ],
-        "vue/v-on-style": [
-            "error",
-            "longform"
-        ],
-        "vue/component-tags-order": [
-            "error",
-            {
-                "order": [
-                    "template",
-                    "script",
-                    "style"
-                ]
-            }
-        ],
+        "vue/v-bind-style": [ "error", "longform" ],
+        "vue/v-on-style": [ "error", "longform" ],
+        "vue/component-tags-order": [ "error", {
+          "order": [ "template", "script", "style" ]
+        } ],
         // Let the implementation decide if self-closing is wanted or not.
-        "vue/html-self-closing": [
-            "warn",
-            {
-                "html": {
-                    "void": "any",
-                    "normal": "any",
-                    "component": "any"
-                },
-                "svg": "any",
-                "math": "any"
-            }
-        ],
+        "vue/html-self-closing": [ "warn", {
+          "html": {
+            "void": "any",
+            "normal": "any",
+            "component": "any"
+          },
+          "svg": "any",
+          "math": "any"
+        }],
         "jquery/no-ajax": 2,
         "jquery/no-ajax-events": 2,
         "jquery/no-animate": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,10 @@
         "ecmaVersion": 2018
     },
     "rules": {
+        "space-before-function-paren": [
+            2,
+            "always"
+        ],
         // The following rule-changes to JSStandard Coding Style are tradition,
         // as they were included with the default configuration of Atom's ESLint
         // plugin, so we'll keep them here for the time being.
@@ -26,28 +30,48 @@
         "quote-props": "off",
         "no-prototype-builtins": "off",
         "dot-notation": "off",
-        "array-bracket-spacing": [ 2, "always", {
-            "objectsInArrays": false,
-            "singleValue": false
-        } ],
+        "array-bracket-spacing": [
+            2,
+            "always",
+            {
+                "objectsInArrays": false,
+                "singleValue": false
+            }
+        ],
         // Here follow vue-styles. While the short form is recommended
         // I tend to value verbose code. At least for now, discussion is
         // well received.
-        "vue/v-bind-style": [ "error", "longform" ],
-        "vue/v-on-style": [ "error", "longform" ],
-        "vue/component-tags-order": [ "error", {
-          "order": [ "template", "script", "style" ]
-        } ],
+        "vue/v-bind-style": [
+            "error",
+            "longform"
+        ],
+        "vue/v-on-style": [
+            "error",
+            "longform"
+        ],
+        "vue/component-tags-order": [
+            "error",
+            {
+                "order": [
+                    "template",
+                    "script",
+                    "style"
+                ]
+            }
+        ],
         // Let the implementation decide if self-closing is wanted or not.
-        "vue/html-self-closing": [ "warn", {
-          "html": {
-            "void": "any",
-            "normal": "any",
-            "component": "any"
-          },
-          "svg": "any",
-          "math": "any"
-        }],
+        "vue/html-self-closing": [
+            "warn",
+            {
+                "html": {
+                    "void": "any",
+                    "normal": "any",
+                    "component": "any"
+                },
+                "svg": "any",
+                "math": "any"
+            }
+        ],
         "jquery/no-ajax": 2,
         "jquery/no-ajax-events": 2,
         "jquery/no-animate": 2,

--- a/source/main/modules/fsal/fsal-file.js
+++ b/source/main/modules/fsal/fsal-file.js
@@ -222,13 +222,13 @@ function parseFileContents (file, content) {
   while ((match = tagRE.exec(mdWithoutCode)) != null) {
     let tag = match[1]
     tag = tag.replace(/#/g, '') // Prevent headings levels 2-6 from showing up in the tag list
-    if (tag.length > 0) file.tags.push(match[1].toLocaleLowerCase())
+    if (tag.length > 0) file.tags.push(match[1].toLocaleLowerCase(global.config.get('appLang')))
   }
 
   // Merge possible keywords from the frontmatter
   if (file.frontmatter && file.frontmatter.hasOwnProperty('keywords')) {
     // Lower-case (as with regex-extracted tags) and replace spaces with dashes
-    file.frontmatter.keywords = file.frontmatter.keywords.map(k => k.toLocaleLowerCase().split(' ').join('-'))
+    file.frontmatter.keywords = file.frontmatter.keywords.map(k => k.toLocaleLowerCase(global.config.get('appLang')))
 
     file.tags = file.tags.concat(file.frontmatter.keywords)
   }

--- a/source/main/modules/fsal/fsal-file.js
+++ b/source/main/modules/fsal/fsal-file.js
@@ -227,9 +227,8 @@ function parseFileContents (file, content) {
 
   // Merge possible keywords from the frontmatter
   if (file.frontmatter && file.frontmatter.hasOwnProperty('keywords')) {
-    // Lower-case (as with regex-extracted tags) and replace spaces with dashes
+    // Lower-case (as with regex-extracted tags)
     file.frontmatter.keywords = file.frontmatter.keywords.map(k => k.toLocaleLowerCase(global.config.get('appLang')))
-
     file.tags = file.tags.concat(file.frontmatter.keywords)
   }
 

--- a/source/main/modules/fsal/fsal-file.js
+++ b/source/main/modules/fsal/fsal-file.js
@@ -222,11 +222,14 @@ function parseFileContents (file, content) {
   while ((match = tagRE.exec(mdWithoutCode)) != null) {
     let tag = match[1]
     tag = tag.replace(/#/g, '') // Prevent headings levels 2-6 from showing up in the tag list
-    if (tag.length > 0) file.tags.push(match[1].toLowerCase())
+    if (tag.length > 0) file.tags.push(match[1].toLocaleLowerCase())
   }
 
   // Merge possible keywords from the frontmatter
   if (file.frontmatter && file.frontmatter.hasOwnProperty('keywords')) {
+    // Lower-case (as with regex-extracted tags) and replace spaces with dashes
+    file.frontmatter.keywords = file.frontmatter.keywords.map(k => k.toLocaleLowerCase().split(' ').join('-'))
+
     file.tags = file.tags.concat(file.frontmatter.keywords)
   }
 

--- a/source/main/modules/fsal/search-file.js
+++ b/source/main/modules/fsal/search-file.js
@@ -54,7 +54,7 @@ module.exports = function searchFile (fileObject, terms, cnt) {
     if (t.operator === 'AND') {
       if (fileObject.name.toLowerCase().indexOf(t.word.toLowerCase()) > -1 || fileObject.tags.includes(t.word.toLowerCase())) {
         matches++
-      } else if (t.word[0] === '#' && fileObject.tags.includes(t.word.substr(1))) {
+      } else if (t.word[0] === '#' && fileObject.tags.includes(t.word.substr(1).toLocaleLowerCase())) {
         // Account for a potential # in front of the tag
         matches++
       }
@@ -65,7 +65,7 @@ module.exports = function searchFile (fileObject, terms, cnt) {
           matches++
           // Break because only one match necessary
           break
-        } else if (wd[0] === '#' && fileObject.tags.includes(wd.toLowerCase().substr(1))) {
+        } else if (wd[0] === '#' && fileObject.tags.includes(wd.toLowerCase().substr(1).toLocaleLowerCase())) {
           // Account for a potential # in front of the tag
           matches++
           break

--- a/source/main/modules/fsal/search-file.js
+++ b/source/main/modules/fsal/search-file.js
@@ -54,7 +54,7 @@ module.exports = function searchFile (fileObject, terms, cnt) {
     if (t.operator === 'AND') {
       if (fileObject.name.toLowerCase().indexOf(t.word.toLowerCase()) > -1 || fileObject.tags.includes(t.word.toLowerCase())) {
         matches++
-      } else if (t.word[0] === '#' && fileObject.tags.includes(t.word.substr(1).toLocaleLowerCase())) {
+      } else if (t.word[0] === '#' && fileObject.tags.includes(t.word.substr(1).toLocaleLowerCase(global.config.get('appLang')))) {
         // Account for a potential # in front of the tag
         matches++
       }
@@ -65,7 +65,7 @@ module.exports = function searchFile (fileObject, terms, cnt) {
           matches++
           // Break because only one match necessary
           break
-        } else if (wd[0] === '#' && fileObject.tags.includes(wd.toLowerCase().substr(1).toLocaleLowerCase())) {
+        } else if (wd[0] === '#' && fileObject.tags.includes(wd.toLowerCase().substr(1).toLocaleLowerCase(global.config.get('appLang')))) {
           // Account for a potential # in front of the tag
           matches++
           break


### PR DESCRIPTION
I recently migrated to Zettlr from a home-brew system. My inconsistencies with tag capitalisation made the 'tag cloud' dialog messy and prevented proper searching (since #TAG wouldn't match usage of #tag). Further, some tags in my YAML front matter had spaces. Although they would show up properly in the tag cloud, it doesn't work to search them. 

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
Tags parsed from documents were already lower-cased. This patch also lower-cases tags when read in from YAML front matter. This makes the tag cloud display show unique tags regardless of case. 

Tag search terms are also lower-cased. Previously, a search for #tag and #TAG would only match their exact case.

Tags from YAML frontmatter are hyphenated if they contain spaces. This prevents search from breaking ('#world war' doesn't actually match usage of 'world war' as a YAML keyword). The usage of a hyphen might better off be a configuration option? Some might prefer an underscore, or period?

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
Added 'toLocalLowerCase()' calls and .split(' ').join('-) at a few places.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
Not sure if this issue is something others get annoyed by, or whether it's worth merging into the project. I needed it though :)

<!-- Please provide any testing system -->
Tested on: Windows 10 v2004, Node 14.7.0, yarn 1.22.4
