### PR TITLE
Fix file-list focus bug

### DIFF
--- a/source/renderer/modules/file-manager/file-manager.vue
+++ b/source/renderer/modules/file-manager/file-manager.vue
@@ -295,6 +295,14 @@ module.exports = {
       }
     },
     /**
+     * Set focus to file list
+     */
+    focusFileList: function () {
+      if (this.isFileListVisible()) {
+        this.$refs.fileList.focus()
+      }
+    },
+    /**
      * Display the arrow button for nagivation, if applicable.
      * @param {MouseEvent} evt The associated event.
      */

--- a/source/renderer/zettlr-body.js
+++ b/source/renderer/zettlr-body.js
@@ -105,8 +105,7 @@ class ZettlrBody {
         // Obviously, focus the editor
         this._renderer.getEditor().focus()
       } else if (focusFileManagerShortcut) { // Cmd/Ctrl+Shift+T
-        // You know what to do
-        document.getElementById('file-list').focus()
+        this._renderer.getFileManager().focusFileList()
       } else if (event.key === 'F2') {
         // Trigger a rename
         this.requestNewFileName(this._renderer.getActiveFile())


### PR DESCRIPTION
## Description

Based on #1394, this makes sure that we don't focus the file-list when it's not visible. Seems to be an old bug.

Reproduce the bug:

1. Select "Combined" file manager mode
2. Press Cmd/Ctrl+Shift+T

The file manager will disappear, and an empty file list will be shown with "No directory selected".

## Additional information

Tested on: Windows 10
