### PR TITLE
Upgrade eslint-plugin-jquery to eslint-plugin-no-jquery 2.5.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
         "node": true
     },
     "plugins": [
-        "jquery",
+        "no-jquery",
         "@typescript-eslint"
     ],
     "extends": [
@@ -76,25 +76,25 @@
         }],
         
         // Disallow jquery
-        "jquery/no-ajax": 2,
-        "jquery/no-ajax-events": 2,
-        "jquery/no-animate": 2,
-        "jquery/no-bind": 2,
-        "jquery/no-fade": 2,
-        "jquery/no-load": 2,
-        "jquery/no-param": 2,
-        "jquery/no-serialize": 2,
-        "jquery/no-size": 2,
-        "jquery/no-sizzle": 2,
-        "jquery/no-slide": 2,
-        "jquery/no-submit": 2,
-        "jquery/no-text": 2,
-        "jquery/no-toggle": 2,
-        "jquery/no-trigger": 2,
-        "jquery/no-trim": 2,
-        "jquery/no-val": 2,
-        "jquery/no-when": 2,
-        "jquery/no-wrap": 2,
+        "no-jquery/no-ajax": 2,
+        "no-jquery/no-ajax-events": 2,
+        "no-jquery/no-animate": 2,
+        "no-jquery/no-bind": 2,
+        "no-jquery/no-fade": 2,
+        "no-jquery/no-load": 2,
+        "no-jquery/no-param": 2,
+        "no-jquery/no-serialize": 2,
+        "no-jquery/no-size": 2,
+        "no-jquery/no-sizzle": 2,
+        "no-jquery/no-slide": 2,
+        "no-jquery/no-submit": 2,
+        "no-jquery/no-text": 2,
+        "no-jquery/no-toggle": 2,
+        "no-jquery/no-trigger": 2,
+        "no-jquery/no-trim": 2,
+        "no-jquery/no-val": 2,
+        "no-jquery/no-when": 2,
+        "no-jquery/no-wrap": 2,
 
         // Disable a few typescript rules as we are not yet there to easily implement them
         "@typescript-eslint/no-floating-promises": [ "warn" ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
     ],
     "extends": [
         "standard-with-typescript",
-        "plugin:vue/vue3-recommended"
+        "plugin:vue/vue3-recommended",
+        "plugin:no-jquery/deprecated-3.5"
     ],
     "globals": {
         "Atomics": "readonly",
@@ -79,19 +80,14 @@
         "no-jquery/no-ajax": 2,
         "no-jquery/no-ajax-events": 2,
         "no-jquery/no-animate": 2,
-        "no-jquery/no-bind": 2,
         "no-jquery/no-fade": 2,
         "no-jquery/no-load": 2,
         "no-jquery/no-param": 2,
         "no-jquery/no-serialize": 2,
-        "no-jquery/no-size": 2,
-        "no-jquery/no-sizzle": 2,
         "no-jquery/no-slide": 2,
         "no-jquery/no-submit": 2,
         "no-jquery/no-text": 2,
         "no-jquery/no-toggle": 2,
-        "no-jquery/no-trigger": 2,
-        "no-jquery/no-trim": 2,
         "no-jquery/no-val": 2,
         "no-jquery/no-when": 2,
         "no-jquery/no-wrap": 2,

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "eslint-config-standard-with-typescript": "^19.0.1",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jquery": "^1.5.1",
+    "eslint-plugin-no-jquery": "^2.5.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",

--- a/source/print/zettlr-print-window.js
+++ b/source/print/zettlr-print-window.js
@@ -78,9 +78,9 @@ class ZettlrPrintWindow {
 
   _act () {
     // Activate the window controls.
-    $('.windows-window-controls .close').click((e) => { ipc.send('message', { 'command': 'win-close', content: {} }) })
-    $('.windows-window-controls .resize').click((e) => { ipc.send('message', { 'command': 'win-maximise', content: {} }) })
-    $('.windows-window-controls .minimise').click((e) => { ipc.send('message', { 'command': 'win-minimise', content: {} }) })
+    $('.windows-window-controls .close').on('click', (e) => { ipc.send('message', { 'command': 'win-close', content: {} }) })
+    $('.windows-window-controls .resize').on('click', (e) => { ipc.send('message', { 'command': 'win-maximise', content: {} }) })
+    $('.windows-window-controls .minimise').on('click', (e) => { ipc.send('message', { 'command': 'win-minimise', content: {} }) })
 
     window.addEventListener('resize', (e) => {
       this._reposition()
@@ -93,7 +93,7 @@ class ZettlrPrintWindow {
     })
 
     // Issue a print command for the frame.
-    $('#init-print').click((e) => {
+    $('#init-print').on('click', (e) => {
       window.frames[0].print()
     })
   }

--- a/source/quicklook/zettlr-quicklook-window.js
+++ b/source/quicklook/zettlr-quicklook-window.js
@@ -101,9 +101,9 @@ class ZettlrQuicklookWindow {
 
   _act () {
     // Activate the window controls.
-    $('.windows-window-controls .close').click((e) => { ipc.send('message', { 'command': 'win-close', content: {} }) })
-    $('.windows-window-controls .resize').click((e) => { ipc.send('message', { 'command': 'win-maximise', content: {} }) })
-    $('.windows-window-controls .minimise').click((e) => { ipc.send('message', { 'command': 'win-minimise', content: {} }) })
+    $('.windows-window-controls .close').on('click', (e) => { ipc.send('message', { 'command': 'win-close', content: {} }) })
+    $('.windows-window-controls .resize').on('click', (e) => { ipc.send('message', { 'command': 'win-maximise', content: {} }) })
+    $('.windows-window-controls .minimise').on('click', (e) => { ipc.send('message', { 'command': 'win-minimise', content: {} }) })
   }
 }
 

--- a/source/renderer/dialog/custom-css.js
+++ b/source/renderer/dialog/custom-css.js
@@ -47,7 +47,7 @@ class CustomCSS extends ZettlrDialog {
     this._cm.refresh()
 
     // Activate the sender
-    $('div.dialog #save').click((e) => {
+    $('div.dialog #save').on('click', (e) => {
       global.ipc.send('set-custom-css', this._cm.getValue(), (ret) => {
         // TODO error handling
         if (ret) {

--- a/source/renderer/dialog/pdf-preferences.js
+++ b/source/renderer/dialog/pdf-preferences.js
@@ -46,17 +46,17 @@ class PDFPreferences extends ZettlrDialog {
     })
 
     // These scripts only are used to update the preview paragraph
-    $('#lineheight').change((e) => {
+    $('#lineheight').on('change', (e) => {
       $('p.pdf-preview').css('line-height', e.target.value + '%')
     })
-    $('#fontsize').change((e) => {
+    $('#fontsize').on('change', (e) => {
       // 1pt is approx. 1.333333 px
       $('p.pdf-preview').css('font-size', (e.target.value * 1.3) + 'px')
     })
-    $('#mainfont').change((e) => {
+    $('#mainfont').on('change', (e) => {
       $('p.pdf-preview').css('font-family', e.target.value)
     })
-    $('#sansfont').change((e) => {
+    $('#sansfont').on('change', (e) => {
       $('h1.pdf-preview').css('font-family', e.target.value)
     })
 

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -229,7 +229,7 @@ class PreferencesDialog extends ZettlrDialog {
     })
 
     // BEGIN functionality for the AutoCorrect options
-    $('#add-autocorrect-key').click(function (e) {
+    $('#add-autocorrect-key').on('click', function (e) {
       e.stopPropagation()
       e.preventDefault()
       let keyCol = $('<td>').html('<div class="input-button-group"><input type="text" name="autoCorrectKeys[]"></div>')
@@ -243,7 +243,7 @@ class PreferencesDialog extends ZettlrDialog {
       $(e.target).parent().parent().parent().detach() // Button -> div -> td -> tr
     })
 
-    $('.mq-select').click(function (e) {
+    $('.mq-select').on('click', function (e) {
       e.preventDefault()
       let primary = e.target.dataset.primary
       let secondary = e.target.dataset.secondary

--- a/source/renderer/dialog/stats.js
+++ b/source/renderer/dialog/stats.js
@@ -138,7 +138,7 @@ class StatsDialog extends ZettlrDialog {
     this._updateChart()
 
     // Now we need to activate the previous/next buttons
-    $('#prev-sheet').click((e) => {
+    $('#prev-sheet').on('click', (e) => {
       if (this._currentSheet > 0) {
         this._currentSheet--
         this._updateChart()
@@ -146,7 +146,7 @@ class StatsDialog extends ZettlrDialog {
     })
 
     // Next button
-    $('#next-sheet').click((e) => {
+    $('#next-sheet').on('click', (e) => {
       if (this._currentSheet < this._backgroundData.length - 1) {
         this._currentSheet++
         this._updateChart()
@@ -162,7 +162,7 @@ class StatsDialog extends ZettlrDialog {
     })
 
     // If the user wants to compare with the previous time frame.
-    $('#data-compare').change((e) => {
+    $('#data-compare').on('change', (e) => {
       this._compare = !this._compare
       this._updateChart()
     })

--- a/source/renderer/dialog/tag-cloud.js
+++ b/source/renderer/dialog/tag-cloud.js
@@ -29,7 +29,7 @@ class TagCloud extends ZettlrDialog {
 
   postAct () {
     // Activate searches on click on the spans
-    $('span.tag').click((evt) => {
+    $('span.tag').on('click', (evt) => {
       let elem = $(evt.target)
       // TODO: Don't access the renderer element via window
       window.renderer.autoSearch(`"${elem.attr('data-tag')}"`)

--- a/source/renderer/dialog/tags-preferences.js
+++ b/source/renderer/dialog/tags-preferences.js
@@ -33,7 +33,7 @@ class TagsPreferences extends ZettlrDialog {
       this.proceed(form.serializeArray())
     })
 
-    $('#addTagLine').click((e) => {
+    $('#addTagLine').on('click', (e) => {
       $('#prefs-taglist').append(
         `<div>
             <input type="text" name="prefs-tags-name" placeholder="${trans('dialog.tags.name_desc')}">

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -132,13 +132,13 @@ class ZettlrBody {
     global.notifyError = (msg) => { this.notifyError(msg) }
 
     // Afterwards, activate the event listeners of the window controls
-    $('.windows-window-controls .minimise').click((e) => {
+    $('.windows-window-controls .minimise').on('click', (e) => {
       global.ipc.send('win-minimise')
     })
-    $('.windows-window-controls .resize').click((e) => {
+    $('.windows-window-controls .resize').on('click', (e) => {
       global.ipc.send('win-maximise')
     })
-    $('.windows-window-controls .close').click((e) => {
+    $('.windows-window-controls .close').on('click', (e) => {
       global.ipc.send('win-close')
     })
   }
@@ -459,7 +459,7 @@ class ZettlrBody {
     // Show the appropriate popup
     global.popupProvider.show('export', document.querySelector('.button.share'))
 
-    $('.btn-share').click((e) => {
+    $('.btn-share').on('click', (e) => {
       // The revealjs-button doesn't trigger an export, but the visibility
       // of the themes selection
       if ($(e.target).hasClass('revealjs')) {
@@ -637,7 +637,7 @@ class ZettlrBody {
       replaceWithElement.classList.toggle('regexp', isRegExp)
 
       if (e.which === 13) { // Enter
-        $('#searchNext').click()
+        $('#searchNext').trigger('click')
       }
     })
 
@@ -646,27 +646,27 @@ class ZettlrBody {
       if (e.which === 13) { // Return
         e.preventDefault()
         if (e.altKey) {
-          $('#replaceAll').click()
+          $('#replaceAll').trigger('click')
         } else {
-          $('#replaceNext').click()
+          $('#replaceNext').trigger('click')
         }
       }
     })
 
-    $('#searchNext').click((e) => {
+    $('#searchNext').on('click', (e) => {
       let res = global.editorSearch.next(searchFor())
       // Indicate non-successful matches where nothing was found
       searchForElement.classList.toggle('not-found', !res)
     })
 
-    $('#replaceNext').click((e) => {
+    $('#replaceNext').on('click', (e) => {
       // If the user hasn't searched before, initate a search beforehand.
-      if (!global.editorSearch.hasSearch()) $('#searchNext').click()
+      if (!global.editorSearch.hasSearch()) $('#searchNext').trigger('click')
       let res = global.editorSearch.replaceNext(replaceWith())
       searchForElement.classList.toggle('not-found', !res)
     })
 
-    $('#replaceAll').click((e) => {
+    $('#replaceAll').on('click', (e) => {
       global.editorSearch.replaceAll(searchFor(), replaceWith())
     })
   }
@@ -709,7 +709,7 @@ class ZettlrBody {
       headerFormattingElement.className = e.target.className
     })
 
-    $('.formatting a').click((e) => {
+    $('.formatting a').on('click', (e) => {
       if (e.target.className === 'markdownInsertTable') {
         e.stopPropagation()
         e.preventDefault()
@@ -726,10 +726,10 @@ class ZettlrBody {
     // Show the popup
     global.popupProvider.show('table', document.querySelector('.button.formatting'))
 
-    $('.table-generator').mouseleave(e => { $('.table-generator .cell').removeClass('active') })
+    $('.table-generator').on('mouseleave', e => { $('.table-generator .cell').removeClass('active') })
 
     // For the nice little colouring effect
-    $('.table-generator .cell').hover(e => {
+    $('.table-generator .cell').on('hover', e => {
       let rows = e.target.dataset.rows
       let cols = e.target.dataset.cols
       $('.table-generator .cell').removeClass('active')
@@ -740,7 +740,7 @@ class ZettlrBody {
       }
     })
 
-    $('.table-generator .cell').click(e => {
+    $('.table-generator .cell').on('click', e => {
       let table = generateTable(e.target.dataset.rows, e.target.dataset.cols)
       this._renderer.getEditor().insertText(table)
       global.popupProvider.close()
@@ -762,7 +762,7 @@ class ZettlrBody {
     global.popupProvider.show('table-of-contents', document.querySelector('.button.show-toc'), { 'entries': toc })
 
     // On click jump to line
-    $('.toc-link').click((event) => {
+    $('.toc-link').on('click', (event) => {
       let elem = $(event.target)
       this._renderer.getEditor().jtl(elem.attr('data-line'))
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3655,10 +3655,10 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jquery@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jquery/-/eslint-plugin-jquery-1.5.1.tgz#d6bac643acf9484ce76394e27e2b07baca06662e"
-  integrity sha512-L7v1eaK5t80C0lvUXPFP9MKnBOqPSKhCOYyzy4LZ0+iK+TJwN8S9gAkzzP1AOhypRIwA88HF6phQ9C7jnOpW8w==
+eslint-plugin-no-jquery@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.5.0.tgz#6c12e3aae172bfd3363b7ac8c3f3e944704867f4"
+  integrity sha512-RrQ380mUJJKdjgpQ/tZAJ3B3W1n3LbVmULooS2Pv5pUDcc5uVHVSJMTdUlsbvQyfo6hWP2LJ4FbOoDzENWcF7A==
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"


### PR DESCRIPTION
##  Description

Use a newer plugin for linting jQuery usage.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
## Changes

Replaces uses of deprecated event shorthands with on/trigger.

<!-- If there is anything else that might be of interest, please provide it here -->
## Additional information

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
