### PR TITLE
Fix #1346

### DIFF
--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -205,14 +205,12 @@ class ZettlrToolbar {
 
     this.searchBarInput.addEventListener('focus', () => {
       this._autocomplete = this._renderer.getFilesInDirectory()
-      if (this.searchBarInput.value === '') {
-        // Let's prefill this with the selection from the editor if possible.
-        let selections = this._renderer.getEditor().getSelections()
-        if (selections.length > 0) {
-          this.searchBarInput.value = selections[0]
-          this.searchBarInput.select() // Ease of access
-        }
+      // Let's prefill this with the selection from the editor if possible.
+      let selections = this._renderer.getEditor().getSelections()
+      if (selections[0].length > 0) {
+        this.searchBarInput.value = selections[0]
       }
+      this.searchBarInput.select() // Ease of access
     })
 
     this.searchBarInput.addEventListener('blur', () => {


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes #1346. Now, whenever the **searchbar** is focussed and there is some highlighted text in the document, the content of the searchbar will be updated with the highlighted text; previously this only happened when the searchbar was empty.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
In file `zettlr-toolbar.js` where the event listener `focus` for the searchbar is defined:
- Removed check for empty searchbar content
- Searchbar content (`searchBarInput.value`) is now changed when the first element of `selections`, `selections[0]`, is a string of non-zero length
    - Previously, it was checked whether the array `selections` _itself_ was of non-zero length
        - However, for some reason this check apparently evaluated as true even when nothing was highlighted
- `searchBarInput.select()` now gets called unconditionally
    - When the searchbar content is non-empty, the content gets selected
    - When the content is empty, nothing will happen



## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Linux Mint 19.2
