### PR TITLE
Added scroll to zoom setting toggle

### DIFF
--- a/resources/templates/dialog/preferences.handlebars
+++ b/resources/templates/dialog/preferences.handlebars
@@ -921,6 +921,13 @@
             </label>
             <label for="system.deleteOnFail">{{i18n "dialog.preferences.delete_on_fail"}}</label>
           </div>
+          <div class="cb-group">
+              <label class="cb-toggle">
+                  <input type="checkbox" name="editor.enableScrollToZoom" value="yes" id="editor.enableScrollToZoom" {{#if editor.enableScrollToZoom}}checked="checked"{{/if}}>
+                  <div class="toggle"></div>
+              </label>
+              <label for="editor.enableScrollToZoom">{{i18n "dialog.preferences.editor_setting.enable_scroll_to_zoom"}}</label>
+          </div>
         </div>
         <div class="box-right">
           <p>{{i18n "dialog.preferences.attachments_info"}}</p>

--- a/source/app/service-providers/config-provider.js
+++ b/source/app/service-providers/config-provider.js
@@ -228,7 +228,8 @@ module.exports = class ConfigProvider extends EventEmitter {
             { key: '--', val: '–' },
             { key: '---', val: '—' }
           ]
-        } // END autoCorrect options
+        }, // END autoCorrect options
+        'enableScrollToZoom': true
       },
       'display': {
         'theme': 'berlin', // The theme, can be berlin|frankfurt|bielefeld|karl-marx-stadt|bordeaux

--- a/source/common/lang/de-DE.json
+++ b/source/common/lang/de-DE.json
@@ -199,7 +199,8 @@
             "editor_setting": {
                 "direction_ltr": "Dokumentenschreibrichtung von links nach rechts (LTR)",
                 "direction_rtl": "Dokumentenschreibrichtung von rechts nach links (RTL)",
-                "rtl_move_visually": "Navigiere visuell mit den Pfeiltasten im RTL-Modus"
+                "rtl_move_visually": "Navigiere visuell mit den Pfeiltasten im RTL-Modus",
+                "enable_scroll_to_zoom" : "Aktivieren Sie den Bildlauf zum Zoomen"
             },
             "enable_rmarkdown": "RMarkdown-Dateisupport aktivieren",
             "enable_table_helper": "Tabelleneditor aktivieren",

--- a/source/common/lang/en-GB.json
+++ b/source/common/lang/en-GB.json
@@ -202,7 +202,8 @@
             "editor_setting": {
                 "direction_ltr": "Use left-to-right (LTR) writing direction",
                 "direction_rtl": "Use right-to-left (RTL) writing direction",
-                "rtl_move_visually": "Use visual order for arrow key movement while in RTL-mode"
+                "rtl_move_visually": "Use visual order for arrow key movement while in RTL-mode",
+                "enable_scroll_to_zoom" : "Enable scroll to zoom"
             },
             "enable_rmarkdown": "Enable RMarkdown file support",
             "enable_table_helper": "Enable Table Editor",

--- a/source/common/lang/en-US.json
+++ b/source/common/lang/en-US.json
@@ -202,7 +202,8 @@
             "editor_setting": {
                 "direction_ltr": "Use left-to-right (LTR) writing direction",
                 "direction_rtl": "Use right-to-left (RTL) writing direction",
-                "rtl_move_visually": "Use visual order for arrow key movement while in RTL-mode"
+                "rtl_move_visually": "Use visual order for arrow key movement while in RTL-mode",
+                "enable_scroll_to_zoom" : "Enable scroll to zoom"
             },
             "enable_rmarkdown": "Enable RMarkdown file support",
             "enable_table_helper": "Enable Table Editor",

--- a/source/common/lang/fr-FR.json
+++ b/source/common/lang/fr-FR.json
@@ -212,7 +212,8 @@
             "editor_setting": {
                 "direction_ltr": "Utiliser la direction d'\u00e9criture de gauche \u00e0 droite (G\u00e0D)",
                 "direction_rtl": "Utiliser la direction d'\u00e9criture de droite \u00e0 gauche (D\u00e0G)",
-                "rtl_move_visually": "Utiliser l'ordre visuel pour le mouvement des touches fl\u00e9ch\u00e9es en mode D\u00e0G"
+                "rtl_move_visually": "Utiliser l'ordre visuel pour le mouvement des touches fl\u00e9ch\u00e9es en mode D\u00e0G",
+                "enable_scroll_to_zoom" : "Activer le d\u00e9filement pour zoomer"
             },
             "enable_rmarkdown": "Utiliser les fichiers RMarkdown",
             "enable_table_helper": "Activer l'\u00e9diteur de tableau",

--- a/source/renderer/dialog/preferences.js
+++ b/source/renderer/dialog/preferences.js
@@ -313,6 +313,7 @@ class PreferencesDialog extends ZettlrDialog {
     cfg['editor.countChars'] = (data.find(elem => elem.name === 'editor.countChars') !== undefined)
     cfg['editor.autoCorrect.active'] = (data.find(elem => elem.name === 'editor.autoCorrect.active') !== undefined)
     cfg['editor.rtlMoveVisually'] = (data.find(elem => elem.name === 'editor.rtlMoveVisually') !== undefined)
+    cfg['editor.enableScrollToZoom'] = (data.find(elem => elem.name === 'editor.enableScrollToZoom') !== undefined)
     cfg['zkn.autoCreateLinkedFiles'] = (data.find(elem => elem.name === 'zkn.autoCreateLinkedFiles') !== undefined)
 
     cfg['watchdog.activatePolling'] = (data.find(elem => elem.name === 'watchdog.activatePolling') !== undefined)

--- a/source/renderer/modules/markdown-editor/hooks/zoom.js
+++ b/source/renderer/modules/markdown-editor/hooks/zoom.js
@@ -1,8 +1,7 @@
 module.exports = (cm) => {
   cm.getWrapperElement().addEventListener('wheel', (e) => {
-    if (
-      (process.platform !== 'darwin' && e.ctrlKey) ||
-      (process.platform === 'darwin' && e.metaKey)
+    if (Boolean(global.config.get('editor.enableScrollToZoom')) &&
+              ((process.platform !== 'darwin' && e.ctrlKey) || (process.platform === 'darwin' && e.metaKey))
     ) {
       // Did you know that pinching events get reported
       // as "wheel" events as well? Me neither.


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
I added a settings toggle that allows to disable the "cmd/ctrl + scroll" zoom behaviour in the editor.
I happen to trigger this accidentally a lot and I saw that someone posted an issue for this ( #1430 ) so I thought I may propose this small enhancement I made in my own version

## Changes
Added:
- the option in the settings menu (in advanced)
- the i18n texts (I used an automatic translation for the german version)
- a check in the zoom hook for the value of the setting
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I don't know how you like to keep the settings organised, I named it "enableScrollToZoom" and put it under "editor".  
As for the toggle itself I put it in advanced section.
Just let me know of the naming / organisation you'd like to see !

<!-- Please provide any testing system -->
Tested on: macos <!-- OS including version --> 
