### PR TITLE
Added 'space-before-function-paren' ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,10 @@
         "ecmaVersion": 2018
     },
     "rules": {
+        "space-before-function-paren": [
+            2,
+            "always"
+        ],
         // The following rule-changes to JSStandard Coding Style are tradition,
         // as they were included with the default configuration of Atom's ESLint
         // plugin, so we'll keep them here for the time being.
@@ -23,27 +27,47 @@
         "quote-props": "off",
         "no-prototype-builtins": "off",
         "dot-notation": "off",
-        "array-bracket-spacing": [ 2, "always", {
-            "objectsInArrays": false,
-            "singleValue": false
-        } ],
+        "array-bracket-spacing": [
+            2,
+            "always",
+            {
+                "objectsInArrays": false,
+                "singleValue": false
+            }
+        ],
         // Here follow vue-styles. While the short form is recommended
         // I tend to value verbose code. At least for now, discussion is
         // well received.
-        "vue/v-bind-style": [ "error", "longform" ],
-        "vue/v-on-style": [ "error", "longform" ],
-        "vue/component-tags-order": [ "error", {
-          "order": [ "template", "script", "style" ]
-        } ],
+        "vue/v-bind-style": [
+            "error",
+            "longform"
+        ],
+        "vue/v-on-style": [
+            "error",
+            "longform"
+        ],
+        "vue/component-tags-order": [
+            "error",
+            {
+                "order": [
+                    "template",
+                    "script",
+                    "style"
+                ]
+            }
+        ],
         // Let the implementation decide if self-closing is wanted or not.
-        "vue/html-self-closing": [ "warn", {
-          "html": {
-            "void": "any",
-            "normal": "any",
-            "component": "any"
-          },
-          "svg": "any",
-          "math": "any"
-        }]
+        "vue/html-self-closing": [
+            "warn",
+            {
+                "html": {
+                    "void": "any",
+                    "normal": "any",
+                    "component": "any"
+                },
+                "svg": "any",
+                "math": "any"
+            }
+        ]
     }
 }


### PR DESCRIPTION
## Description
The ESLint rules didn't reflect the project's coding style of having a space after function names and before parentheses. This improves the linter coverage. (And what was important for me was preventing VS Code from wrongly auto-formatting code when saving files)

## Changes
Added the 'space-before-function-paren' rule.

## Additional information
VS Code also reformatted the remainder of the .eslintrc.json file, it seems to improve readability. If this is not preferred I can edit to avoid this.