### PR TITLE
Fix file open extensions (remove dot prefix)

### DIFF
--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -396,9 +396,9 @@ export default class Zettlr {
     // TODO: Move this to a command
     // The user wants to open another file or directory.
     const rmdSupport = global.config.get('enableRMarkdown') as boolean
-    const extensions = [ '.markdown', '.md', '.txt' ]
+    const extensions = [ 'markdown', 'md', 'txt' ]
     if (rmdSupport) {
-      extensions.push('.rmd')
+      extensions.push('rmd')
     }
 
     const filter = [{ 'name': trans('system.files'), 'extensions': extensions }]


### PR DESCRIPTION
## Description
Current behaviour removes all files on windows (due to double dot).

## Changes
Removed dots in extensions list provided to file open dialog.

## Additional information
Electron expects extensions without dot: https://github.com/electron/electron/blob/v10.1.5/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options

I am not in a position to test this on other platforms, but I assume following electron docs is the safest bet.

Tested on: Windows
