### PR TITLE
Disable disk cache for http requests.

### DIFF
--- a/source/main.ts
+++ b/source/main.ts
@@ -24,6 +24,9 @@ import extractFilesFromArgv from './common/util/extract-files-from-argv'
 // Developer tools
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 
+// Disable the disk cache for http requests.
+app.commandLine.appendSwitch('disable-http-cache')
+
 global.preBootLog = [{
   'level': 2, // Info
   // eslint-disable-next-line no-irregular-whitespace


### PR DESCRIPTION
This globally disables the on-disk cache for http requests within electron.

Conveniently, https images still work on the develop branch. :D 

This definitely changes the caching behavour of http/https images; large images now visibly take time to be received and rendered by Zettlr once you force the action.

Tested on: Gentoo Linux
