### PR TITLE
Require Yarn in README instead of just recommend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ If you have downloaded Zettlr, [head over to our website](https://docs.zettlr.co
 ## Contributing
 
 Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have:
+
 1. A [NodeJS](https://nodejs.org/)-stack on your computer installed. Make sure it is Node 12+ (`lts/erbium`). To test what version you have, try `node -v`.
-2. [Yarn](https://yarnpkg.com/en/) installed, which is the recommended package manager for the project. You can install this globally using `npm install -g yarn`.
+2. [Yarn](https://yarnpkg.com/en/) installed, the _required_ package manager for the project. You can install this globally using `npm install -g yarn`.
 
 Then, simply clone the repository and install the dependencies on your local computer:
 
@@ -89,7 +90,7 @@ The `install`-scripts will automatically precompile all assets for the first tim
 
 ### Development Commands
 
-This section lists all available commands that you can use during application development. These are defined within the `package.json` and can be run from the command line by prefixing them either with `npm run` or `yarn`, depending on which package manager you use. Run them from within the base directory of the repository.
+This section lists all available commands that you can use during application development. These are defined within the `package.json` and can be run from the command line by prefixing them with `yarn`. Run them from within the base directory of the repository.
 
 #### `build:quick`
 


### PR DESCRIPTION
The `node_modules` built by `npm` and `yarn` differ due to there only
being a lock file for Yarn. The easier-to-maintain solution is to
specifically require Yarn for the project.

## Description

The README [_recommends_ `yarn`, but infers `npm` is _not_ unsupported](https://github.com/Zettlr/Zettlr/blame/7d6d049c8ec1259d81402b944d5627e5be579e72/README.md#L74). There is a discrepancy between the `node_modules` created by `yarn` and `npm` though. The current `develop` branch build works with `yarn`, but is failing on https://github.com/Zettlr/Zettlr/commit/7d6d049c8ec1259d81402b944d5627e5be579e72 with `npm`. I was only using `npm` due to muscle memory from other projects, so it doesn't bother me to switch.

<!-- Below describe the steps necessary to reproduce the malicious behaviour -->
## Reproducing

```bash
$ node --version
v12.18.4
$ npm --version
6.14.8
$ yarn --version
1.21.1
$ rm -rf node_modules/
$ npm i

<snip install log noise>
added 1539 packages from 1609 contributors and audited 1546 packages in 16.818s
found 0 vulnerabilities

$ npm run start
> zettlr@1.7.5 start /home/USER/development/Zettlr
> electron-forge start

✔ Checking your system
✔ Locating Application
✔ Preparing native dependencies
✔ Compiling Main Process Code
✔ Launch Dev Servers
✔ Compiling Preload Scripts
✔ Launching Application

Webpack Output Available: http://localhost:9000

App threw an error during load
Error: Cannot find module 'readable-stream/passthrough'
    at webpackMissingModule (/home/USER/development/Zettlr/.webpack/main/index.js:63119:83)
    at Object../node_modules/lazystream/lib/lazystream.js (/home/USER/development/Zettlr/.webpack/main/index.js:63119:185)
    at __webpack_require__ (/home/USER/development/Zettlr/.webpack/main/index.js:21:30)
    at Object../node_modules/archiver-utils/index.js (/home/USER/development/Zettlr/.webpack/main/index.js:3934:18)
    at __webpack_require__ (/home/USER/development/Zettlr/.webpack/main/index.js:21:30)
    at Object../node_modules/archiver/lib/core.js (/home/USER/development/Zettlr/.webpack/main/index.js:4182:12)
    at __webpack_require__ (/home/USER/development/Zettlr/.webpack/main/index.js:21:30)
    at Object../node_modules/archiver/index.js (/home/USER/development/Zettlr/.webpack/main/index.js:4098:16)
    at __webpack_require__ (/home/USER/development/Zettlr/.webpack/main/index.js:21:30)
    at Object../source/main/modules/export/make-textbundle.js (/home/USER/development/Zettlr/.webpack/main/index.js:112603:18)
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Cannot find module 'readable-stream/passthrough'
<snip error log duplication>
webpack built 442c0299cc71434efb14 in 16709ms
No issues found.
^C # Nothing happens, Ctrl-C pressed here.

$ rm -rf node_modules/
$ yarn install
yarn install v1.21.1
[1/4] Resolving packages...
[2/4] Fetching packages...
<snip fsevents complaints on linux>
[3/4] Linking dependencies...
<snip dep peer warnings>
[4/4] Building fresh packages...
$ electron-builder install-app-deps
  • electron-builder  version=22.8.0
  • loaded configuration  file=package.json ("build" field)
Done in 9.97s.

$ yarn run start
yarn run v1.21.1
$ electron-forge start
✔ Checking your system
✔ Locating Application
✔ Preparing native dependencies
✔ Compiling Main Process Code
✔ Launch Dev Servers
✔ Compiling Preload Scripts
✔ Launching Application

Webpack Output Available: http://localhost:9000

158 ms: Loaded directory /home/USER/zk
Starting chokidar ...
webpack built 1050f682807aab3e51cd in 17587ms
No issues found.

# Zettlr loads and works fine.
```

<!-- Below, please describe what Zettlr should do instead -->
## Expected behaviour

`npm` should work or be specifically disallowed.
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Update README to require `yarn`.

<!-- Please provide any testing system -->
Tested on: Ubuntu 20.04 LTS / Mint 20