### PR TITLE
Latex Template: Update for new Citeproc

### DIFF
--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -163,10 +163,24 @@ pdfborder={0 0 0}
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
-\newenvironment{cslreferences}%
-{$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
-\everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
-{\par}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
 \title{$PDF_TITLE$}


### PR DESCRIPTION
##  Description

Latex Template: Update for new Citeproc.
* Also merge in some updates that make numbered citation styles render properly.

## Changes
Update `$if(csl-refs)$` block to be consistent with current pandoc default.latex.

This *will not* work with old version of pandoc (<=2.11 required). Note that the current template does *not* work with pandoc >=2.11.

Newer versions of pandoc will require that citeproc be explicitly called with `-C` or `--citeproc`; Citeproc will not be automatically run if a bibliography is passed to pandoc.

<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

## Additional information
This probably shouldn't be merged as is - the default pandoc command will not work!

<!-- Please provide any testing system -->
Tested on: Windows 10 (20.04); Head of Develop.
