### PR TITLE
Move regexes to source/common/regular-expressions

### DIFF
--- a/source/common/regular-expressions.js
+++ b/source/common/regular-expressions.js
@@ -97,6 +97,13 @@ module.exports = {
   /**
    * Returns a regular expression that matches MarkDown footnote references.
    *
+   * This matches footnote links in the style of [^<text>] but only if it includes
+   * numbers, letters (without umlauts) and _ as well as - chars.
+   * The second or third capturing group contains the identifier. The other
+   * will then be `undefined`
+   * This also matches strings where ] is the end of a string, but
+   * still ensures, ":" is NOT behind the closing bracket.
+   *
    * @return  {RegExp}              The compiled Regular Expression
    */
   'getFnRE': function () {
@@ -118,6 +125,11 @@ module.exports = {
 
   /**
    * Returns a regular expression that matches MarkDown footnote references.
+   *
+   * This matches footnote references in the style of [^<text>]: <reference text>
+   * This matches the same type of footnotes as the fnRE and includes two
+   * capturing groups: match[1] holds the identifier, match[2] the reference text.
+   * group 1: footnote number; group 2: text
    *
    * @param   {boolean}  multiline  Whether to match multiline
    *

--- a/source/common/regular-expressions.js
+++ b/source/common/regular-expressions.js
@@ -253,12 +253,6 @@ module.exports = {
   /**
    * Returns a regular expression that matches inline Maths.
    *
-   * Matches all inlines according to the Pandoc documentation
-   * on its tex_math_dollars-extension.
-   * More information: https://pandoc.org/MANUAL.html#math
-   * First alternative is only for single-character-equations
-   * such as $x$. All others are captured by the second alternative.
-   *
    * @param   {boolean} global      whether the expression should be global
    *
    * @return  {RegExp}              The compiled Regular Expression
@@ -270,6 +264,27 @@ module.exports = {
       flag)
   },
 
+  /**
+   * Returns a regular expression that matches inline Maths.
+   *
+   * Used to render inline math.
+   *
+   * Matches all inlines according to the Pandoc documentation
+   * on its tex_math_dollars-extension.
+   * More information: https://pandoc.org/MANUAL.html#math
+   * First alternative is only for single-character-equations
+   * such as $x$. All others are captured by the second alternative.
+   *
+   * @param   {boolean} global      whether the expression should be global
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getInlineMathRenderRE': function (global = false) {
+    let flag = (global) ? 'g' : ''
+    return RegExp(
+      /(?<!\\)\${1,2}([^\s\\])\${1,2}(?!\d)|(?<!\\)\${1,2}([^\s].*?[^\s\\])\${1,2}(?!\d)/.source,
+      flag)
+  },
   /**
    * Returns a regular expression that matches MarkDown links.
    *

--- a/source/common/regular-expressions.js
+++ b/source/common/regular-expressions.js
@@ -27,7 +27,11 @@ module.exports = {
   },
 
   /**
-   * Returns a regular expression that matches MarkDown Blocks (???).
+   * Returns a regular expression that matches MarkDown Blocks.
+   *
+   * First capturing group: preceding whitespace. Second cap.: line contents
+   * Non-capturing group in the middle: all block elements.
+   * Non-capturing group afterwards: catches all whitespace
    *
    * @return  {RegExp}              The compiled Regular Expression
    */
@@ -39,6 +43,11 @@ module.exports = {
 
   /**
    * Returns a regular expression that matches MarkDown Citations.
+   *
+   * Should match everything permittible -- first alternative are the huge
+   * blocks, second alternative are the simple @ID-things, both recognised by
+   * Pandoc citeproc.
+   * citationRE is taken from the Citr library (the extraction regex)
    *
    * @return  {RegExp}              The compiled Regular Expression
    */
@@ -155,7 +164,7 @@ module.exports = {
   },
 
   /**
-   * Returns a regular expression that matches MarkDown highlighting (???).
+   * Returns a regular expression that matches Zettlr's MarkDown highlighting extension.
    *
    * @return  {RegExp}              The compiled Regular Expression
    */
@@ -298,6 +307,8 @@ module.exports = {
   /**
    * Returns a regular expression that matches unordered Markdown lists.
    *
+   * Includes a capture group to capture list tokens.
+   *
    * @return  {RegExp}              The compiled Regular Expression
    */
   'getListTokenRE': function () {
@@ -319,6 +330,8 @@ module.exports = {
 
   /**
    * Returns a regular expression that matches unordered MarkDown lists.
+   *
+   * Used in CodeMirror.
    *
    * @return  {RegExp}              The compiled Regular Expression
    */
@@ -366,7 +379,7 @@ module.exports = {
   },
 
   /**
-   * Returns a regular expression that matches inline frames.
+   * Returns a regular expression that matches MarkDown table headings.
    *
    * @return  {RegExp}              The compiled Regular Expression
    */
@@ -399,7 +412,16 @@ module.exports = {
   },
 
   /**
-   * Returns a regular expression that matches inline frames.
+   * Returns a regular expression that matches:
+   *
+   * 1. Underscore strong
+   * 2. Underscore emphasis
+   * 3. Asterisk strong
+   * 4. Asterisk emphasis
+   * 5. Heading levels 1-6 (mark)
+   * 6. Heading levels 1-6 (content)
+   * 7. Blockquotes
+   * 8. Inline code
    *
    * @return  {RegExp}              The compiled Regular Expression
    */

--- a/source/common/regular-expressions.js
+++ b/source/common/regular-expressions.js
@@ -253,12 +253,21 @@ module.exports = {
   /**
    * Returns a regular expression that matches inline Maths.
    *
+   * Matches all inlines according to the Pandoc documentation
+   * on its tex_math_dollars-extension.
+   * More information: https://pandoc.org/MANUAL.html#math
+   * First alternative is only for single-character-equations
+   * such as $x$. All others are captured by the second alternative.
+   *
+   * @param   {boolean} global      whether the expression should be global
+   *
    * @return  {RegExp}              The compiled Regular Expression
    */
-  'getInlineMathRE': function () {
+  'getInlineMathRE': function (global = false) {
+    let flag = (global) ? 'g' : ''
     return RegExp(
-      /^(?:\${1,2}[^\s\\]\${1,2}(?!\d)|\${1,2}[^\s].*?[^\s\\]\${1,2}(?!\d))/.source
-    )
+      /^(?:\${1,2}[^\s\\]\${1,2}(?!\d)|\${1,2}[^\s].*?[^\s\\]\${1,2}(?!\d))/.source,
+      flag)
   },
 
   /**
@@ -343,7 +352,7 @@ module.exports = {
   /**
    * Returns a regular expression that matches unordered MarkDown lists.
    *
-   * Used in CodeMirror.
+   * Used in CodeMirror MarkDown shortcuts.
    *
    * @return  {RegExp}              The compiled Regular Expression
    */

--- a/source/common/regular-expressions.js
+++ b/source/common/regular-expressions.js
@@ -14,49 +14,157 @@
  */
 
 module.exports = {
+
   /**
-   * Returns a regular expression that can detect Markdown images globally
+   * Returns a regular expression that matches block Maths.
    *
-   * @param   {boolean}  multiline  Whether or not the regular expression should be multiline
-   *
-   * @return  {RegExp}           The wanted regular expression.
+   * @return  {RegExp}              The compiled Regular Expression
    */
-  'getImageRE': function (multiline = false) {
+  'getBlockMathRE': function () {
+    return RegExp(
+      /^\s*\$\$\s*$/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Blocks (???).
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getBlockRE': function () {
+    return RegExp(
+      /^(\s*?)(?:#{1,6}|>|\*|\+|-|\d{1,5}\.)(?:\s+)(.*)$/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Citations.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getCitationRE': function () {
+    return RegExp(
+      /(\[(?:[^[\]]*@[^[\]]+)\])|(?<=\s|^)(@[\p{L}\d_][\p{L}\d_:.#$%&\-+?<>~/]*)/.source,
+      'gu')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown inline code.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getCodeRE': function () {
+    return RegExp(
+      /`.*?`/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Code Blocks.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getCodeBlockRE': function () {
+    return RegExp(
+      /^\s{0,3}(`{3,}|~{3,})/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches footnotes for project export.
+   *
+   * @param   {boolean}  multiline  Whether to match multiline
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getFnExportRE': function (multiline = false) {
     let flag = (multiline) ? 'm' : ''
     return RegExp(
-      /(?<=\s|^)!\[(.*?)\]\((.+?(?:(?<= )"(.+)")?)\)({[^{]+})?/.source,
+      /\[\^([\w]+?)\]/.source,
       // Necessary flags + optional multiline flag
       'g' + flag)
   },
+
   /**
-   * Returns a regular expression that matches image file names
+   * Returns a regular expression that matches MarkDown footnote references.
    *
-   * @param   {boolean}  multiline  Whether the expression should match multilines
-   *
-   * @return  {RegExp}             The compiled expression
+   * @return  {RegExp}              The compiled Regular Expression
    */
-  'getImageFileRE': function (multiline = false) {
-    let flag = (multiline) ? 'm' : ''
+  'getFnRE': function () {
     return RegExp(
-      /(\.jpg|\.jpeg|\.png|\.gif|\.svg|\.tiff|\.tif)$/.source,
-      // Necessary flags + optional multiline flag
-      'i' + flag
+      /(\[\^([\da-zA-Z_-]+)\][^:]|\[\^([\da-zA-Z_-]+)\]$)/.source,
+      'g')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown footnote references.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getFnReferenceRE': function () {
+    return RegExp(
+      /^\[\^.+\]:\s/.source
     )
   },
+
   /**
-   * Returns a regular expression that matches URL protocols (e.g. http://)
+   * Returns a regular expression that matches MarkDown footnote references.
    *
-   * @param   {boolean}  multiline  Whether or not the expression should be multiline
+   * @param   {boolean}  multiline  Whether to match multiline
    *
-   * @return  {RegExp}           The wanted regular expression
+   * @return  {RegExp}              The compiled Regular Expression
    */
-  'getProtocolRE': function (multiline = false) {
+  'getFnRefRE': function (multiline = false) {
     let flag = (multiline) ? 'm' : ''
     return RegExp(
-      /^([a-z]{1,10}):\/\//,
-      'i' + flag
+      /^\[\^([\da-zA-Z_-]+)\]: (.+)/.source,
+      'g' + flag)
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown footnote references.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getFootnoteRefRE': function () {
+    return RegExp(
+      /\[\^[^\]]+\]/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Headings.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getHeadRE': function () {
+    return RegExp(
+      /^(#{1,6}) (.*)/.source,
+      'g')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Headings.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getHeadingRE': function () {
+    return RegExp(
+      /(#+)\s+/.source
     )
   },
+
+  /**
+   * Returns a regular expression that matches MarkDown highlighting (???).
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getHighlightRE': function () {
+    return RegExp(
+      /::.+?::|==.+?==/.source
+    )
+  },
+
   /**
    * Returns a regular expression that matches file IDs as in the settings
    *
@@ -77,5 +185,239 @@ module.exports = {
       idRegExpString,
       'g' + flag
     )
+  },
+
+  /**
+   * Returns a regular expression that matches inline frames.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getIframeRE': function () {
+    return RegExp(
+      /^<iframe.*?>.*?<\/iframe>$/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that can detect Markdown images globally
+   *
+   * @param   {boolean}  multiline  Whether or not the regular expression should be multiline
+   *
+   * @return  {RegExp}           The wanted regular expression.
+   */
+  'getImageRE': function (multiline = false) {
+    let flag = (multiline) ? 'm' : ''
+    return RegExp(
+      /(?<=\s|^)!\[(.*?)\]\((.+?(?:(?<= )"(.+)")?)\)({[^{]+})?/.source,
+      // Necessary flags + optional multiline flag
+      'g' + flag)
+  },
+
+  /**
+   * Returns a regular expression that matches image file names
+   *
+   * @param   {boolean}  multiline  Whether the expression should match multilines
+   *
+   * @return  {RegExp}             The compiled expression
+   */
+  'getImageFileRE': function (multiline = false) {
+    let flag = (multiline) ? 'm' : ''
+    return RegExp(
+      /(\.jpg|\.jpeg|\.png|\.gif|\.svg|\.tiff|\.tif)$/.source,
+      // Necessary flags + optional multiline flag
+      'i' + flag
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches inline Maths.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getInlineMathRE': function () {
+    return RegExp(
+      /^(?:\${1,2}[^\s\\]\${1,2}(?!\d)|\${1,2}[^\s].*?[^\s\\]\${1,2}(?!\d))/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown links.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getLinkRE': function () {
+    return RegExp(
+      /^.+\.[a-z0-9]+/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListRE': function () {
+    return RegExp(
+      /^(\s*)([*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches empty MarkDown lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListEmptyRE': function () {
+    return RegExp(
+      /^(\s*)([*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Ordered lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListOrderedRE': function () {
+    return RegExp(
+      /^(\s*)((\d+)([.)]))(\s*)/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown task lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListTaskListRE': function () {
+    return RegExp(
+      /^(\s*)(- \[[x ]\])(\s*)/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches unordered Markdown lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListTokenRE': function () {
+    return RegExp(
+      /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches unordered MarkDown lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListUnorderedRE': function () {
+    return RegExp(
+      /[*+-]\s/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches unordered MarkDown lists.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getListUnorderedCMRE': function () {
+    return RegExp(
+      /^(\s*)([*+-])\s/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown files.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getMarkDownFileRE': function () {
+    return RegExp(
+      /.+\.(?:md|markdown|txt)$/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches URL protocols (e.g. http://)
+   *
+   * @param   {boolean}  multiline  Whether or not the expression should be multiline
+   *
+   * @return  {RegExp}           The wanted regular expression
+   */
+  'getProtocolRE': function (multiline = false) {
+    let flag = (multiline) ? 'm' : ''
+    return RegExp(
+      /^([a-z]{1,10}):\/\//,
+      'i' + flag
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches MarkDown Tables.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getTableRE': function () {
+    return RegExp(
+      /^\|.+\|$/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches inline frames.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getTableHeadingRE': function () {
+    return RegExp(
+      /(^[- ]+$)|(^[- +:]+$)|(^[- |:+]+$)/.source
+    )
+  },
+
+  /**
+   * Returns a regular expression that matches tasks.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getTaskRE': function () {
+    return RegExp(
+      /^(\s*)([-+*]) \[( |x)\] /.source,
+      'g')
+  },
+
+  /**
+   * Returns a regular expression that matches URLs.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getUrlRE': function () {
+    return RegExp(
+      /^\[([^\]]+)\]\((.+?)\)|(((?:(?:aaas?|about|acap|adiumxtra|af[ps]|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|cap|chrome(?:-extension)?|cid|coap|com-eventbrite-attendee|content|crid|cvs|data|dav|dict|dlna-(?:playcontainer|playsingle)|dns|doi|dtn|dvb|ed2k|facetime|feed|file|finger|fish|ftp|geo|gg|git|gizmoproject|go|gopher|gtalk|h323|hcp|https?|iax|icap|icon|im|imap|info|ipn|ipp|irc[6s]?|iris(?:\.beep|\.lwz|\.xpc|\.xpcs)?|itms|jar|javascript|jms|keyparc|lastfm|ldaps?|magnet|mailto|maps|market|message|mid|mms|ms-help|msnim|msrps?|mtqp|mumble|mupdate|mvn|news|nfs|nih?|nntp|notes|oid|opaquelocktoken|palm|paparazzi|platform|pop|pres|proxy|psyc|query|res(?:ource)?|rmi|rsync|rtmp|rtsp|secondlife|service|session|sftp|sgn|shttp|sieve|sips?|skype|sm[bs]|snmp|soap\.beeps?|soldat|spotify|ssh|steam|svn|tag|teamspeak|tel(?:net)?|tftp|things|thismessage|tip|tn3270|tv|udp|unreal|urn|ut2004|vemmi|ventrilo|view-source|webcal|wss?|wtai|wyciwyg|xcon(?:-userid)?|xfire|xmlrpc\.beeps?|xmpp|xri|ymsgr|z39\.50[rs]?):(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]|\([^\s()<>]*\))+(?:\([^\s()<>]*\)|[^\s`*!()[\]{};:'".,<>?«»“”‘’])))|([a-z0-9.\-_+]+?@[a-z0-9.\-_+]+\.[a-z]{2,7})$/.source,
+      'i')
+  },
+
+  /**
+   * Returns a regular expression that matches inline frames.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getWysiwygRE': function () {
+    return RegExp(
+      /__(.+?)__|_(.+?)_|\*\*(.+?)\*\*|\*(.+?)\*|^(#{1,6}) (.+?)$|^(?:\s*)> (.+)$|`(.+?)`/.source,
+      'gi')
+  },
+
+  /**
+   * Returns a regular expression that matches Zettelkasten IDs.
+   *
+   * @return  {RegExp}              The compiled Regular Expression
+   */
+  'getZknTagRE': function () {
+    return RegExp(
+      /##?[^\s,.:;…!?"'`»«“”‘’—–@$%&*#^+~÷\\/|<=>[\](){}]+#?/.source,
+      'i')
   }
+
 }

--- a/source/common/util/make-valid-uri.js
+++ b/source/common/util/make-valid-uri.js
@@ -17,10 +17,11 @@ const path = require('path')
 // NOTE: fileExists is called "isFile" everywhere else, we have just renamed
 // it because of a naming conflict in the function.
 const fileExists = require('../../common/util/is-file')
+const { getProtocolRE, getLinkRE, getMarkDownFileRE } = require('../regular-expressions')
 
-const protocolRE = /^([a-z0-9]{1,100}):\/\//i
-const linkRE = /^.+\.[a-z0-9]+/i
-const mdFileRE = /.+\.(?:md|markdown|txt)$/i
+const protocolRE = getProtocolRE()
+const linkRE = getLinkRE()
+const mdFileRE = getMarkDownFileRE()
 
 /**
  * Returns a valid URI, using the available context information

--- a/source/main/commands/dir-delete.ts
+++ b/source/main/commands/dir-delete.ts
@@ -34,7 +34,7 @@ export default class DirDelete extends ZettlrCommand {
     // Now that all files are corresponding files are closed, we can
     // proceed to remove the directory.
 
-    if (await this._app.confirmRemove(dirToDelete) === false) {
+    if (!await this._app.confirmRemove(dirToDelete)) {
       return false
     }
 

--- a/source/main/commands/dir-project-export.ts
+++ b/source/main/commands/dir-project-export.ts
@@ -19,7 +19,7 @@ import makeExport from '../modules/export'
 import objectToArray from '../../common/util/object-to-array'
 import makeImgPathsAbsolute from '../../common/util/make-img-paths-absolute'
 
-const { getFnExportRE } = require('../../common/regular-expressions')
+import { getFnExportRE } from '../../common/regular-expressions'
 
 export default class DirProjectExport extends ZettlrCommand {
   constructor (app: any) {

--- a/source/main/commands/dir-project-export.ts
+++ b/source/main/commands/dir-project-export.ts
@@ -19,8 +19,7 @@ import makeExport from '../modules/export'
 import objectToArray from '../../common/util/object-to-array'
 import makeImgPathsAbsolute from '../../common/util/make-img-paths-absolute'
 
-// Extracts footnotes
-const fnRE = /\[\^([\w]+?)\]/gm
+const { getFnExportRE } = require('../../common/regular-expressions')
 
 export default class DirProjectExport extends ZettlrCommand {
   constructor (app: any) {
@@ -54,6 +53,9 @@ export default class DirProjectExport extends ZettlrCommand {
     // Reduce to files-only
     files = files.filter((elem) => { return elem.type === 'file' })
 
+    // Import our RE
+    let fnExportRE = getFnExportRE(true) // We want the multiline version.
+
     // Concat the files
     let contents: string[] = []
     for (let file of files) {
@@ -64,7 +66,9 @@ export default class DirProjectExport extends ZettlrCommand {
       // same for all files). Also make the footnotes unique to prevent
       // assigning errors.
       fileContents = makeImgPathsAbsolute(file.dir, fileContents)
-      fileContents = fileContents.replace(fnRE, (match, p1: string, offset, string) => `[^${String(file.hash)}${p1}]`)
+
+      fileContents = fileContents.replace(fnExportRE, (match, p1: string, offset, string) => `[^${String(file.hash)}${p1}]`)
+
       contents.push(fileContents)
     }
     const finalContents = contents.join('\n\n')

--- a/source/renderer/modules/file-manager/file-manager.vue
+++ b/source/renderer/modules/file-manager/file-manager.vue
@@ -136,7 +136,10 @@
               v-bind:page-mode="true"
               v-on:update="updateDynamics"
             >
-              <file-item v-bind:obj="item.props" v-bind:activeFile="activeFile"></file-item>
+              <file-item
+                v-bind:obj="item.props"
+                v-bind:active-file="activeFile"
+              ></file-item>
             </recycle-scroller>
           </template>
         </template>

--- a/source/renderer/modules/file-manager/tree-item.vue
+++ b/source/renderer/modules/file-manager/tree-item.vue
@@ -39,7 +39,10 @@
         v-bind:data-hash="obj.hash"
       >
         <!-- First: Primary icon (either directory icon, file icon, or project icon) -->
-        <span class="item-icon" role="presentation">
+        <span
+          class="item-icon"
+          role="presentation"
+        >
           <!-- Is this a project? -->
           <clr-icon
             v-if="obj.project && hasChildren"
@@ -59,7 +62,10 @@
           />
         </span> <!-- End primary (item) icon -->
         <!-- Second: Secondary icon (the collapse/expand icon) -->
-        <span class="toggle-icon" role="presentation">
+        <span
+          class="toggle-icon"
+          role="presentation"
+        >
           <!-- Display a toggle to collapse/expand the file list -->
           <!-- Only display in this position if the item has a primary icon -->
           <clr-icon

--- a/source/renderer/modules/markdown-editor/hooks/autocomplete.js
+++ b/source/renderer/modules/markdown-editor/hooks/autocomplete.js
@@ -12,7 +12,8 @@
  * END HEADER
  */
 
-const codeBlockRE = /^\s{0,3}(`{3,}|~{3,})/
+const { getCodeBlockRE } = require('../../../../common/regular-expressions')
+const codeBlockRE = getCodeBlockRE()
 
 var autocompleteStart = null
 var currentDatabase = null

--- a/source/renderer/modules/markdown-editor/hooks/footnotes.js
+++ b/source/renderer/modules/markdown-editor/hooks/footnotes.js
@@ -2,6 +2,7 @@
 // it's not in the plugins folder.
 
 const tippy = require('tippy.js').default
+const { getFnRefRE } = require('../../../../common/regular-expressions')
 const md2html = require('../../../../common/util/md-to-html')
 
 module.exports = (cm) => {
@@ -60,7 +61,7 @@ function showFootnoteTooltip (cm, element) {
 
   // Now find the respective line and extract the footnote content using
   // our RegEx from the footnotes plugin.
-  let fnrefRE = /^\[\^([\da-zA-Z_-]+)\]: (.+)/gm
+  let fnrefRE = getFnRefRE(true) // Get the multiline version
 
   for (let lineNo = cm.doc.lastLine(); lineNo > -1; lineNo--) {
     fnrefRE.lastIndex = 0

--- a/source/renderer/modules/markdown-editor/modes/markdown-zkn.js
+++ b/source/renderer/modules/markdown-editor/modes/markdown-zkn.js
@@ -1,5 +1,9 @@
 /* global CodeMirror define */
 // ZETTLR SPELLCHECKER PLUGIN
+const {
+  getZknTagRE, getHeadingRE, getHighlightRE,
+  getTableRE, getInlineMathRE, getBlockMathRE, getFnReferenceRE
+} = require('../../../../common/regular-expressions');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
@@ -12,13 +16,13 @@
 })(function (CodeMirror) {
   'use strict'
 
-  var zknTagRE = /##?[^\s,.:;…!?"'`»«“”‘’—–@$%&*#^+~÷\\/|<=>[\](){}]+#?/i
-  var headingRE = /(#+)\s+/
-  var highlightRE = /::.+?::|==.+?==/
-  var tableRE = /^\|.+\|$/i
-  var inlineMathRE = /^(?:\${1,2}[^\s\\]\${1,2}(?!\d)|\${1,2}[^\s].*?[^\s\\]\${1,2}(?!\d))/
-  var blockMathRE = /^\s*\$\$\s*$/
-  var fnReferenceRE = /^\[\^.+\]:\s/
+  var zknTagRE = getZknTagRE()
+  var headingRE = getHeadingRE()
+  var highlightRE = getHighlightRE()
+  var tableRE = getTableRE()
+  var inlineMathRE = getInlineMathRE()
+  var blockMathRE = getBlockMathRE()
+  var fnReferenceRE = getFnReferenceRE()
 
   /**
     * This defines the Markdown Zettelkasten system mode, which highlights IDs

--- a/source/renderer/modules/markdown-editor/modes/spellchecker.js
+++ b/source/renderer/modules/markdown-editor/modes/spellchecker.js
@@ -13,10 +13,11 @@
   'use strict'
 
   const { ipcRenderer } = require('electron')
+  const { getCodeRE, getFootnoteRefRE, getZknTagRE } = require('../../../../common/regular-expressions.js')
 
-  var codeRE = /`.*?`/i
-  var zknTagRE = /##?[^\s,.:;…!?"'`»«“”‘’—–@$%&*^+~÷\\/|<=>[\](){}]+#?/i
-  var footnoteRefRE = /\[\^[^\]]+\]/
+  var codeRE = getCodeRE()
+  var zknTagRE = getZknTagRE()
+  var footnoteRefRE = getFootnoteRefRE()
   // NOTE: The whitespace after ~ are first a normal space, then an NBSP
   var delim = '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~  «»‹›„“”「」『』–—…÷‘’‚'
 

--- a/source/renderer/modules/markdown-editor/plugins/continuelist.js
+++ b/source/renderer/modules/markdown-editor/plugins/continuelist.js
@@ -20,9 +20,9 @@
   'use strict'
 
   const { getListUnorderedRE, getListEmptyRE, getListRE } = require('../../../../common/regular-expressions')
-  var listRE = getListRE()
-  let emptyListRE = getListEmptyRE()
-  let unorderedListRE = getListUnorderedRE()
+  const listRE = getListRE()
+  const emptyListRE = getListEmptyRE()
+  const unorderedListRE = getListUnorderedRE()
 
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function (cm) {
     if (cm.isReadOnly()) return CodeMirror.Pass

--- a/source/renderer/modules/markdown-editor/plugins/continuelist.js
+++ b/source/renderer/modules/markdown-editor/plugins/continuelist.js
@@ -19,9 +19,10 @@
 })(function (CodeMirror) {
   'use strict'
 
-  var listRE = /^(\s*)([*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/
-  let emptyListRE = /^(\s*)([*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/
-  let unorderedListRE = /[*+-]\s/
+  const { getListUnorderedRE, getListEmptyRE, getListRE } = require('../../../../common/regular-expressions')
+  var listRE = getListRE()
+  let emptyListRE = getListEmptyRE()
+  let unorderedListRE = getListUnorderedRE()
 
   CodeMirror.commands.newlineAndIndentContinueMarkdownList = function (cm) {
     if (cm.isReadOnly()) return CodeMirror.Pass

--- a/source/renderer/modules/markdown-editor/plugins/footnotes.js
+++ b/source/renderer/modules/markdown-editor/plugins/footnotes.js
@@ -11,19 +11,20 @@
   }
 })(function (CodeMirror) {
   'use strict'
-
+  const { getFnRE, getFnRefRE } = require('../../../../common/regular-expressions')
   // This matches footnote links in the style of [^<text>] but only if it includes
   // numbers, letters (without umlauts) and _ as well as - chars.
   // The second or third capturing group contains the identifier. The other
   // will then be `undefined`
   // This also matches strings where ] is the end of a string, but
   // still ensures, ":" is NOT behind the closing bracket.
-  var fnRE = /(\[\^([\da-zA-Z_-]+)\][^:]|\[\^([\da-zA-Z_-]+)\]$)/g
+  var fnRE = getFnRE()
 
   // This matches footnote references in the style of [^<text>]: <reference text>
   // This matches the same type of footnotes as the fnRE and includes two
   // capturing groups: match[1] holds the identifier, match[2] the reference text.
-  var fnrefRE = /^\[\^([\da-zA-Z_-]+)\]: (.+)/gm // group 1: footnote number; group 2: text
+  // group 1: footnote number; group 2: text
+  var fnrefRE = getFnRefRE(true) // Get the multiline version
 
   // Inserts a footnote
   // This is done by parseInt()-ing the existing footnotes and search for the

--- a/source/renderer/modules/markdown-editor/plugins/footnotes.js
+++ b/source/renderer/modules/markdown-editor/plugins/footnotes.js
@@ -12,18 +12,7 @@
 })(function (CodeMirror) {
   'use strict'
   const { getFnRE, getFnRefRE } = require('../../../../common/regular-expressions')
-  // This matches footnote links in the style of [^<text>] but only if it includes
-  // numbers, letters (without umlauts) and _ as well as - chars.
-  // The second or third capturing group contains the identifier. The other
-  // will then be `undefined`
-  // This also matches strings where ] is the end of a string, but
-  // still ensures, ":" is NOT behind the closing bracket.
   var fnRE = getFnRE()
-
-  // This matches footnote references in the style of [^<text>]: <reference text>
-  // This matches the same type of footnotes as the fnRE and includes two
-  // capturing groups: match[1] holds the identifier, match[2] the reference text.
-  // group 1: footnote number; group 2: text
   var fnrefRE = getFnRefRE(true) // Get the multiline version
 
   // Inserts a footnote

--- a/source/renderer/modules/markdown-editor/plugins/indentlist.js
+++ b/source/renderer/modules/markdown-editor/plugins/indentlist.js
@@ -11,6 +11,8 @@
  */
 
 // Additional fix: Different paths to CodeMirror
+const { getListTokenRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -23,7 +25,7 @@
   'use strict'
 
   var Pos = CodeMirror.Pos
-  var listTokenRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/
+  const listTokenRE = getListTokenRE()
 
   function matchListToken (pos, cm) {
     /* Get some info about the current state */

--- a/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
+++ b/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
@@ -24,9 +24,6 @@ const { getListOrderedRE, getListTaskListRE, getListUnorderedCMRE, getUrlRE, get
 
   var reservedChars = '+.*_/\\[](){}?^$'.split('')
   var urlRE = getUrlRE()
-  // First capturing group: preceding whitespace. Second cap.: line contents
-  // Non-capturing group in the middle: all block elements.
-  // Non-capturing group afterwards: catches all whitespace
   var blockRE = getBlockRE()
 
   /**

--- a/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
+++ b/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
@@ -4,7 +4,8 @@
 //
 // This plugin defines shortcuts for CodeMirror Markdown (Bold, italic, link, etc)
 
-const { clipboard } = require('electron');
+const { clipboard } = require('electron')
+const { getListOrderedRE, getListTaskListRE, getListUnorderedCMRE, getUrlRE, getBlockRE } = require('../../../../common/regular-expressions');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
@@ -17,16 +18,16 @@ const { clipboard } = require('electron');
 })(function (CodeMirror) {
   'use strict'
 
-  var unorderedListRE = /^(\s*)([*+-])\s/
-  var taskListRE = /^(\s*)(- \[[x ]\])(\s*)/
-  var orderedListRE = /^(\s*)((\d+)([.)]))(\s*)/
+  var unorderedListRE = getListUnorderedCMRE()
+  var taskListRE = getListTaskListRE()
+  var orderedListRE = getListOrderedRE()
 
   var reservedChars = '+.*_/\\[](){}?^$'.split('')
-  var urlRE = /^\[([^\]]+)\]\((.+?)\)|(((?:(?:aaas?|about|acap|adiumxtra|af[ps]|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|cap|chrome(?:-extension)?|cid|coap|com-eventbrite-attendee|content|crid|cvs|data|dav|dict|dlna-(?:playcontainer|playsingle)|dns|doi|dtn|dvb|ed2k|facetime|feed|file|finger|fish|ftp|geo|gg|git|gizmoproject|go|gopher|gtalk|h323|hcp|https?|iax|icap|icon|im|imap|info|ipn|ipp|irc[6s]?|iris(?:\.beep|\.lwz|\.xpc|\.xpcs)?|itms|jar|javascript|jms|keyparc|lastfm|ldaps?|magnet|mailto|maps|market|message|mid|mms|ms-help|msnim|msrps?|mtqp|mumble|mupdate|mvn|news|nfs|nih?|nntp|notes|oid|opaquelocktoken|palm|paparazzi|platform|pop|pres|proxy|psyc|query|res(?:ource)?|rmi|rsync|rtmp|rtsp|secondlife|service|session|sftp|sgn|shttp|sieve|sips?|skype|sm[bs]|snmp|soap\.beeps?|soldat|spotify|ssh|steam|svn|tag|teamspeak|tel(?:net)?|tftp|things|thismessage|tip|tn3270|tv|udp|unreal|urn|ut2004|vemmi|ventrilo|view-source|webcal|wss?|wtai|wyciwyg|xcon(?:-userid)?|xfire|xmlrpc\.beeps?|xmpp|xri|ymsgr|z39\.50[rs]?):(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]|\([^\s()<>]*\))+(?:\([^\s()<>]*\)|[^\s`*!()[\]{};:'".,<>?«»“”‘’])))|([a-z0-9.\-_+]+?@[a-z0-9.\-_+]+\.[a-z]{2,7})$/i
+  var urlRE = getUrlRE()
   // First capturing group: preceding whitespace. Second cap.: line contents
   // Non-capturing group in the middle: all block elements.
   // Non-capturing group afterwards: catches all whitespace
-  var blockRE = /^(\s*?)(?:#{1,6}|>|\*|\+|-|\d{1,5}\.)(?:\s+)(.*)$/
+  var blockRE = getBlockRE()
 
   /**
    * This function undoes a block formatting and then re-applies another one.

--- a/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
+++ b/source/renderer/modules/markdown-editor/plugins/markdown-shortcuts.js
@@ -18,13 +18,13 @@ const { getListOrderedRE, getListTaskListRE, getListUnorderedCMRE, getUrlRE, get
 })(function (CodeMirror) {
   'use strict'
 
-  var unorderedListRE = getListUnorderedCMRE()
-  var taskListRE = getListTaskListRE()
-  var orderedListRE = getListOrderedRE()
+  const unorderedListRE = getListUnorderedCMRE()
+  const taskListRE = getListTaskListRE()
+  const orderedListRE = getListOrderedRE()
 
   var reservedChars = '+.*_/\\[](){}?^$'.split('')
-  var urlRE = getUrlRE()
-  var blockRE = getBlockRE()
+  const urlRE = getUrlRE()
+  const blockRE = getBlockRE()
 
   /**
    * This function undoes a block formatting and then re-applies another one.

--- a/source/renderer/modules/markdown-editor/plugins/render-citations.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-citations.js
@@ -13,6 +13,7 @@
   'use strict'
 
   const { ipcRenderer } = require('electron')
+  const { getCitationRE } = require('../../../../common/regular-expressions')
 
   // Listen to IPC events to update the citations
   ipcRenderer.on('citation-renderer', (event, message) => {
@@ -45,7 +46,7 @@
   // blocks, second alternative are the simple @ID-things, both recognised by
   // Pandoc citeproc.
   // citationRE is taken from the Citr library (the extraction regex)
-  var citationRE = /(\[(?:[^[\]]*@[^[\]]+)\])|(?<=\s|^)(@[\p{L}\d_][\p{L}\d_:.#$%&\-+?<>~/]*)/gu
+  var citationRE = getCitationRE()
   var Citr = require('@zettlr/citr')
 
   /**

--- a/source/renderer/modules/markdown-editor/plugins/render-citations.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-citations.js
@@ -42,10 +42,6 @@
     }
   })
 
-  // Should match everything permittible -- first alternative are the huge
-  // blocks, second alternative are the simple @ID-things, both recognised by
-  // Pandoc citeproc.
-  // citationRE is taken from the Citr library (the extraction regex)
   var citationRE = getCitationRE()
   var Citr = require('@zettlr/citr')
 

--- a/source/renderer/modules/markdown-editor/plugins/render-h-tags.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-h-tags.js
@@ -1,6 +1,8 @@
 /* global CodeMirror define */
 // This plugin renders Bear-style heading indicators
 
+const { getHeadRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -12,7 +14,7 @@
 })(function (CodeMirror) {
   'use strict'
 
-  var headRE = /^(#{1,6}) (.*)/g
+  var headRE = getHeadRE()
 
   var currentCallback = null
 

--- a/source/renderer/modules/markdown-editor/plugins/render-iframes.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-iframes.js
@@ -1,6 +1,8 @@
 /* global CodeMirror $ define */
 // This plugin renders iFrames in CodeMirror instances
 
+const { getIframeRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -12,7 +14,7 @@
 })(function (CodeMirror) {
   'use strict'
 
-  var iframeRE = /^<iframe.*?>.*?<\/iframe>$/i // Matches all iframes
+  var iframeRE = getIframeRE() // Matches all iframes
 
   CodeMirror.commands.markdownRenderIframes = function (cm) {
     let match

--- a/source/renderer/modules/markdown-editor/plugins/render-math.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-math.js
@@ -1,6 +1,8 @@
 /* global CodeMirror $ define */
 // This plugin renders MathJax parts in CodeMirror instances
 
+const { getBlockMathRE, getInlineMathRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -20,8 +22,8 @@
   // More information: https://pandoc.org/MANUAL.html#math
   // First alternative is only for single-character-equations
   // such as $x$. All others are captured by the second alternative.
-  var inlineMathRE = /(?<!\\)\${1,2}([^\s\\])\${1,2}(?!\d)|(?<!\\)\${1,2}([^\s].*?[^\s\\])\${1,2}(?!\d)/g
-  var multilineMathRE = /^\s*\$\$\s*$/
+  var inlineMathRE = getInlineMathRE()
+  var multilineMathRE = getBlockMathRE()
 
   CodeMirror.commands.markdownRenderMath = function (cm) {
     let match

--- a/source/renderer/modules/markdown-editor/plugins/render-math.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-math.js
@@ -17,12 +17,7 @@ const { getBlockMathRE, getInlineMathRE } = require('../../../../common/regular-
   const katex = require('katex')
   require('katex/dist/contrib/mhchem.js') // modify katex module
 
-  // Matches all inlines according to the Pandoc documentation
-  // on its tex_math_dollars-extension.
-  // More information: https://pandoc.org/MANUAL.html#math
-  // First alternative is only for single-character-equations
-  // such as $x$. All others are captured by the second alternative.
-  var inlineMathRE = getInlineMathRE()
+  var inlineMathRE = getInlineMathRE(true) // Get the RE with the global flag set.
   var multilineMathRE = getBlockMathRE()
 
   CodeMirror.commands.markdownRenderMath = function (cm) {

--- a/source/renderer/modules/markdown-editor/plugins/render-math.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-math.js
@@ -1,7 +1,7 @@
 /* global CodeMirror $ define */
 // This plugin renders MathJax parts in CodeMirror instances
 
-const { getBlockMathRE, getInlineMathRE } = require('../../../../common/regular-expressions');
+const { getBlockMathRE, getInlineMathRenderRE } = require('../../../../common/regular-expressions');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
@@ -17,7 +17,7 @@ const { getBlockMathRE, getInlineMathRE } = require('../../../../common/regular-
   const katex = require('katex')
   require('katex/dist/contrib/mhchem.js') // modify katex module
 
-  var inlineMathRE = getInlineMathRE(true) // Get the RE with the global flag set.
+  var inlineMathRE = getInlineMathRenderRE(true) // Get the RE with the global flag set.
   var multilineMathRE = getBlockMathRE()
 
   CodeMirror.commands.markdownRenderMath = function (cm) {

--- a/source/renderer/modules/markdown-editor/plugins/render-tables.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-tables.js
@@ -1,7 +1,8 @@
 /* global define CodeMirror */
 // This plugin renders markdown tables for easy editability
 
-const TableEditor = require('../../table-editor');
+const TableEditor = require('../../table-editor')
+const { getTableHeadingRE } = require('../../../../common/regular-expressions.js');
 
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
@@ -15,7 +16,7 @@ const TableEditor = require('../../table-editor');
   'use strict'
 
   var tables = []
-  var tableHeadingRE = /(^[- ]+$)|(^[- +:]+$)|(^[- |:+]+$)/
+  var tableHeadingRE = getTableHeadingRE()
 
   CodeMirror.commands.markdownInsertTable = function (cm) {
     // A small command that inserts a 2x2 table at the current cursor position.

--- a/source/renderer/modules/markdown-editor/plugins/render-tasks.js
+++ b/source/renderer/modules/markdown-editor/plugins/render-tasks.js
@@ -1,6 +1,8 @@
 /* global CodeMirror define */
 // This plugin renders GitHub Flavoured Markdown Task items
 
+const { getTaskRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -12,7 +14,7 @@
 })(function (CodeMirror) {
   'use strict'
 
-  var taskRE = /^(\s*)([-+*]) \[( |x)\] /g // Matches `- [ ]` and `- [x]`
+  var taskRE = getTaskRE() // Matches `- [ ]` and `- [x]`
 
   CodeMirror.commands.markdownRenderTasks = function (cm) {
     let match

--- a/source/renderer/modules/markdown-editor/plugins/wysiwyg.js
+++ b/source/renderer/modules/markdown-editor/plugins/wysiwyg.js
@@ -1,6 +1,8 @@
 /* global define CodeMirror */
 // This plugin gives the editor a real WYSIWYG feeling
 
+const { getWysiwygRE } = require('../../../../common/regular-expressions');
+
 (function (mod) {
   if (typeof exports === 'object' && typeof module === 'object') { // CommonJS
     mod(require('codemirror/lib/codemirror'))
@@ -15,7 +17,7 @@
   // Should match everything permittible -- first alternative are the huge
   // blocks, second alternative are the simple @ID-things, both recognised by
   // Pandoc citeproc.
-  var wysiwygRE = /__(.+?)__|_(.+?)_|\*\*(.+?)\*\*|\*(.+?)\*|^(#{1,6}) (.+?)$|^(?:\s*)> (.+)$|`(.+?)`/gi
+  var wysiwygRE = getWysiwygRE()
   /**
    * Match explanation:
    * 1. Underscore strong

--- a/source/renderer/modules/markdown-editor/plugins/wysiwyg.js
+++ b/source/renderer/modules/markdown-editor/plugins/wysiwyg.js
@@ -14,21 +14,7 @@ const { getWysiwygRE } = require('../../../../common/regular-expressions');
 })(function (CodeMirror) {
   'use strict'
 
-  // Should match everything permittible -- first alternative are the huge
-  // blocks, second alternative are the simple @ID-things, both recognised by
-  // Pandoc citeproc.
   var wysiwygRE = getWysiwygRE()
-  /**
-   * Match explanation:
-   * 1. Underscore strong
-   * 2. Underscore emphasis
-   * 3. Asterisk strong
-   * 4. Asterisk emphasis
-   * 5. Heading levels 1-6 (mark)
-   * 6. Heading levels 1-6 (content)
-   * 7. Blockquotes
-   * 8. Inline code
-   */
 
   // WYSIWYG means you need HTML elements rendered instead of
   // the underlying Markdown code


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Moved all of the regexes that I could find to source/common/regular-expressions
## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Regexes removed from source files in favour of calls to functions in source/common/regular-expressions
## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I'm pretty sure that I got all of the regexes, but I'm 100% sure that I missed something with a non-standard name.

I've done my best to keep the names consistent, but where the same RE was called within two different functions I've made a call. 

List RE functions have all been given consistent names.

At some point, it would be a good idea to alphabetise the list of functions in source/common/regular-expressions

I've tested as many of the functions as I can; various syntax highlighting / markup things all seem to be working:

- Lists
- Images
- URLs
- Footnotes
- References

Let me know if you have any feedback; this should make all of the Regexes easier to maintain.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
Gentoo Linux.