### PR TITLE
HTML Export: Properly centre figures and figure captions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed the fold-gutter being too close to the text.
 - The editor link autocompletion now respects the setting to use headings level 1 instead of YAML frontmatter titles where possible.
 - The paste image dialog now also provides the original image size as a default value, so that you simply can use the arrow buttons on the field to adjust the image size.
+- HTML export should now centre both figures and figure captions.
 
 ## Under the Hood
 

--- a/source/main/assets/export.tpl.htm
+++ b/source/main/assets/export.tpl.htm
@@ -88,8 +88,7 @@
   }
 
   figure {
-    display: inline-block;
-    align-items: center;
+    text-align: center;
   }
 
   figure figcaption {


### PR DESCRIPTION
Remove some redundant CSS (inline block for figures) and instead use `text-align` in both figure and figcaption, providing a more consistent experience on HTML export, particularly where the figures aren't particularly wide.

Closes Zettlr/Zettlr#1233

Tested on: Gentoo Linux (current head of develop)
