### PR TITLE
Latex Template: Define `\VERB` that pandoc uses for the inline_code_attributes extension

### DIFF
--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -104,56 +104,12 @@ pdfproducer={Zettlr with Pandoc and XeLaTeX},
 pdfborder={0 0 0}
 }
 
-% The following preconditions are necessary to have Pandoc produce highlighted
-% code without throwing errors like mad.
-% \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
-\usepackage{color}
-\usepackage{fancyvrb}
+% Setup pandoc code highlighting
+% pandoc uses an if statement, but until we have code
+% to enable or disable highlighting we'll ignore that.
 
-% Define the Shaded environment Pandoc uses
-\newenvironment{Shaded}{}{}
+$highlighting-macros$
 
-% Define the Highlighting environment for Pandoc
-\DefineShortVerb[commandchars=\\\{\}]{\|}
-\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
-
-% Define the VERB environment that pandoc uses for inline_code_attributes
-\newcommand{\VerbBar}{|}
-\newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
-
-% Now some code highlighting commands Pandoc uses
-\newcommand{\euro}{€}
-\newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{{#1}}}}
-\newcommand{\DataTypeTok}[1]{\textcolor[rgb]{0.56,0.13,0.00}{{#1}}}
-\newcommand{\DecValTok}[1]{\textcolor[rgb]{0.25,0.63,0.44}{{#1}}}
-\newcommand{\BaseNTok}[1]{\textcolor[rgb]{0.25,0.63,0.44}{{#1}}}
-\newcommand{\FloatTok}[1]{\textcolor[rgb]{0.25,0.63,0.44}{{#1}}}
-\newcommand{\CharTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{{#1}}}
-\newcommand{\StringTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{{#1}}}
-\newcommand{\CommentTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textit{{#1}}}}
-\newcommand{\OtherTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{{#1}}}
-\newcommand{\AlertTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{{#1}}}}
-\newcommand{\FunctionTok}[1]{\textcolor[rgb]{0.02,0.16,0.49}{{#1}}}
-\newcommand{\RegionMarkerTok}[1]{{#1}}
-\newcommand{\ErrorTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{{#1}}}}
-\newcommand{\NormalTok}[1]{{#1}}
-\newcommand{\ConstantTok}[1]{\textcolor[rgb]{0.53,0.00,0.00}{#1}}
-\newcommand{\SpecialCharTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
-\newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.25,0.44,0.63}{#1}}
-\newcommand{\SpecialStringTok}[1]{\textcolor[rgb]{0.73,0.40,0.53}{#1}}
-\newcommand{\ImportTok}[1]{#1}
-\newcommand{\DocumentationTok}[1]{\textcolor[rgb]{0.73,0.13,0.13}{\textit{#1}}}
-\newcommand{\AnnotationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
-\newcommand{\CommentVarTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
-\newcommand{\VariableTok}[1]{\textcolor[rgb]{0.10,0.09,0.49}{#1}}
-\newcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{#1}}}
-\newcommand{\OperatorTok}[1]{\textcolor[rgb]{0.40,0.40,0.40}{#1}}
-\newcommand{\BuiltInTok}[1]{#1}
-\newcommand{\ExtensionTok}[1]{#1}
-\newcommand{\PreprocessorTok}[1]{\textcolor[rgb]{0.74,0.48,0.00}{#1}}
-\newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.49,0.56,0.16}{#1}}
-\newcommand{\InformationTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
-\newcommand{\WarningTok}[1]{\textcolor[rgb]{0.38,0.63,0.69}{\textbf{\textit{#1}}}}
 
 % Set the date (either \today or a date from the frontmatter)
 \date{$PDF_DATE$}

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -117,6 +117,10 @@ pdfborder={0 0 0}
 \DefineShortVerb[commandchars=\\\{\}]{\|}
 \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
 
+% Define the VERB environment that pandoc uses for inline_code_attributes
+\newcommand{\VerbBar}{|}
+\newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
+
 % Now some code highlighting commands Pandoc uses
 \newcommand{\euro}{€}
 \newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.00,0.44,0.13}{\textbf{{#1}}}}


### PR DESCRIPTION
## Description
Add `\VERB` command to latex template. Pandoc uses this when inline code is given an attribute (e.g. `` `test`{.rest} ``) and exports will fail if this command is not defined. 

## Changes
Added `\VERB` and `\VerbBar` commands to default export template.
## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Gentoo Linux; Current head of develop. Pandoc 2.9.21
