### PR TITLE
Adds a 'close all' context menu to tab header. Fixes #1226

### DIFF
--- a/source/renderer/assets/context/tabs.json
+++ b/source/renderer/assets/context/tabs.json
@@ -1,0 +1,21 @@
+[
+  {
+    "label": "menu.rename_file",
+    "command": "file-rename"
+  },
+  {
+    "label": "menu.delete_file",
+    "command": "file-delete"
+  },
+  {
+    "label": "menu.duplicate_file",
+    "command": "file-duplicate"
+  },
+  {
+    "type": "separator"
+  },
+  {
+    "label": "menu.close_all_tabs",
+    "command": "file-close-all"
+  }
+]

--- a/source/renderer/util/editor-tabs.js
+++ b/source/renderer/util/editor-tabs.js
@@ -131,10 +131,12 @@ module.exports = class EditorTabs {
     // Now make sure that the active tab is visible and scroll if necessary.
     let tabbarWidth = this._div.offsetWidth
     let activeElem = this._div.getElementsByClassName('active')[0]
-    if (activeElem.offsetLeft + activeElem.offsetWidth > tabbarWidth) {
-      this._div.scrollLeft += activeElem.offsetLeft + activeElem.offsetWidth - tabbarWidth
-    } else if (activeElem.offsetLeft < this._div.scrollLeft) {
-      this._div.scrollLeft = activeElem.offsetLeft
+    if (typeof activeElem !== 'undefined') {
+      if (activeElem.offsetLeft + activeElem.offsetWidth > tabbarWidth) {
+        this._div.scrollLeft += activeElem.offsetLeft + activeElem.offsetWidth - tabbarWidth
+      } else if (activeElem.offsetLeft < this._div.scrollLeft) {
+        this._div.scrollLeft = activeElem.offsetLeft
+      }
     }
 
     // After synchronising, enable the tippy

--- a/source/renderer/zettlr-context.js
+++ b/source/renderer/zettlr-context.js
@@ -24,7 +24,8 @@ const TEMPLATES = {
   'directory': require('./assets/context/directory.json'),
   'editor': require('./assets/context/editor.json'),
   'file': require('./assets/context/file.json'),
-  'text': require('./assets/context/text.json')
+  'text': require('./assets/context/text.json'),
+  'tabs': require('./assets/context/tabs.json')
 }
 
 /**
@@ -256,7 +257,7 @@ class ZettlrCon {
       // 2. The file name
       // 3. The document itself
       if (elem.hasClass('filename') || elem.hasClass('close')) elem = elem.parent()
-      template = TEMPLATES.file
+      template = TEMPLATES.tabs
       shouldSelectWordUnderCursor = false
       hash = elem.attr('data-hash')
       if (elem.attr('data-id')) attr.push({ 'data-id': elem.attr('data-id') })

--- a/source/renderer/zettlr-editor.js
+++ b/source/renderer/zettlr-editor.js
@@ -779,6 +779,15 @@ class ZettlrEditor {
   }
 
   /**
+   * Closes all open files
+   */
+  closeAll () {
+    for (let file of this._openFiles) {
+      global.ipc.send('file-close', { 'hash': file.fileObject.hash })
+    }
+  }
+
+  /**
    * Attempts to close an open tab, and returns true if it did.
    * @returns {boolean} True, if a tab has been closed, otherwise false.
    */

--- a/source/renderer/zettlr-renderer.js
+++ b/source/renderer/zettlr-renderer.js
@@ -560,6 +560,13 @@ class ZettlrRenderer {
   }
 
   /**
+   * Closes all open files
+   */
+  closeAllFiles () {
+    this._editor.closeAll()
+  }
+
+  /**
    * Request the renaming of a file
    * @param  {ZettlrFile} f The file, whose name should be changed
    */

--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -393,6 +393,10 @@ class ZettlrRendererIPC {
         this._app.closeFile(cnt.hash)
         break
 
+      case 'file-close-all':
+        this._app.closeAllFiles()
+        break
+
       case 'file-save':
         this._app.getEditor().saveFiles(true) // true means only save active file
         break


### PR DESCRIPTION
## Description

This is my first PR. Please be gentle.
Adds a new menu option "Close all" which closes all open tab. Fixes #1226 


## Changes
Added a new menu context json in `renderer/assets/context/` directory specifically for context menu for tab header. Earlier the context menu was file.json which is shared with the context menu for the file/directory tree. I feel like adding a new context json is more cleaner that introducing a new scope and making it work with exiting json files. In the future this will enable us to add tab specific menu options like Close all to right, Close others etc

## Additional information
Fixes #1226

All tests passed.
Tested on: Arch Linux
