### PR TITLE
Move global keyboard shortcuts to main menu

### DIFF
--- a/source/app/service-providers/assets/menu.darwin.json
+++ b/source/app/service-providers/assets/menu.darwin.json
@@ -289,6 +289,19 @@
         "type": "separator"
       },
       {
+        "label": "menu.focus_filemanager",
+        "accelerator": "Cmd+Shift+T",
+        "command": "focus-file-manager"
+      },
+      {
+        "label": "menu.focus_editor",
+        "accelerator": "Cmd+Shift+E",
+        "command": "focus-text-editor"
+      },
+      {
+        "type": "separator"
+      },
+      {
         "label": "menu.reset_zoom",
         "accelerator": "Cmd+0",
         "command": "zoom-reset"

--- a/source/app/service-providers/assets/menu.win32.json
+++ b/source/app/service-providers/assets/menu.win32.json
@@ -239,6 +239,19 @@
         "type": "separator"
       },
       {
+        "label": "menu.focus_filemanager",
+        "accelerator": "Ctrl+Shift+T",
+        "command": "focus-file-manager"
+      },
+      {
+        "label": "menu.focus_editor",
+        "accelerator": "Ctrl+Shift+E",
+        "command": "focus-text-editor"
+      },
+      {
+        "type": "separator"
+      },
+      {
         "label": "menu.reset_zoom",
         "accelerator": "Ctrl+0",
         "command": "zoom-reset"

--- a/source/renderer/modules/file-manager/file-manager.vue
+++ b/source/renderer/modules/file-manager/file-manager.vue
@@ -295,6 +295,14 @@ module.exports = {
       }
     },
     /**
+     * Set focus to file list
+     */
+    focusFileList: function () {
+      if (this.isFileListVisible()) {
+        this.$refs.fileList.focus();
+      }
+    },
+    /**
      * Display the arrow button for nagivation, if applicable.
      * @param {MouseEvent} evt The associated event.
      */

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -94,25 +94,6 @@ class ZettlrBody {
       }
     })
 
-    // React to global GUI shortcuts
-    $(document).on('keydown', (event) => {
-      let isDarwin = document.body.classList.contains('darwin')
-      let cmdOrCtrl = (isDarwin && event.metaKey) || (!isDarwin && event.ctrlKey)
-
-      let focusEditorShortcut = (cmdOrCtrl && event.shiftKey && event.key === 'e')
-      let focusFileManagerShortcut = (cmdOrCtrl && event.shiftKey && event.key === 't')
-      if (focusEditorShortcut) { // Cmd/Ctrl+Shift+E
-        // Obviously, focus the editor
-        this._renderer.getEditor().focus()
-      } else if (focusFileManagerShortcut) { // Cmd/Ctrl+Shift+T
-        // You know what to do
-        document.getElementById('file-list').focus()
-      } else if (event.key === 'F2') {
-        // Trigger a rename
-        this.requestNewFileName(this._renderer.getActiveFile())
-      }
-    })
-
     // Inject a global notify and notifyError function
     global.notify = (msg) => { this.notify(msg) }
     global.notifyError = (msg) => { this.notifyError(msg) }

--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -486,7 +486,7 @@ class ZettlrRendererIPC {
         break
 
       case 'focus-file-manager':
-        document.getElementById('file-list').focus()
+        this._app.getFileManager().focusFileList()
         break
   
       case 'focus-text-editor':

--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -485,6 +485,14 @@ class ZettlrRendererIPC {
         }
         break
 
+      case 'focus-file-manager':
+        document.getElementById('file-list').focus()
+        break
+  
+      case 'focus-text-editor':
+        this._app.getEditor().focus()
+        break
+  
       // An update in the config needs to be reflected in the renderer.
       case 'config-update':
         this._app.configChange()


### PR DESCRIPTION
## Description

Bug fix for #759 (keyboard shortcuts not working _on Windows_).

## Changes

The suggested fix is to remove the "global GUI shortcuts" (keydown event listener), which is never triggered on Windows, and replace with menu items with accelerators. This is suggested by [Electron tutorial](https://www.electronjs.org/docs/tutorial/keyboard-shortcuts).

I added two menu items in the View menu, between Toggle Sidebar and Reset Zoom:

- Focus on File Manager (Ctrl/Cmd+Shift+T)
- Focus on Text Editor (Ctrl/Cmd+Shift+E)

Please note that the F2 keyboard shortcut has now been removed, since the menu item "Rename file" already has Ctrl/Cmd+R as accelerator. I don't know if this is a problem or how to fix it.

## Additional information

New strings for Zettlr Translate:

- menu.focus_filemanager
- menu.focus_editor

<!-- Please provide any testing system -->
Tested on: Windows 10
