### PR TITLE
Fix image rendering in Electron forge branch.

### DIFF
--- a/source/common/util/make-absolute-url.js
+++ b/source/common/util/make-absolute-url.js
@@ -7,7 +7,7 @@ const path = require('path')
 * @param {string} fragment The URL to be converted, either relative or absolute
 * @returns {string} The converted absolute URL with a cachefree-parameter.
 */
-module.exports = function makeAbsoluteCachefreeURL (base, fragment) {
+module.exports = function makeAbsoluteURL (base, fragment) {
   let urlObject
   try {
     // If it's already a correct URL, we are almost done
@@ -16,11 +16,13 @@ module.exports = function makeAbsoluteCachefreeURL (base, fragment) {
     // Obviously not a correct URL. In the context of this limited
     // application, we can be sure base is always a path to a Markdown file.
     let resolvedPath = path.resolve(base, fragment)
-    if (!protocolRE.test(resolvedPath)) resolvedPath = 'file://' + resolvedPath
+    if (!protocolRE.test(resolvedPath)) resolvedPath = 'safe-file://' + resolvedPath
     urlObject = new URL(resolvedPath)
   }
-
-  // Now make the thing cachefree
-  urlObject.searchParams.append('c', new Date().getTime())
+  if (urlObject.protocol === 'file:') {
+    // Windows C:/ etc. file paths are valid URLs,
+    // but use the file:// protocol that we don't handle.
+    return 'safe-' + urlObject.toString()
+  }
   return urlObject.toString()
 }

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-images.js
@@ -14,7 +14,7 @@
 
   // GENERAL PLUGIN VARIABLES
   const { getImageRE } = require('../../../common/regular-expressions')
-  const makeAbsoluteCachefreeURL = require('../../../common/util/make-absolute-cachefree-url')
+  const makeAbsoluteURL = require('../../../common/util/make-absolute-url')
 
   // Image detection regex
   var imageRE = getImageRE()
@@ -25,28 +25,6 @@
 
   // This variable holds a base64 encoded placeholder image.
   var img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5PURAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggeDC8lR+xuCgAABkNJREFUeNrt3V2IXGcdx/Hfo2va7oIoiq3mwoJgtLfdFUVj2UDUiiBooWJ9oZRYIVdqz8aAFBHZlPMEYi5WqkGK70aKbyi1iC5VsBeOLzeNpN7Yi4reKglpCHu8yC7IsrvObGYnM7Ofz11yzmTO/p/lm3N2zs6U5eXlLgD70MuMABBAAAEEEEAAAQSYRjM7bLuU5EKSYkzAhOqS3JVkbtAAXjh58uSC+QGT7NSpU39IsjDoJbAzP2AabNsyPwME9i0BBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAgJtuxggm3+rq6qFer2cQo3WlaZoXjEEAucl6vd5SkodMYqT+agQugRkPLxnByF0yAgEEEEAAAQQQQAABBBBAAAEEGANuhN4//pPkVNd1/zaK7ZVSXpHkZJLXmYYAMj0uHz9+/NbZ2dllo9hZrfV5AXQJzJRZWVn5qin0dyJoBAIIIIAAAggggACTz6vA/F+11jcm+UKSTyY58D+bnkzy5aZp/mJKOANk6rRteyzJ35Ic2xS/JLkvyZ9qrd82KQSQqYtfKeXcFuHb/D308bZtv2tiCCDTctl7sJTylX73L6U8UGu9x+QQQKbBI0nmBnzM14wNAWQafGYXj3nL6urqIaNDANmXer3eO00BAWRiXb58+UumgACyL83Ozj6628eura09PcxjqbUu1Fr/ZVUQQEbp/C4e848TJ068OOTj+HmS291riAAySo8lWRvkAV3XfW7IZ3+/SnL7+h8fqLX6+SICyN5rmubPSb43wEMuLi0tfX+I8ftwkqObvld/amUQQEYVwY91XddPBC82TTO021/WX4T5zhabXltr/bGVQQAZiaWlpY8muSfJc1tsvtp13f3DjF+SrKysHEly2zabP9i27dusDMPg3WDo50zwmfXL0oNJ3ptcf7V3/QWP88N8rlrrg0me2Ok/7VLK01YFAWTUIXxxL//9Wut8kl4fu7661rraNM2iVcElMNPiZ0m6Pvc9XGs9bGQIIBOv1vpYkjek/09km0nya5NDABnXqD1Va32ij/2OJvn8Lp7iwPq9giCAjFX8ziW5N8mDtdZfbrff+i0vN/JbHkfbtn2PiSOAjEv8vp7rb6G/4X211t9ste/KysrBJHfcyPOVUtwgjQAyNvH71BabjtRaf7dp3y8meWgIT3vbdoEFAWQk2rZ9ZJv4bTi8EcFa65uTfHaIT3+k1vohq8Ag3AfIsM78Hi6l9POW+IdrrU8l+UaSVw75MH5oJXAGyMjjl8E+D+TeJHtxD99MrfVZK4IAMqr4HUvy+Bgd0jtcCiOA7Lm2bd+f5Fz6v3l5VH509erVb1ohBJC9OvN7dynlJ+N6fGfPnn2TVUIA2ZP4JfltkgNjfJjvqrV+xGohgAzzsvfuJJPy62c/uHbt2jNWDQFkGPG7s5Ty+yS3TMoxnzlzZtbKIYDc6GXvnaWUP05S/NYttG17vxVEANl1/JJcTPKaSTz+Usr5tm3vsJIIIANZW1v7e5JnJ/DMb3MEf2E1EUAGcvr06ZeSvH4KvpS7a62fsKIIIP1e+j5fSjk0RV/St2qtb7WybPBmCGwXv8eTvD39fUjRJHnU6iKA7Khpmk9P6Zc2b3VxCQwIoBEAAggggAACCCCAAAIIIIBMoK5pmn8aQ1/WjGB/cCP0/vGqWuuTSa6MvLxdl1z/3JBu4+9KKeM6p5cn+YBvFwFkutya5L6b8cRjHDtcAgMIIIAAAggggAACCCCAAAIIIOPgFiMYuTkjmHxuhJ4C8/Pzba/Xa01ipK4kecEYBJCbbHFx8eLi4qJBgEtgAAEEEEAAAQQQQAABBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBNAJAAAEEEEAAAQQQQAABBBBAAAEEEEAAAaYggJ3xAFNg25aV5eXl7TZeSnIhSTE/YILjd1eSua02zuzwwLkkC+YH7MdLYAABBBBAAAEEEECAifVfoVk7QcTH/rgAAAAASUVORK5CYII='
-
-  /**
-   * Creates a definite absolute URL if the information suffices.
-   * @param {string} base The base path to be used
-   * @param {string} fragment The URL to be converted, either relative or absolute
-   * @returns {string} The converted absolute URL.
-   */
-  function makeAbsoluteURL (base, fragment) {
-    let urlObject
-    try {
-      // If it's already a correct URL, we are almost done
-      urlObject = new URL(fragment)
-    } catch (e) {
-      // Obviously not a correct URL. In the context of this limited
-      // application, we can be sure base is always a path to a Markdown file.
-      let resolvedPath = path.resolve(base, fragment)
-      if (!protocolRE.test(resolvedPath)) resolvedPath = 'safe-file://' + resolvedPath
-      urlObject = new URL(resolvedPath)
-    }
-
-    return urlObject.toString()
-  }
 
   /**
    * Defines the CodeMirror command to render all found markdown images.
@@ -170,8 +148,7 @@
         if (/data:[a-zA-Z0-9/;=]+(?:;base64){0,1},.+/.test(url)) {
           img.src = url
         } else {
-          // img.src = makeAbsoluteURL(cm.getOption('markdownImageBasePath'), url)
-          img.src = makeAbsoluteCachefreeURL(cm.getOption('markdownImageBasePath'), url)
+          img.src = makeAbsoluteURL(cm.getOption('markdownImageBasePath'), url)
         }
 
         // Push the textMarker into the array

--- a/source/renderer/assets/codemirror/zettlr-plugin-render-links.js
+++ b/source/renderer/assets/codemirror/zettlr-plugin-render-links.js
@@ -12,7 +12,7 @@
 })(function (CodeMirror) {
   'use strict'
 
-  const makeAbsoluteCachefreeURL = require('../../../common/util/make-absolute-cachefree-url')
+  const makeAbsoluteURL = require('../../../common/util/make-absolute-url')
 
   // This regular expression matches three different kinds of URLs:
   // 1. Linked images in the format [![Alt text](image/path.png)](www.link-target.tld)
@@ -164,7 +164,7 @@
         if (isLinkedImage) {
           let img = document.createElement('img')
           img.title = `${linkImageCaption} (${linkImageTarget})`
-          img.src = makeAbsoluteCachefreeURL(cm.getOption('markdownImageBasePath'), linkImagePath)
+          img.src = makeAbsoluteURL(cm.getOption('markdownImageBasePath'), linkImagePath)
           img.style.cursor = 'pointer' // Nicer cursor
           // Copied over from the other plugin
           let width = (cm.getOption('imagePreviewWidth')) ? cm.getOption('imagePreviewWidth') + '%' : '100%'


### PR DESCRIPTION
#  Description
Fix image rendering in electron forge branch.
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
# Changes
Replaced `makeAbsoluteCachefreeURL` with `makeAbsoluteURL`
makeAbsoluteURL now returns all 'file:' protocol URIs as 'safe-file:', which we have a handler for.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information
Fixes #1228
<!-- Please provide any testing system -->
Tested on: 
Gentoo Linux.