### PR TITLE
HTML Template: Update Figure CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.7.5
+
+## Export
+
+- HTML Export now centres figure captions underneath figures.
+
 # 1.7.4
 
 ## GUI and Functionality

--- a/source/main/assets/export.tpl.htm
+++ b/source/main/assets/export.tpl.htm
@@ -87,6 +87,15 @@
     border-bottom: 1px solid #333;
   }
 
+  figure {
+    display: inline-block;
+    align-items: center;
+  }
+
+  figure figcaption {
+    text-align: center;
+  }
+
   /* List of classes taken from the skylighting lib */
   /* See: https://github.com/jgm/skylighting/blob/master/skylighting-core/src/Skylighting/Format/HTML.hs */
 


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Repository and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

<!-- Below, please shortly describe what the PR does in one or two short sentences. -->
## Description
Figure captions should be, by default, centred under the caption.
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes
This PR adds some CSS to the default HTML export template to handle `figure` and `figure figcaption`

To do this, `figure` needs to be rendered as an inline-block.
<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
This isn't perfect - if the figure isn't wide enough to centre the caption, it will be aligned with the left edge of the figure. 

I consider this to be an edge case though - Having a long caption under a very narrow image isn't something you come across too often, and it falls back to the old behaviour when this is the case.

Please squash this PR when you merge - I forgot to update the changelog with my initial commit!

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
Win10: 20.04 (Zettlr 1.7.4 via custom CSS)
Gentoo Linux: Compiled from current head of develop branch.