### PR TITLE
Fix language files search path

### DIFF
--- a/source/common/i18n.js
+++ b/source/common/i18n.js
@@ -269,7 +269,7 @@ function getTranslationMetadata (paths = [ path.join(app.getPath('userData'), '/
  * @param  {Array} [paths=[]] An array of paths to search for. Optional.
  * @return {Array}       An array containing metadata for all found files.
  */
-function enumLangFiles (paths = [ path.join(app.getPath('userData'), '/lang'), __dirname ]) {
+function enumLangFiles (paths = [ path.join(app.getPath('userData'), '/lang'), path.join(__dirname, '/lang') ]) {
   // Now go through all search paths and enumerate all available files of interest
   let candidates = []
   for (let p of paths) {


### PR DESCRIPTION
e5d807a moved i18n into the lang directory within language pack, which
caused the incorrect search path of enumLangFiles helper.

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

I believe this is missed in e5d807a. This would cause issues if the user drops a customized translation into the webpack directory.

## Changes

Fix the search path, to be consistent with `getTranslationMetadata`.