### PR TITLE
Add %y and %X placeholders

### DIFF
--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -422,12 +422,14 @@
             {{i18n "dialog.preferences.zkn.intro"}}
             <ul>
               <li><strong>%Y</strong>: {{i18n "dialog.preferences.zkn.var_year"}}</li>
+              <li><strong>%y</strong>: {{i18n "dialog.preferences.zkn.var_year_two"}}</li>
               <li><strong>%M</strong>: {{i18n "dialog.preferences.zkn.var_month"}}</li>
               <li><strong>%D</strong>: {{i18n "dialog.preferences.zkn.var_day"}}</li>
               <li><strong>%W</strong>: {{i18n "dialog.preferences.zkn.var_week_number"}}</li>
               <li><strong>%h</strong>: {{i18n "dialog.preferences.zkn.var_hour"}}</li>
               <li><strong>%m</strong>: {{i18n "dialog.preferences.zkn.var_minute"}}</li>
               <li><strong>%s</strong>: {{i18n "dialog.preferences.zkn.var_second"}}</li>
+              <li><strong>%X</strong>: {{i18n "dialog.preferences.zkn.var_unix_epoch"}}</li>
               <li><strong>%uuid4</strong>: Universally Unique Identifier (UUID) v4</li>
             </ul>
           </p>
@@ -848,7 +850,7 @@
             {{i18n "dialog.preferences.filename_generator"}}
           </label>
           <input type="text" id="filename-generator" name="newFileNamePattern" placeholder="%id.md" value="{{newFileNamePattern}}">
-          <span class="info">Variables: %id, %Y, %M, %D, %W, %h, %m, %s, %uuid4</span>
+          <span class="info">Variables: %id, %Y, %y, %M, %D, %W, %h, %m, %s, %X, %uuid4</span>
 
           <div class="cb-group">
             <label class="cb-toggle">

--- a/source/common/util/replace-string-variables.js
+++ b/source/common/util/replace-string-variables.js
@@ -25,14 +25,15 @@ module.exports = function (string) {
   let d = moment()
 
   // Now generate the id by replacing all placeholders in the pattern
-  string = string.replace(/%Y/g, d.format('YYYY'))
-  string = string.replace(/%M/g, d.format('MM'))
-  string = string.replace(/%D/g, d.format('DD'))
-  string = string.replace(/%W/g, d.format('WW'))
-  string = string.replace(/%h/g, d.format('HH'))
-  string = string.replace(/%m/g, d.format('mm'))
-  string = string.replace(/%s/g, d.format('ss'))
-  string = string.replace(/%uuid4/g, uuid4())
-
   return string
+    .replace(/%Y/g, d.format('YYYY'))
+    .replace(/%y/g, d.format('YY'))
+    .replace(/%M/g, d.format('MM'))
+    .replace(/%D/g, d.format('DD'))
+    .replace(/%W/g, d.format('WW'))
+    .replace(/%h/g, d.format('HH'))
+    .replace(/%m/g, d.format('mm'))
+    .replace(/%s/g, d.format('ss'))
+    .replace(/%X/g, d.format('X'))
+    .replace(/%uuid4/g, uuid4())
 }

--- a/source/common/validation.json
+++ b/source/common/validation.json
@@ -15,7 +15,7 @@
    "zkn.idRE": "required|string|default:",
    "zkn.linkStart": "required|string|default:",
    "zkn.linkEnd": "required|string|default:",
-   "zkn.idGen": "required|string|min:3|default:",
+   "zkn.idGen": "required|string|min:2|default:",
    "zkn.autoCreateLinkedFiles": "required|boolean|default:false",
    "attachmentExtensions": "optional|array",
    "pandoc": "optional|string|min:6|default:",


### PR DESCRIPTION
## Description

Add `%y` and `%X` placeholders for generating Zettelkasten ID and names for new files.

- `%y` is the year with 2 digits
- `%X` is the Unix epoch/timestamp (10 digits)

To allow an ID with only Unix epoch, had to lower the minimum string length requirement of zkn.idGen to 2 characters (for "%X").

As an aside, I don't know how much you want to limit or allow when it comes to generating Zettelkasten IDs. Of course, the default 14 digit timestamp is not as likely to be confused with something else when parsing the full text of notes. But, using two digits for years will "save" two unnecessary characters, and the Unix epoch can represent the same point in time with only 10 characters.

## Additional Information

I have not created language strings for the preferences, as I'm not sure how to go about doing this. Please advice.

<!-- Please provide any testing system -->
Tested on: Windows 10
