### PR TITLE
Remove usage of jQuery .val() #1055

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,7 @@
         "jquery/no-sizzle": 2,
         "jquery/no-slide": 2,
         "jquery/no-toggle": 2,
+        "jquery/no-val": 2,
         "jquery/no-when": 2,
         "jquery/no-wrap": 2
     }

--- a/source/common/util/make-img-paths-absolute.js
+++ b/source/common/util/make-img-paths-absolute.js
@@ -45,6 +45,6 @@ module.exports = function (basePath, mdstring) {
       p2 = path.resolve(basePath, p2)
     }
 
-    return `![${p1}](${p2}${(p3 !== undefined) ? ' "' + p3 + '"' : ''})${(p4 != undefined) ? p4 : ''}`
+    return `![${p1}](${p2}${(p3 !== undefined) ? ' "' + p3 + '"' : ''})${(p4 !== undefined) ? p4 : ''}`
   })
 }

--- a/source/quicklook/zettlr-quicklook.js
+++ b/source/quicklook/zettlr-quicklook.js
@@ -55,17 +55,18 @@ class ZettlrQuicklook {
     CodeMirror.commands.focusFind = (cm) => { this._window.find('#searchWhat').first().focus() }
 
     this._window.find('#searchWhat').first().on('keydown', (e) => {
+      const textToFind = this._window.getElementById('searchWhat').value
       if (e.which === 13) {
         e.preventDefault()
         e.stopPropagation()
         // Search next immediately because the term is the same and the user
         // wants to cycle through the results.
-        this.searchNext($('#searchWhat').val())
+        this.searchNext(textToFind)
       } else {
         // Set a timeout with a short delay to not make the app feel laggy
         clearTimeout(this._findTimeout)
         this._findTimeout = setTimeout(() => {
-          this.searchNext($('#searchWhat').val())
+          this.searchNext(textToFind)
         }, 300) // 300ms delay
       }
     })

--- a/source/renderer/dialog/paste-image.js
+++ b/source/renderer/dialog/paste-image.js
@@ -47,15 +47,55 @@ class PasteImage extends ZettlrDialog {
     return data
   }
 
+  get imageNameElement () {
+    return document.getElementById('img-name')
+  }
+
+  get imageName () {
+    return this.imageNameElement.value
+  }
+
+  get imageWidthElement () {
+    return document.getElementById('img-width')
+  }
+
+  get imageWidth () {
+    return parseInt(this.imageWidthElement.value || 0)
+  }
+
+  set imageWidth (width) {
+    this.imageWidthElement.value = width
+  }
+
+  get imageHeightElement () {
+    return document.getElementById('img-height')
+  }
+
+  get imageHeight () {
+    return parseInt(this.imageHeightElement.value || 0)
+  }
+
+  set imageHeight (height) {
+    this.imageHeightElement.value = height
+  }
+
+  get aspectRatioElement () {
+    return document.getElementById('aspect-ratio')
+  }
+
+  get aspectRatio () {
+    return this.aspectRatioElement.value
+  }
+
   postAct () {
     // Activate the sending buttons
     $('#save-cwd, #save-other').on('click', (e) => {
       // The content is either save-cwd or save-other
       global.ipc.send('save-image-from-clipboard', {
         'mode': $(e.target).attr('id'),
-        'name': $('#img-name').val(),
-        'width': parseInt($('#img-width').val() || 0), // Resize to width, 0 indicates no change
-        'height': parseInt($('#img-height').val() || 0) // Resize to height, 0 indicates no change
+        'name': this.imageName,
+        'width': this.imageWidth, // Resize to width, 0 indicates no change
+        'height': this.imageHeight // Resize to height, 0 indicates no change
       })
 
       // Now close the dialog
@@ -67,19 +107,21 @@ class PasteImage extends ZettlrDialog {
     setTimeout(() => { this._place() }, 10)
 
     // Enable the custom javascript actions
-    $('#img-width').on('change', (e) => {
-      let aspect = $('#aspect-ratio').val()
-      if ($('#aspect').prop('checked')) {
-        $('#img-height').val(Math.round($('#img-width').val() / aspect))
+    this.imageWidthElement.addEventListener('change', (e) => {
+      if (this.shouldRetainAspectRatio()) {
+        this.imageHeight = Math.round(this.imageWidth / this.aspectRatio)
       }
     })
 
-    $('#img-height').on('change', (e) => {
-      let aspect = $('#aspect-ratio').val()
-      if ($('#aspect').prop('checked')) {
-        $('#img-width').val(Math.round($('#img-height').val() * aspect))
+    this.imageHeightElement.addEventListener('change', (e) => {
+      if (this.shouldRetainAspectRatio()) {
+        this.imageWidth = Math.round(this.imageHeight * this.aspectRatio)
       }
     })
+  }
+
+  shouldRetainAspectRatio () {
+    return $('#aspect').prop('checked')
   }
 }
 

--- a/source/renderer/dialog/pdf-preferences.js
+++ b/source/renderer/dialog/pdf-preferences.js
@@ -46,24 +46,24 @@ class PDFPreferences extends ZettlrDialog {
 
     // These scripts only are used to update the preview paragraph
     $('#lineheight').change((e) => {
-      $('p.pdf-preview').css('line-height', $(e.target).val() + '%')
+      $('p.pdf-preview').css('line-height', e.target.value + '%')
     })
     $('#fontsize').change((e) => {
       // 1pt is approx. 1.333333 px
-      $('p.pdf-preview').css('font-size', ($(e.target).val() * 1.3) + 'px')
+      $('p.pdf-preview').css('font-size', (e.target.value * 1.3) + 'px')
     })
     $('#mainfont').change((e) => {
-      $('p.pdf-preview').css('font-family', $(e.target).val())
+      $('p.pdf-preview').css('font-family', e.target.value)
     })
     $('#sansfont').change((e) => {
-      $('h1.pdf-preview').css('font-family', $(e.target).val())
+      $('h1.pdf-preview').css('font-family', e.target.value)
     })
 
     // Initial changing of CSS
-    $('p.pdf-preview').css('line-height', $('#lineheight').val() + '%')
-    $('p.pdf-preview').css('font-size', ($('#fontsize').val() * 1.3) + 'px')
-    $('p.pdf-preview').css('font-family', $('#mainfont').val())
-    $('h1.pdf-preview').css('font-family', $('#sansfont').val())
+    $('p.pdf-preview').css('line-height', document.getElementById('lineheight').value + '%')
+    $('p.pdf-preview').css('font-size', (document.getElementById('fontsize').value * 1.3) + 'px')
+    $('p.pdf-preview').css('font-family', document.getElementById('mainfont').value)
+    $('h1.pdf-preview').css('font-family', document.getElementById('sansfont').value)
   }
 
   proceed (data) {

--- a/source/renderer/dialog/project-properties.js
+++ b/source/renderer/dialog/project-properties.js
@@ -50,24 +50,24 @@ class ProjectDialog extends ZettlrDialog {
 
     // These scripts only are used to update the preview paragraph
     $('#lineheight').change((e) => {
-      $('p.pdf-preview').css('line-height', $(e.target).val() + '%')
+      $('p.pdf-preview').css('line-height', e.target.value + '%')
     })
     $('#fontsize').change((e) => {
       // 1pt is approx. 1.333333 px
-      $('p.pdf-preview').css('font-size', ($(e.target).val() * 1.3) + 'px')
+      $('p.pdf-preview').css('font-size', (e.target.value * 1.3) + 'px')
     })
     $('#mainfont').change((e) => {
-      $('p.pdf-preview').css('font-family', $(e.target).val())
+      $('p.pdf-preview').css('font-family', e.target.value)
     })
     $('#sansfont').change((e) => {
-      $('h1.pdf-preview').css('font-family', $(e.target).val())
+      $('h1.pdf-preview').css('font-family', e.target.value)
     })
 
     // Initial changing of CSS
-    $('p.pdf-preview').css('line-height', $('#lineheight').val() + '%')
-    $('p.pdf-preview').css('font-size', ($('#fontsize').val() * 1.3) + 'px')
-    $('p.pdf-preview').css('font-family', $('#mainfont').val())
-    $('h1.pdf-preview').css('font-family', $('#sansfont').val())
+    $('p.pdf-preview').css('line-height', document.getElementById('lineheight').value + '%')
+    $('p.pdf-preview').css('font-size', (document.getElementById('fontsize').value * 1.3) + 'px')
+    $('p.pdf-preview').css('font-family', document.getElementById('mainfont').value)
+    $('h1.pdf-preview').css('font-family', document.getElementById('sansfont').value)
   }
 
   proceed (data) {

--- a/source/renderer/dialog/stats.js
+++ b/source/renderer/dialog/stats.js
@@ -154,8 +154,9 @@ class StatsDialog extends ZettlrDialog {
     })
 
     // If the user wants to change the precision of the graph.
-    $('#data-mode').change((e) => {
-      this._mode = $(e.target).val()
+    const period = document.getElementById('data-mode')
+    period.addEventListener('change', () => {
+      this._mode = period.value
       this._prepareData()
       this._updateChart()
     })

--- a/source/renderer/dialog/tag-cloud.js
+++ b/source/renderer/dialog/tag-cloud.js
@@ -36,16 +36,16 @@ class TagCloud extends ZettlrDialog {
       this.close()
     })
 
-    $('#filter-tags').keyup((evt) => {
-      let res = $('#filter-tags').val()
+    const tagSearch = document.getElementById('filter-tags')
+    tagSearch.addEventListener('keyup', (evt) => {
+      const tag = tagSearch.value.toLowerCase()
       let remainingTags = []
-      $('.dialog .tag').each(function (index) {
-        res = res.toLowerCase()
-        if ($(this).text().toLowerCase().indexOf(res) < 0) {
-          $(this).hide()
+      document.querySelectorAll('.dialog .tag').forEach((element) => {
+        if (element.textContent.toLowerCase().includes(tag)) {
+          $(element).show()
+          remainingTags.push(element.dataset.tag)
         } else {
-          $(this).show()
-          remainingTags.push(this.dataset.tag)
+          $(element).hide()
         }
       })
 

--- a/source/renderer/dialog/zettlr-dialog.js
+++ b/source/renderer/dialog/zettlr-dialog.js
@@ -182,23 +182,21 @@ class ZettlrDialog extends EventEmitter {
     // Are there any open-file-buttons? If so enable the request for a file by
     // clicking them.
     this._modal.find('.request-file').on('click', (event) => {
-      let elem = $(event.target)
-      if (event.target.tagName.toLowerCase() === 'clr-icon') elem = $(event.target.parentElement)
+      const targetButton = event.target.tagName.toLowerCase() === 'clr-icon'
+        ? event.target.parentElement
+        : event.target
+      const { requestExt, requestName, requestTarget } = targetButton.dataset
 
-      let payload = {}
-      let extensions = elem.attr('data-request-ext')
-      if (extensions.indexOf(',') > 0) {
-        extensions = extensions.split(',')
-      } else {
-        extensions = [extensions]
+      const payload = {
+        // Only one filter possible for brevity reasons
+        filters: [{
+          'name': requestName,
+          'extensions': requestExt.includes(',')
+            ? requestExt.split(',')
+            : [requestExt]
+        }],
+        multiSel: false
       }
-
-      // Only one filter possible for brevity reasons
-      payload.filters = [{
-        'name': elem.attr('data-request-name'),
-        'extensions': extensions
-      }]
-      payload.multiSel = false
 
       // After all is done send an async callback message
       global.ipc.send('request-files', payload, (ret) => {
@@ -206,7 +204,7 @@ class ZettlrDialog extends EventEmitter {
         if (!ret || ret.length === 0 || ret[0] === '') return
         // Write the return value into the data-request-target of the clicked
         // button, because each button has a designated text field.
-        $(elem.attr('data-request-target')).val(ret[0])
+        document.querySelector(requestTarget).value = ret[0]
       })
     })
 

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -657,39 +657,39 @@ class ZettlrBody {
       this._currentPopup = null
     }) // .makePersistent()
 
+    const searchForElement = document.getElementById('searchWhat')
+    const searchFor = () => searchForElement.value || ''
+    const replaceWithElement = document.getElementById('replaceWhat')
+    const replaceWith = () => replaceWithElement.value
     // If a regular expression was restored to the find popup, make sure to set
     // the respective class.
-    if (regexRE.test($('#searchWhat').val())) {
-      $('#searchWhat').addClass('regexp')
-      $('#replaceWhat').addClass('regexp')
+    if (regexRE.test(searchFor())) {
+      searchForElement.classList.add('regexp')
+      replaceWithElement.classList.add('regexp')
     }
 
     // Select the search input for convenience
-    $('#searchWhat').select()
+    searchForElement.select()
 
     // Another convenience: Already highlight all occurrences within the
     // document, if there is content in the find field.
-    if ($('#searchWhat').val() !== '') {
-      global.editorSearch.highlightOccurrences($('#searchWhat').val())
+    if (searchFor()) {
+      global.editorSearch.highlightOccurrences(searchFor())
     }
 
-    $('#searchWhat').on('keyup', (e) => {
-      this._findPopup.searchVal = $('#searchWhat').val()
-      if (regexRE.test($('#searchWhat').val())) {
-        $('#searchWhat').addClass('regexp')
-        $('#replaceWhat').addClass('regexp')
-      } else {
-        $('#searchWhat').removeClass('regexp')
-        $('#replaceWhat').removeClass('regexp')
-      }
+    searchForElement.addEventListener('keyup', (e) => {
+      this._findPopup.searchVal = searchFor()
+      const isRegExp = regexRE.test(searchFor())
+      searchForElement.classList.toggle('regexp', isRegExp)
+      replaceWithElement.classList.toggle('regexp', isRegExp)
 
       if (e.which === 13) { // Enter
         $('#searchNext').click()
       }
     })
 
-    $('#replaceWhat').on('keyup', (e) => {
-      this._findPopup.replaceVal = $('#replaceWhat').val()
+    replaceWithElement.addEventListener('keyup', (e) => {
+      this._findPopup.replaceVal = replaceWith()
       if (e.which === 13) { // Return
         e.preventDefault()
         if (e.altKey) {
@@ -701,22 +701,20 @@ class ZettlrBody {
     })
 
     $('#searchNext').click((e) => {
-      let res = global.editorSearch.next($('#searchWhat').val())
+      let res = global.editorSearch.next(searchFor())
       // Indicate non-successful matches where nothing was found
-      if (!res) $('#searchWhat').addClass('not-found')
-      else $('#searchWhat').removeClass('not-found')
+      searchForElement.classList.toggle('not-found', !res)
     })
 
     $('#replaceNext').click((e) => {
       // If the user hasn't searched before, initate a search beforehand.
       if (!global.editorSearch.hasSearch()) $('#searchNext').click()
-      let res = global.editorSearch.replaceNext($('#replaceWhat').val())
-      if (!res) $('#searchWhat').addClass('not-found')
-      else $('#searchWhat').removeClass('not-found')
+      let res = global.editorSearch.replaceNext(replaceWith())
+      searchForElement.classList.toggle('not-found', !res)
     })
 
     $('#replaceAll').click((e) => {
-      global.editorSearch.replaceAll($('#searchWhat').val(), $('#replaceWhat').val())
+      global.editorSearch.replaceAll(searchFor(), replaceWith())
     })
   }
 

--- a/source/renderer/zettlr-pomodoro.js
+++ b/source/renderer/zettlr-pomodoro.js
@@ -202,10 +202,12 @@ class ZettlrPomodoro {
           if (this._sound.volume === 0) console.log('Starting muted!')
         }) // END callback
 
+        const volumeDisplay = document.getElementById('pomodoro-volume-level')
+        const volumeSlider = document.getElementById('pomodoro-volume-range')
+        const volumeLevel = () => volumeSlider.value
         // Play the sound immediately as a check for the user
-        $('#pomodoro-volume-range').on('change', (evt) => {
-          let level = $('#pomodoro-volume-range').val()
-          this._sound.volume = parseInt(level, 10) / 100
+        volumeSlider.addEventListener('change', (evt) => {
+          this._sound.volume = parseInt(volumeLevel(), 10) / 100
           this._sound.currentTime = 0
           this._sound.play()
         })
@@ -213,9 +215,8 @@ class ZettlrPomodoro {
         // Indicate the correct volume immediately.
         // "onChange" triggers when the mouse is released,
         // "onInput" as soon as the bar moves.
-        $('#pomodoro-volume-range').on('input', (evt) => {
-          let level = $('#pomodoro-volume-range').val()
-          $('#pomodoro-volume-level').text(level + ' %')
+        volumeSlider.addEventListener('input', (evt) => {
+          volumeDisplay.textContent = `${volumeLevel()} %`
         })
       } else {
         // Display information and a stop button


### PR DESCRIPTION
**Note**: The goal of this change is to remove the `.val()` usage, but removing every jQuery usage is not a goal in this change.

Added jquery/no-val eslint rule to prevent future usage.

Tested on: macOS 10.15.6
