### PR TITLE
Standalone Template

### DIFF
--- a/source/main/assets/export-beamer.tex
+++ b/source/main/assets/export-beamer.tex
@@ -1,0 +1,483 @@
+% Lackadaisical / Zettlr Beamer Template
+% Use to generate presentations from MarkDown via Pandoc
+% Heavily based on the pandoc default template, but customised for beamer (i.e. removed all if/else statements relating to beamer)
+
+\PassOptionsToPackage{hyphens}{url}
+
+\documentclass[
+$if(fontsize)$
+  $fontsize$,
+$endif$
+$if(papersize)$
+  $papersize$paper,
+$endif$
+  ignorenonframetext,
+$if(handout)$
+  handout,
+$endif$
+$if(aspectratio)$
+  aspectratio=$aspectratio$,
+$endif$
+$for(classoption)$
+  $classoption$$sep$,
+$endfor$
+xcolor={table},]{beamer}
+
+% Background image for each slide.
+$if(background-image)$
+\usebackgroundtemplate{%
+\includegraphics[width=\paperwidth, height=\paperheight]{/working/templates/template_resources/lackadaisical_beamer_background.pdf}%
+$endif$
+}
+
+% Navigation symbols should be suppressed by default, but can be enabled.
+\setbeamercolor{caption name}{fg=normal text.fg}
+\beamertemplatenavigationsymbols$if(navigation)$$navigation$$else$empty$endif$
+$for(beameroption)$
+\setbeameroption{$beameroption$}
+$endfor$
+
+% Set beamer font theme early
+\usefonttheme{serif}
+
+\widowpenalties 1 10000
+\raggedbottom
+
+% Define some colours and then tell beamer to use them.
+\definecolor{blue}{HTML}{0D324D}
+\definecolor{burgandy}{HTML}{880D1E}
+\definecolor{green}{HTML}{6A8E7F}
+\definecolor{white}{RGB}{251,252,255}
+
+\definecolor{foreground}{RGB}{2, 2, 2} % Black
+\definecolor{background}{RGB}{251,252,255} % White
+\definecolor{grey}{RGB}{155,155,155}
+\definecolor{subtitle}{RGB}{102,255,204}
+%\definecolor{hilight}{RGB}{102,255,204}
+%\definecolor{vhilight}{RGB}{255,111,207}
+
+% Titles on every page
+\setbeamercolor{titlelike}{fg=burgandy}
+% Titles witin blocks
+\setbeamercolor{block title}{fg=blue}
+
+% Titlepage items.
+\setbeamercolor{subtitle}{fg=green}
+\setbeamercolor{institute}{fg=grey}
+
+% Body text
+\setbeamercolor{normal text}{fg=foreground,bg=background}
+
+% Lists
+\setbeamercolor{item}{fg=blue} % Bullet colour
+\setbeamercolor{itemize items}{fg=blue}
+\setbeamercolor{subitem}{fg=grey}
+\setbeamercolor{itemize/enumerate subbody}{fg=grey}
+\setbeamertemplate{itemize subitem}{{\textendash}} % Use en-dash for subitems.
+\setbeamerfont{itemize/enumerate subbody}{size=\footnotesize} % make them smaller.
+\setbeamerfont{itemize/enumerate subitem}{size=\footnotesize}
+
+
+$if(section-titles)$
+\setbeamertemplate{part page}{
+  \centering
+  \begin{beamercolorbox}[sep=16pt,center]{part title}
+    \usebeamerfont{part title}\insertpart\par
+  \end{beamercolorbox}
+}
+\setbeamertemplate{section page}{
+  \centering
+  \begin{beamercolorbox}[sep=12pt,center]{part title}
+    \usebeamerfont{section title}\insertsection\par
+  \end{beamercolorbox}
+}
+\setbeamertemplate{subsection page}{
+  \centering
+  \begin{beamercolorbox}[sep=8pt,center]{part title}
+    \usebeamerfont{subsection title}\insertsubsection\par
+  \end{beamercolorbox}
+}
+\AtBeginPart{
+  \frame{\partpage}
+}
+\AtBeginSection{
+  \ifbibliography
+  \else
+    \frame{\sectionpage}
+  \fi
+}
+\AtBeginSubsection{
+  \frame{\subsectionpage}
+}
+$endif$
+
+% ulem is needed for underlining and strikethrough text commands.
+% the option "normalem" is needed to preserve _italics_. Without the option,
+% _italics_ will become underlines, which is not desirable.
+\usepackage[normalem]{ulem}
+
+
+$if(theme)$
+\usetheme[$for(themeoptions)$$themeoptions$$sep$,$endfor$]{$theme$}
+$endif$
+$if(colortheme)$
+\usecolortheme{$colortheme$}
+$endif$
+$if(fonttheme)$
+\usefonttheme{$fonttheme$}
+$endif$
+$if(mainfont)$
+\usefonttheme{serif} % use mainfont rather than sansfont for slide text
+$endif$
+$if(innertheme)$
+\useinnertheme{$innertheme$}
+$endif$
+$if(outertheme)$
+\useoutertheme{$outertheme$}
+$endif$
+
+%
+% Configure Fonts
+%
+
+% fontspec provides an easy interface to XeTeX's font configuration.
+\usepackage{fontspec}
+
+$if(monofont)$
+  \setmonofont{$monofont$}
+$else$
+  \setmonofont{Inconsolata}[Scale=MatchLowercase]
+$endif$
+
+\defaultfontfeatures{ Ligatures=TeX } % This is actually a default option for main and sans font, but applies to all fonts set after this point.
+$if(mainfont)$
+  \setmainfont{$mainfont$}
+$else$
+  \setmainfont[%
+    BoldFont={Noto Sans Bold},
+    ItalicFont={Noto Sans Italic},
+    BoldItalicFont={Noto Sans Bold Italic}
+  ]{Noto Sans}
+    % We can use ucharclasses to setup font transitions based on unicode blocks.
+  \usepackage[CJK, Latin, Mathematics, Malayalam, Thai, Sinhala, Symbols]{ucharclasses}
+
+  \newfontfamily{\cjkfont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\japanesefont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\latinfont}{Noto Sans}
+  \newfontfamily{\malayalamfont}{Noto Sans Malayalam}
+  \newfontfamily{\sinhalafont}{Noto Sans Sinhala}
+  \newfontfamily{\thaifont}{Noto Sans Thai}
+  \newfontfamily{\unifiedCJKfont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\mathsfont}{Noto Sans Math}
+  \newfontfamily{\symbolfont}{Noto Sans Symbols}
+
+
+% We're beginning and ending groups here so that the transition works anywhere.
+% This means that if e.g. a symbol is used within monospaced text that it will return to being monospaced
+% instead of going back to our default\main font!
+
+  \setTransitionsForCJK{\begingroup\cjkfont}{\endgroup}
+  \setTransitionsForJapanese{\begingroup\japanesefont}{\endgroup}
+  \setTransitionsForMathematics{\begingroup\mathsfont}{\endgroup}
+  \setTransitionsForSymbols{\begingroup\symbolfont}{\endgroup}
+
+  \setTransitionFrom{Malayalam}{\endgroup}
+  \setTransitionFrom{Sinhala}{\endgroup}
+  \setTransitionFrom{Thai}{\endgroup}
+  \setTransitionTo{Malayalam}{\begingroup\malayalamfont}
+  \setTransitionTo{Sinhala}{\begingroup\sinhalafont}
+  \setTransitionTo{Thai}{\begingroup\thaifont}
+$endif$
+
+$if(sansfont)$
+  \setsansfont{$sansfont$}
+$else$
+  \setsansfont{Liberation Sans}
+$endif$
+
+
+\usepackage{unicode-math}
+
+%
+% Required for pandoc to generate tables.
+%
+
+$if(tables)$
+  \usepackage{longtable,booktabs,array,caption}
+  % Make caption package work with longtable
+  \makeatletter
+  \def\fnum@table{\tablename~\thetable}
+  \makeatother
+$endif$
+
+$if(table-row-highlighting)$
+  \let\oldtabular\tabular
+  \let\endoldtabular\endtabular
+  \renewenvironment{tabular}{%
+    \rowcolors{2}{green}{}
+    \oldtabular
+  }{\endoldtabular}
+
+  \let\oldlongtable\longtable
+  \let\endoldlongtable\endlongtable
+  \renewenvironment{longtable}{%
+    \rowcolors{2}{green}{}
+    \oldlongtable
+  }{\endoldlongtable}
+$endif$
+
+
+% Pandoc puts lists within \tightlist. We need to provide that command else the conversion will fail.
+\providecommand{\tightlist}{
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+
+\newif\ifbibliography
+
+$if(listings)$
+\usepackage{listings}
+\newcommand{\passthrough}[1]{#1}
+\lstset{defaultdialect=[5.3]Lua}
+\lstset{defaultdialect=[x86masm]Assembler}
+$endif$
+
+$highlighting-macros$
+
+$if(graphics)$
+\usepackage{graphicx}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+$endif$
+
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+
+$if(natbib)$
+\usepackage[$natbiboptions$]{natbib}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
+$endif$
+$if(biblatex)$
+\usepackage[$if(biblio-style)$style=$biblio-style$,$endif$$for(biblatexoptions)$$biblatexoptions$$sep$,$endfor$]{biblatex}
+$for(bibliography)$
+\addbibresource{$bibliography$}
+$endfor$
+$endif$
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+
+% Slide number in lower right
+\definecolor{white}{RGB}{255,255,255}
+\setbeamertemplate{footline}{%
+    \raisebox{5pt}{\makebox[\paperwidth]{\hfill\makebox[20pt]{\color{white}
+          \scriptsize\insertframenumber}}}\hspace*{5pt}}
+
+% Required for title page background. Provides \AddToShipoutPicture
+% We use the PDF for a vector image because XeLaTeX can't determine the SVG width.
+\usepackage[pscoord]{eso-pic}
+\usepackage{calc}
+\newcommand\BackgroundPic{
+    \put(0,0){
+    \parbox[b][\paperheight]{\paperwidth}{%
+    \centering
+    \includegraphics[width=\paperwidth,height=\paperheight]{/working/templates/template_resources/lackadaisical_beamer_title.pdf}
+}}}
+
+%
+% Set metadata & content variables
+%
+
+% PDF metadata, also some other URL
+% options (breaklinks breaks URLs so they aren't ugly)
+%\usepackage[hyphens]{url} % This package breaks links even better
+\usepackage{hyperref}
+\hypersetup{
+unicode=true,
+breaklinks=true,
+colorlinks=true,
+linkcolor=[rgb]{0.00,0.00,0.00},
+urlcolor=[rgb]{0.00,0.00,0.00},
+pdftitle={$title$},
+pdfsubject={$subject$},
+pdfauthor={$author$},
+pdfkeywords={$keywords$},
+pdfproducer={Pandoc and XeLaTeX},
+pdfborder={0 0 0},
+pdfpagemode=UseNone
+}
+
+% Set some content variables.
+\title{$title$}
+$if(author)$
+\author{$author$}
+$endif$
+\subtitle{$subtitle$}
+
+% Set the date (use \today to get date when generated)
+$if(date)$
+\date{$date$}
+$else$
+\date{\today}
+$endif$
+
+%
+% Customise beamer title page
+%
+\defbeamertemplate*{title page}{customised}[1][]
+{
+\AddToShipoutPicture*{\BackgroundPic}
+\mbox{}
+\vfill
+\begin{flushright}\vfill\color{white}
+  \usebeamerfont{date}\insertdate\par
+  \bigskip
+  \usebeamerfont{title}\inserttitle\par
+  %\usebeamerfont{subtitle}\insertsubtitle\par
+\end{flushright}
+}
+
+$if(logo)$
+\logo{\includegraphics{$logo$}}
+$endif$
+
+%
+% Fix Section Headings
+% Hyperref stops hyperlinks from looking bad as content buuuuut
+% It also changes the colour of section titles. Let's stop that happening.
+
+\AtBeginSection[]{
+  \begin{frame}
+  \vfill
+  \centering
+  \begin{beamercolorbox}[sep=8pt,center,shadow=true,rounded=true]{title}
+    \usebeamerfont{title}%
+    \hypersetup{hidelinks}%
+    \insertsectionhead\par%
+  \end{beamercolorbox}
+  \vfill
+  \end{frame}
+}
+
+%
+% DOCUMENT BEGINS HERE
+%
+
+\begin{document}
+$if(has-frontmatter)$
+\frontmatter
+$endif$
+$if(title)$
+\frame{\titlepage}
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+$endif$
+
+$for(include-before)$
+$include-before$
+$endfor$
+
+$if(toc)$
+$if(toc-title)$
+\renewcommand*\contentsname{$toc-title$}
+$endif$
+\begin{frame}[allowframebreaks]
+$if(toc-title)$
+  \frametitle{$toc-title$}
+$endif$
+  \tableofcontents[hideallsubsections]
+\end{frame}
+$endif$
+
+$if(lot)$
+\listoftables
+$endif$
+
+$if(lof)$
+\listoffigures
+$endif$
+
+$if(linestretch)$
+\setstretch{$linestretch$}
+$endif$
+
+$if(has-frontmatter)$
+\mainmatter
+$endif$
+
+$body$
+
+$if(has-frontmatter)$
+\backmatter
+$endif$
+
+$if(natbib)$
+$if(bibliography)$
+$if(biblio-title)$
+$if(has-chapters)$
+\renewcommand\bibname{$biblio-title$}
+$else$
+\renewcommand\refname{$biblio-title$}
+$endif$
+$endif$
+\begin{frame}[allowframebreaks]{$biblio-title$}
+  \bibliographytrue
+  \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+\end{frame}
+
+$endif$
+$endif$
+
+$if(biblatex)$
+\begin{frame}[allowframebreaks]{$biblio-title$}
+  \bibliographytrue
+  \printbibliography[heading=none]
+\end{frame}
+$else$
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+$endif$
+
+$for(include-after)$
+$include-after$
+$endfor$
+
+\end{document}

--- a/source/main/assets/export-beamer.tex
+++ b/source/main/assets/export-beamer.tex
@@ -2,6 +2,16 @@
 % Use to generate presentations from MarkDown via Pandoc
 % Heavily based on the pandoc default template, but customised for beamer (i.e. removed all if/else statements relating to beamer)
 
+% Variables:
+% background-image          String - Path to image to be used as background on every slide.
+% links-as-notes            Boolean - Make links footnotes rather than hyperlinks.
+% navigation                String - Navigation Symbols:
+%                               - default: none
+%                               - Not sure what other values are valid, but they're rarely used!
+% table-row-highlighting    Boolean - Enable alternate row colours.
+% title-page-background     String - Path to image to be used as background on title page.
+% toc-title                 String - Title on the Table of Contents slide. Default: none
+
 \PassOptionsToPackage{hyphens}{url}
 
 \documentclass[
@@ -359,7 +369,7 @@ $else$
 \date{\today}
 $endif$
 
-
+$if(title-page-background)$
 %
 % Customise beamer title page, if it makes sense
 %

--- a/source/main/assets/export-beamer.tex
+++ b/source/main/assets/export-beamer.tex
@@ -26,9 +26,9 @@ xcolor={table},]{beamer}
 % Background image for each slide.
 $if(background-image)$
 \usebackgroundtemplate{%
-\includegraphics[width=\paperwidth, height=\paperheight]{/working/templates/template_resources/lackadaisical_beamer_background.pdf}%
-$endif$
+\includegraphics[width=\paperwidth, height=\paperheight]{$background-image$}%
 }
+$endif$
 
 % Navigation symbols should be suppressed by default, but can be enabled.
 \setbeamercolor{caption name}{fg=normal text.fg}
@@ -309,6 +309,7 @@ $endif$
     \raisebox{5pt}{\makebox[\paperwidth]{\hfill\makebox[20pt]{\color{white}
           \scriptsize\insertframenumber}}}\hspace*{5pt}}
 
+$if(title-page-background)$
 % Required for title page background. Provides \AddToShipoutPicture
 % We use the PDF for a vector image because XeLaTeX can't determine the SVG width.
 \usepackage[pscoord]{eso-pic}
@@ -317,8 +318,9 @@ $endif$
     \put(0,0){
     \parbox[b][\paperheight]{\paperwidth}{%
     \centering
-    \includegraphics[width=\paperwidth,height=\paperheight]{/working/templates/template_resources/lackadaisical_beamer_title.pdf}
+    \includegraphics[width=\paperwidth,height=\paperheight]{$title-page-background$}
 }}}
+$endif$
 
 %
 % Set metadata & content variables
@@ -357,8 +359,9 @@ $else$
 \date{\today}
 $endif$
 
+
 %
-% Customise beamer title page
+% Customise beamer title page, if it makes sense
 %
 \defbeamertemplate*{title page}{customised}[1][]
 {
@@ -372,6 +375,7 @@ $endif$
   %\usebeamerfont{subtitle}\insertsubtitle\par
 \end{flushright}
 }
+$endif$
 
 $if(logo)$
 \logo{\includegraphics{$logo$}}

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -93,7 +93,7 @@ $if(draft)$
 \newcommand\watermark[1]{
   \makebox[0pt][c]{
     \scalebox{3.1}{% scaling
-      \rotatebox[origin=bc]{45}{% rotating
+      \rotatebox[origin=bc]{45}{% rotation
         \Huge\bfseries\textcolor{lightgrey}{% font settings
           \watermarktext}{}
   }}}}
@@ -102,10 +102,13 @@ $if(draft)$
   background,
   %textarea,
   mode=picture,
-  contents={\putC{\watermark{\the\value{page}}}}
+  contents={\putC{\watermark}}
 ]{watermark}
 \AddLayersToPageStyle{@everystyle@}{watermark}
 $endif$
+
+% Lets us show date and time information in local format (if lang is set)
+\usepackage[calc,useregional,showdow]{datetime2}
 
 % These directives are necessary for Pandoc to correctly set the language of the
 % document.
@@ -386,6 +389,19 @@ $endif$
 \xpatchcmd{\@maketitle}{\begin{tabular}[t]{c}}{\begin{tabular}[t]{@{}r@{}}}{}{}
 \makeatother
 
+$if(title-page-background)$
+  \usepackage{eso-pic}
+  \newcommand\BackgroundPic{%
+    \put(0,0){%
+    \parbox[b][\paperheight]{\paperwidth}{%
+      \vfill
+        \centering
+        \includegraphics[width=\paperwidth,height=\paperheight,%
+  keepaspectratio]{$title-page-background$}%
+  \vfill
+  }}}
+$endif$
+
 %
 % Set Variables
 %
@@ -420,6 +436,9 @@ $else$
 $endif$
 
 $if(title-page)$
+  $if(title-page-background)$
+    \AddToShipoutPicture*{\includegraphics[width=\paperwidth,height=\paperheight]{$title-page-background$}} % XeLatex does not like being passed a string here, but hardcoding this value into Zettlr right now is also bad.
+  $endif$
   \maketitle
   \pagebreak
 $endif$

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -61,6 +61,9 @@ $endif$
 
 % Define any colours
 \definecolor{lightgrey}{HTML}{D3D3D3}
+\definecolor{charcoal}{RGB}{56,63,69}
+\definecolor{blue}{RGB}{38,63,126}
+\definecolor{grey}{RGB}{120,128,128}
 
 % These packages are needed by pandoc for certain special glyphs, such as the
 % \square symbol for checkboxes.
@@ -127,7 +130,7 @@ $endif$
 
 \usepackage{geometry}
 % Additional options for geometry can be found here: http://texdoc.net/texmf-dist/doc/latex/geometry/geometry.
-\geometry{verbose,$if(margins)$margin=$margin$$else$margin=2cm$endif$$if(top-margin)$,tmargin=$top-margin$$endif$$if(bottom-margin)$,bmargin=$bottom-margin$$endif$$if(left-margin)$,lmargin=$left_margin$$endif$$if(right-margin)$,rmargin=$right-margin$$endif$}
+\geometry{verbose,$if(page-size)$$page-size$paper,$else$a4paper,$endif$$if(margins)$margin=$margin$$else$margin=2cm$endif$$if(top-margin)$,tmargin=$top-margin$$endif$$if(bottom-margin)$,bmargin=$bottom-margin$$endif$$if(left-margin)$,lmargin=$left_margin$$endif$$if(right-margin)$,rmargin=$right-margin$$endif$}
 
 %
 % Image Handling
@@ -180,7 +183,7 @@ $if(table-row-highlighting)$
   \let\oldlongtable\longtable
   \let\endoldlongtable\endlongtable
   \renewenvironment{longtable}{%
-    \rowcolors{2}{lightgray}{}
+    \rowcolors{2}{lightgrey}{}
     \oldlongtable
   }{\endoldlongtable}
 $endif$
@@ -202,17 +205,12 @@ $if(mainfont)$
   \setmainfont{$mainfont$}
 $else$
   \setmainfont[%
-    BoldFont = Noto Sans Bold,
-    ItalicFont = Noto Sans Italic,
-    BoldItalicFont = Noto Sans Bold Italic
+    BoldFont={Noto Sans Bold},
+    ItalicFont={Noto Sans Italic},
+    BoldItalicFont={Noto Sans Bold Italic}
   ]{Noto Sans}
     % We can use ucharclasses to setup font transitions based on unicode blocks.
   \usepackage[CJK, Latin, Mathematics, Malayalam, Thai, Sinhala, Symbols]{ucharclasses}
-  \newfontfamily{\defaultfont}{Noto Sans}[%
-    BoldFont = Noto Sans Bold,
-    ItalicFont = Noto Sans Italic,
-    BoldItalicFont = Noto Sans Bold Italic
-  ]
 
   \newfontfamily{\cjkfont}{NotoSansCJK-Regular.ttc}
   \newfontfamily{\japanesefont}{NotoSansCJK-Regular.ttc}
@@ -225,17 +223,21 @@ $else$
   \newfontfamily{\symbolfont}{Noto Sans Symbols}
 
 
-  \setTransitionsForCJK{\cjkfont}{\defaultfont}
-  \setTransitionsForJapanese{\japanesefont}{\defaultfont}
-  \setTransitionsForMathematics{\mathsfont}{\defaultfont}
-  \setTransitionsForSymbols{\symbolfont}{\defaultfont}
+% We're beginning and ending groups here so that the transition works anywhere.
+% This means that if e.g. a symbol is used within monospaced text that it will return to being monospaced
+% instead of going back to our default\main font!
 
-  \setTransitionFrom{Malayalam}{\defaultfont}
-  \setTransitionFrom{Sinhala}{\defaultfont}
-  \setTransitionFrom{Thai}{\defaultfont}
-  \setTransitionTo{Malayalam}{\malayalamfont}
-  \setTransitionTo{Sinhala}{\sinhalafont}
-  \setTransitionTo{Thai}{\thaifont}
+  \setTransitionsForCJK{\begingroup\cjkfont}{\endgroup}
+  \setTransitionsForJapanese{\begingroup\japanesefont}{\endgroup}
+  \setTransitionsForMathematics{\begingroup\mathsfont}{\endgroup}
+  \setTransitionsForSymbols{\begingroup\symbolfont}{\endgroup}
+
+  \setTransitionFrom{Malayalam}{\endgroup}
+  \setTransitionFrom{Sinhala}{\endgroup}
+  \setTransitionFrom{Thai}{\endgroup}
+  \setTransitionTo{Malayalam}{\begingroup\malayalamfont}
+  \setTransitionTo{Sinhala}{\begingroup\sinhalafont}
+  \setTransitionTo{Thai}{\begingroup\thaifont}
 $endif$
 
 $if(sansfont)$
@@ -248,6 +250,11 @@ $endif$
 %
 % Setup page content
 %
+
+% Control spacing around enumeration (lists).
+\usepackage{enumitem}
+%The key noitemsep kills the space between items and paragraphs (i.e., itemsep=0pt and parsep=0pt), while nosep kills all vertical spacing.
+\setlist{noitemsep}
 
 % Line spacing
 \usepackage{setspace}
@@ -264,15 +271,17 @@ $if(links-as-notes)$
 $endif$
 
 $if(block-headings)$
-% Make \paragraph and \subparagraph free-standing
-\ifx\paragraph\undefined\else
-  \let\oldparagraph\paragraph
-  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-  \let\oldsubparagraph\subparagraph
-  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
-\fi
+% Make \paragraph and \subparagraph (H4, H5) free-standing
+% Also style the headings so that they stand out. Issue: H4 is bigger than H3 - It should also be redeclared!
+\RedeclareSectionCommand[
+    beforeskip=-10pt plus -2pt minus -1pt,
+    afterskip=1sp plus -1sp minus 1sp,
+    font=\normalfont\bfseries]{paragraph}
+\RedeclareSectionCommand[
+    beforeskip=-10pt plus -2pt minus -1pt,
+    afterskip=1sp plus -1sp minus 1sp,
+    font=\normalfont\scshape,
+    indent=0pt]{subparagraph}
 $endif$
 
 $if(numbersections)$
@@ -284,6 +293,14 @@ $endif$
 $if(pagestyle)$
   \pagestyle{$pagestyle$}
 $endif$
+
+%
+% The Tikz package is unhappy if codeblock line numbers are enabled and forces the build to stop.
+% Let's prevent that.
+
+\makeatletter
+\let\tikz@ensure@dollar@catcode\relax
+\makeatother
 
 %
 % This is where the values can be inserted into the template from metadata.
@@ -365,6 +382,13 @@ $if(csquotes)$
 $endif$
 
 %
+% Style blockquotes so that they're distinct from body text
+%
+
+\usepackage{etoolbox}
+\AtBeginEnvironment{quote}{\color{grey}}
+
+%
 % Header and Footer
 %
 \usepackage{pageslts}
@@ -388,6 +412,9 @@ $endif$
 \xpatchcmd{\@maketitle}{\end{center}}{\end{flushright}}{}{}
 \xpatchcmd{\@maketitle}{\begin{tabular}[t]{c}}{\begin{tabular}[t]{@{}r@{}}}{}{}
 \makeatother
+
+% Change the colour of the subtitle.
+\addtokomafont{subtitle}{\color{lightgrey}}
 
 $if(title-page-background)$
   \usepackage{eso-pic}

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -373,8 +373,8 @@ $endif$
 % Koma-Script safe header and footer options. See scrlayer documentation for more information.
 \clearpairofpagestyles
 \setkomafont{pageheadfoot}{\color{lightgrey}\small}
-\refoot{\theCurrentPage  of \lastpageref*{VeryLastPage}}
-\rofoot{\theCurrentPage  of \lastpageref*{VeryLastPage}}
+\refoot{\theCurrentPage\ of \lastpageref*{VeryLastPage}}
+\rofoot{\theCurrentPage\ of \lastpageref*{VeryLastPage}}
 
 %
 % Title Page

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -121,10 +121,6 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{H} % ensure default position as H (exactly where the figure is in the text)
 
-<<<<<<< HEAD
-% Needed for pandoc's table generation
-\usepackage{longtable, booktabs, array}
-=======
 %
 % Required for pandoc to generate tables.
 %
@@ -140,7 +136,6 @@ $if(tables)$
   \IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
   \makesavenoteenv{longtable}
 $endif$
->>>>>>> 252084d5... First pass at template. Works when appropriate variables are passed via frontmatter.
 
 $if(table-row-highlighting)$
   \let\oldtabular\tabular
@@ -312,13 +307,13 @@ $endif$
 % Header and Footer
 %
 \usepackage{pageslts}
-\addtokomafont{pagenumber}{\color{lightgrey}}
-\renewcommand{\pagemark}{} % Suppress default page mark.
+\renewcommand{\pagemark}{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}} % Suppress default page mark.
 
 % Koma-Script safe header and footer options. See scrlayer documentation for more information.
 \usepackage{scrlayer-scrpage}
-\refoot*{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
-\rofoot*{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
+\clearpairofpagestyles
+\refoot{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
+\rofoot{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
 
 %
 % Title Page
@@ -376,11 +371,11 @@ $if(toc)$
   $if(toc-title)$
     \renewcommand*\contentsname{$toc-title$}
   $endif$
-$else$
-{
-  $if(colorlinks)$
-    \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
-  $endif$
+  $else$
+  {
+    $if(colorlinks)$
+      \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
+    $endif$
   \setcounter{tocdepth}{$toc-depth$}
   \tableofcontents
   }

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -20,6 +20,7 @@
 %
 % page-size - The size of the paper, e.g. a4 (default)
 % title-page - Generate a title page (boolean - if passed at all title page will generate)
+% toc - Generate a TOC?
 % toc-depth - How many heading levels should the TOC show?
 % Can be a number or a koma script variable; https://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/koma-script/doc/scrguien.pdf#desc%3Amaincls.counter.tocdepth
 
@@ -30,20 +31,20 @@
 
 \documentclass[
 $if(page-size)$
-  $page-size$paper,
+  paper=$page-size$,
 $else$
-  a4paper,
+  paper=a4,
 $endif$
 $if(fontsize)$
-  $font-size$,
+  fontsize=$font-size$pt,
 $else$
-  10pt,
+  fontsize=10pt,
 $endif$
 $if(lang)$
   $babel-lang$,
 $endif$
 $if(draft)$
-  draft,
+  draft=true,
 $endif$
   parskip=half
 ]{scrartcl}
@@ -79,8 +80,36 @@ $endif$
 % The nowidow package attempts to prevent line breaks in the middle of paragraphs and lists.
 \usepackage[defaultlines=4,all]{nowidow}
 
+% Enable character protrusion.
+\usepackage{microtype}
+
+% Control of page styles (incl header and footer)
+\usepackage{scrlayer-scrpage}
+
+$if(draft)$
+% Create a custom watermark
+\newcommand\watermarktext{DRAFT}
+
+\newcommand\watermark[1]{
+  \makebox[0pt][c]{
+    \scalebox{3.1}{% scaling
+      \rotatebox[origin=bc]{45}{% rotating
+        \Huge\bfseries\textcolor{lightgrey}{% font settings
+          \watermarktext}{}
+  }}}}
+
+\DeclareLayer[
+  background,
+  %textarea,
+  mode=picture,
+  contents={\putC{\watermark{\the\value{page}}}}
+]{watermark}
+\AddLayersToPageStyle{@everystyle@}{watermark}
+$endif$
+
 % These directives are necessary for Pandoc to correctly set the language of the
 % document.
+% Polyglossia changes the way that some other packages (e.g. bidi) work, so should be loaded late.
 $if(lang)$
   \usepackage{polyglossia}
   \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
@@ -141,9 +170,16 @@ $if(table-row-highlighting)$
   \let\oldtabular\tabular
   \let\endoldtabular\endtabular
   \renewenvironment{tabular}{%
-    \rowcolors{2}{}{lightgrey}
+    \rowcolors{2}{lightgrey}{}
     \oldtabular
   }{\endoldtabular}
+
+  \let\oldlongtable\longtable
+  \let\endoldlongtable\endlongtable
+  \renewenvironment{longtable}{%
+    \rowcolors{2}{lightgray}{}
+    \oldlongtable
+  }{\endoldlongtable}
 $endif$
 
 %
@@ -236,7 +272,29 @@ $if(block-headings)$
 \fi
 $endif$
 
+$if(numbersections)$
+  \setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
+$else$
+  \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+$endif$
+
+$if(pagestyle)$
+  \pagestyle{$pagestyle$}
+$endif$
+
+%
+% This is where the values can be inserted into the template from metadata.
+%
+
+$for(header-includes)$
+  $header-includes$
+$endfor$
+
+%
 % The following commands must be provided for Pandoc to work correctly.
+%
+
+\setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
@@ -307,13 +365,13 @@ $endif$
 % Header and Footer
 %
 \usepackage{pageslts}
-\renewcommand{\pagemark}{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}} % Suppress default page mark.
+\renewcommand{\pagemark}{} % Suppress default page mark.
 
 % Koma-Script safe header and footer options. See scrlayer documentation for more information.
-\usepackage{scrlayer-scrpage}
 \clearpairofpagestyles
-\refoot{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
-\rofoot{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
+\setkomafont{pageheadfoot}{\color{lightgrey}\small}
+\refoot{\theCurrentPage  of \lastpageref*{VeryLastPage}}
+\rofoot{\theCurrentPage  of \lastpageref*{VeryLastPage}}
 
 %
 % Title Page
@@ -371,11 +429,11 @@ $if(toc)$
   $if(toc-title)$
     \renewcommand*\contentsname{$toc-title$}
   $endif$
-  $else$
-  {
-    $if(colorlinks)$
-      \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
-    $endif$
+$else$
+{
+  $if(colorlinks)$
+    \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
+  $endif$
   \setcounter{tocdepth}{$toc-depth$}
   \tableofcontents
   }

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -1,57 +1,112 @@
-% Barebone template for use with Zettlr exporting engine
+% XeLaTeX template for Lackadaisical\Zettlr
+% Based on the pandoc default template.
 
-% We have to use KOMA classes (scrartcl instead of article and scrreprt instead of report as well as scrbook instead of book)
-% More info: https://ctan.org/pkg/koma-script?lang=de
+% Variables/Metadata:
+% block-subheadings - \paragraph and \subparagraph headings not typset as inline.
+% draft: Enable draft mode for document class & insert 'DRAFT' watermark.
+% font:
+%   fontsize - Base font size.
+%   mainfont - Body font
+%   sansfont - Heading font
+%   monofont - Monospaced font
+% line-spacing - The line spacing. 1.2 = 120%
+% links-as-notes - Turns hyperlinks into footnotes instead of making them clickable.
+% margin - Set all margins (cm, in, pt)
+% *-margin - Set the value (cm, in, pt) for:
+%   top-margin
+%   bottom-margin
+%   left-margin
+%   right-margin
+%
+% page-size - The size of the paper, e.g. a4 (default)
+% title-page - Generate a title page (boolean - if passed at all title page will generate)
+% toc-depth - How many heading levels should the TOC show?
+% Can be a number or a koma script variable; https://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/koma-script/doc/scrguien.pdf#desc%3Amaincls.counter.tocdepth
+
+% We use KOMA classes
+% More info: https://ctan.org/pkg/koma-script?lang=en
+
+\PassOptionsToPackage{table,dvipsnames,svgnames*,x11names*}{xcolor}
+
 \documentclass[
-$FONT_SIZE$,
+$if(page-size)$
+  $page-size$paper,
+$else$
+  a4paper,
+$endif$
+$if(fontsize)$
+  $font-size$,
+$else$
+  10pt,
+$endif$
 $if(lang)$
   $babel-lang$,
 $endif$
+$if(draft)$
+  draft,
+$endif$
+  parskip=half
 ]{scrartcl}
+
+%
+% Early package loading
+%
 
 % The following packages are needed for the combined use of Pandoc and XeTeX engine
 \usepackage{fontspec,xltxtra,xunicode}
 
-% These directives are necessary for Pandoc to correctly set the language of the
-% document. If the user uses XeLaTeX (the default for Zettlr), it will use
-% polyglossia, else it will use babel. We've simply copied that from the default
-% template -- thanks to the Pandoc community at this point!
-$if(lang)$
-\ifxetex
-  \usepackage{polyglossia}
-  \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
-$for(polyglossia-otherlangs)$
-  \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
-$endfor$
-\else
-  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
-\fi
-$endif$
+% Calc is needed to compute the image width (to prevent up-scaling of small images)
+\usepackage{xcolor, graphics, calc}
 
-% Captions for tables and images
-\usepackage{caption}
-\captionsetup{format=plain, font=small, labelfont=bf}
-
-% This package is needed for better rendering of images (including captions)
-\usepackage{graphicx}
+% Define any colours
+\definecolor{lightgrey}{HTML}{D3D3D3}
 
 % These packages are needed by pandoc for certain special glyphs, such as the
 % \square symbol for checkboxes.
 \usepackage{amssymb,amsmath}
 
-% Calc is needed to compute the image width (to prevent up-scaling of small images)
-\usepackage{calc}
+% Captions for tables and images
+\usepackage[format=plain, font=small, labelfont=bf]{caption}
+
+% This package is needed for better rendering of images (including captions)
+\usepackage{graphicx}
 
 % ulem is needed for underlining and strikethrough text commands.
 % the option "normalem" is needed to preserve _italics_. Without the option,
 % _italics_ will become underlines, which is not desirable.
 \usepackage[normalem]{ulem}
 
+% The nowidow package attempts to prevent line breaks in the middle of paragraphs and lists.
+\usepackage[defaultlines=4,all]{nowidow}
+
+% These directives are necessary for Pandoc to correctly set the language of the
+% document.
+$if(lang)$
+  \usepackage{polyglossia}
+  \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
+  $for(polyglossia-otherlangs)$
+    \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
+  $endfor$
+$endif$
+
+%
+% Configure page margins
+%
+
+\usepackage{geometry}
+% Additional options for geometry can be found here: http://texdoc.net/texmf-dist/doc/latex/geometry/geometry.
+\geometry{verbose,$if(margins)$margin=$margin$$else$margin=2cm$endif$$if(top-margin)$,tmargin=$top-margin$$endif$$if(bottom-margin)$,bmargin=$bottom-margin$$endif$$if(left-margin)$,lmargin=$left_margin$$endif$$if(right-margin)$,rmargin=$right-margin$$endif$}
+
+%
+% Image Handling
+%
+
 % Image scaling code from pandoc default.latex template
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
 \makeatother
+
 % Scale images if necessary, so that they will not overflow the page
 % margins by default, and it is still possible to overwrite the defaults
 % using explicit options in \includegraphics[width, height, ...]{}
@@ -63,31 +118,137 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{H} % ensure default position as H (exactly where the figure is in the text)
 
+<<<<<<< HEAD
 % Needed for pandoc's table generation
 \usepackage{longtable, booktabs, array}
+=======
+%
+% Required for pandoc to generate tables.
+%
 
-% Optional packages that Zettlr makes use of
-% fontspec is used to set the different fonts to the user's whishes
-\setmainfont{$MAIN_FONT$}
-\setsansfont{$SANS_FONT$}
+$if(tables)$
+  \usepackage{longtable,booktabs,array}
+  % Correct order of tables after \paragraph or \subparagraph
+  \usepackage{etoolbox}
+  \makeatletter
+  \patchcmd\longtable{\par}{\if@noskipsec\mbox{}\fi\par}{}{}
+  \makeatother
+  % Allow footnotes in longtable head/foot
+  \IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
+  \makesavenoteenv{longtable}
+$endif$
+>>>>>>> 252084d5... First pass at template. Works when appropriate variables are passed via frontmatter.
 
-% With geometry we can let the user decide on the margin
-\usepackage{geometry}
-% Additional options for geometry can be found here: http://texdoc.net/texmf-dist/doc/latex/geometry/geometry.pdf
-\geometry{verbose,$PAPER_TYPE$,tmargin=$TOP_MARGIN$,bmargin=$BOTTOM_MARGIN$,lmargin=$LEFT_MARGIN$,rmargin=$RIGHT_MARGIN$}
+$if(table-row-highlighting)$
+  \let\oldtabular\tabular
+  \let\endoldtabular\endtabular
+  \renewenvironment{tabular}{%
+    \rowcolors{2}{}{lightgrey}
+    \oldtabular
+  }{\endoldtabular}
+$endif$
 
-% PAGE NUMBERING OPTIONS: https://de.sharelatex.com/learn/Page_numbering
-\pagenumbering{$PAGE_NUMBERING$}
+%
+% Configure Fonts
+%
+
+% fontspec provides an easy interface to XeTeX's font configuration.
+
+$if(monofont)$
+  \setmonofont{$monofont$}
+$else$
+  \setmonofont{Inconsolata}[Scale=MatchLowercase]
+$endif$
+
+\defaultfontfeatures{ Ligatures=TeX } % This is actually a default option for main and sans font, but applies to all fonts set after this point.
+$if(mainfont)$
+  \setmainfont{$mainfont$}
+$else$
+  \setmainfont[%
+    BoldFont = Noto Sans Bold,
+    ItalicFont = Noto Sans Italic,
+    BoldItalicFont = Noto Sans Bold Italic
+  ]{Noto Sans}
+    % We can use ucharclasses to setup font transitions based on unicode blocks.
+  \usepackage[CJK, Latin, Mathematics, Malayalam, Thai, Sinhala, Symbols]{ucharclasses}
+  \newfontfamily{\defaultfont}{Noto Sans}[%
+    BoldFont = Noto Sans Bold,
+    ItalicFont = Noto Sans Italic,
+    BoldItalicFont = Noto Sans Bold Italic
+  ]
+
+  \newfontfamily{\cjkfont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\japanesefont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\latinfont}{Noto Sans}
+  \newfontfamily{\malayalamfont}{Noto Sans Malayalam}
+  \newfontfamily{\sinhalafont}{Noto Sans Sinhala}
+  \newfontfamily{\thaifont}{Noto Sans Thai}
+  \newfontfamily{\unifiedCJKfont}{NotoSansCJK-Regular.ttc}
+  \newfontfamily{\mathsfont}{Noto Sans Math}
+  \newfontfamily{\symbolfont}{Noto Sans Symbols}
+
+
+  \setTransitionsForCJK{\cjkfont}{\defaultfont}
+  \setTransitionsForJapanese{\japanesefont}{\defaultfont}
+  \setTransitionsForMathematics{\mathsfont}{\defaultfont}
+  \setTransitionsForSymbols{\symbolfont}{\defaultfont}
+
+  \setTransitionFrom{Malayalam}{\defaultfont}
+  \setTransitionFrom{Sinhala}{\defaultfont}
+  \setTransitionFrom{Thai}{\defaultfont}
+  \setTransitionTo{Malayalam}{\malayalamfont}
+  \setTransitionTo{Sinhala}{\sinhalafont}
+  \setTransitionTo{Thai}{\thaifont}
+$endif$
+
+$if(sansfont)$
+  \setsansfont{$sansfont$}
+$else$
+  \setsansfont{Liberation Sans}
+$endif$
+
+
+%
+% Setup page content
+%
 
 % Line spacing
 \usepackage{setspace}
-
 % Can be a multiple of 1 (i.e. 1.5 for 150 percent)
-\setstretch{$LINE_SPACING$}
+$if(line-spacing)$
+  \setstretch{$line-spacing$}
+$else$
+  \setstretch{1.2}
+$endif$
 
-% PDF metadata generated by Zettlr or given by the user, also some other URL
-% options (breaklinks breaks URLs so they aren't ugly)
-\usepackage[hyphens]{url} % This package breaks links even better
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+
+$if(block-headings)$
+% Make \paragraph and \subparagraph free-standing
+\ifx\paragraph\undefined\else
+  \let\oldparagraph\paragraph
+  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
+  \let\oldsubparagraph\subparagraph
+  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
+$endif$
+
+% The following commands must be provided for Pandoc to work correctly.
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+
+%
+% Configure PDF metadata
+%
+
+% hypens breaks URLs so they aren't ugly
+\usepackage[hyphens]{url}
 \usepackage{hyperref}
 \hypersetup{
 unicode=true,
@@ -95,27 +256,25 @@ breaklinks=true,
 colorlinks=true,
 linkcolor=[rgb]{0.00,0.00,0.00},
 urlcolor=[rgb]{0.00,0.00,0.00},
-pdftitle={$PDF_TITLE$},
-pdfsubject={$PDF_SUBJECT$},
-pdfauthor={$PDF_AUTHOR$},
-pdfkeywords={$PDF_KEYWORDS$},
+pdftitle={$title$},
+pdfsubject={$subject$},
+pdfauthor={$author$},
+pdfkeywords={$keywords$},
 pdfproducer={Zettlr with Pandoc and XeLaTeX},
 pdfborder={0 0 0}
 }
 
-% Setup pandoc code highlighting
-% pandoc uses an if statement, but until we have code
-% to enable or disable highlighting we'll ignore that.
+%
+% Setup pandoc code highlighting environment
+%
 
-$highlighting-macros$
+$if(highlighting-macros)$
+  $highlighting-macros$
+$endif$
 
-
-% Set the date (either \today or a date from the frontmatter)
-\date{$PDF_DATE$}
-
-% The following commands must be provided for Pandoc to work correctly.
-\providecommand{\tightlist}{%
-  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+%
+% References
+%
 
 % The following commands are used by Pandoc if a CSL bibliography is present
 % to create proper indentation, especially for styles with hanging indentation.
@@ -142,16 +301,89 @@ $if(csl-refs)$
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 
-\title{$PDF_TITLE$}
-\author{$PDF_AUTHOR$}
+$if(csquotes)$
+\usepackage{csquotes}
+$endif$
+
+%
+% Header and Footer
+%
+\usepackage{pageslts}
+\addtokomafont{pagenumber}{\color{lightgrey}}
+\renewcommand{\pagemark}{} % Suppress default page mark.
+
+% Koma-Script safe header and footer options. See scrlayer documentation for more information.
+\usepackage{scrlayer-scrpage}
+\refoot*{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
+\rofoot*{\begin{flushright}\color{lightgrey}\theCurrentPage of \lastpageref*{VeryLastPage}\end{flushright}}
+
+%
+% Title Page
+%
+
+% KOMA classes use a table to align the title page content.
+% We can patch it to be right-aligned rather than centred.
+\usepackage{xpatch}
+\makeatletter
+\xpatchcmd{\@maketitle}{\begin{center}}{\begin{flushright}}{}{}
+\xpatchcmd{\@maketitle}{\end{center}}{\end{flushright}}{}{}
+\xpatchcmd{\@maketitle}{\begin{tabular}[t]{c}}{\begin{tabular}[t]{@{}r@{}}}{}{}
+\makeatother
+
+%
+% Set Variables
+%
+
+$if(title)$
+  \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+$endif$
+
+$if(subtitle)$
+  \subtitle{$subtitle$}
+$endif$
+
+\author{$for(author)$$author$$sep$ \and $endfor$}
+
+$if(logo)$
+  \logo{\includegraphics{$logo$}}
+$endif$
+
+% Set the date (either \today or a date from the frontmatter)
+$if(date)$
+  \date{$date$}
+$else$
+  \date{\today}
+$endif$
 
 \begin{document}
+% PAGE NUMBERING OPTIONS: https://de.sharelatex.com/learn/Page_numbering
+$if(page-numbering)$
+  \pagenumbering{$page-numbering$}
+$else$
+  \pagenumbering{arabic}
+$endif$
 
-% Title page?
-$TITLEPAGE$
+$if(title-page)$
+  \maketitle
+  \pagebreak
+$endif$
 
 % Generate a table of contents?
-$GENERATE_TOC$
+$if(toc)$
+  $if(toc-title)$
+    \renewcommand*\contentsname{$toc-title$}
+  $endif$
+$else$
+{
+  $if(colorlinks)$
+    \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
+  $endif$
+  \setcounter{tocdepth}{$toc-depth$}
+  \tableofcontents
+  }
+  \pagebreak
+$endif$
+
 
 % LIST OF TABLES?
 $if(lot)$

--- a/source/main/assets/export.tex
+++ b/source/main/assets/export.tex
@@ -112,9 +112,12 @@ $endif$
 % using explicit options in \includegraphics[width, height, ...]{}
 \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 
-% Now we also have to make sure that the figures Pandoc inserts are positioned
-% approximately where they are at. Therefore we have to overwrite the
-% \begin{figure} command a little bit by using the float package:
+% We use the float package to configure figure placement.
+% while pandoc uses \def\fps@figure{htbp} where h=here t=top b=bottom p=somewhere on page
+% The float package attempts to position the float where we've put it, rather than where LaTeX thinks it should go.
+% Available float styles \floatstyle: plain (default), plaintop, bottom, ruled
+% For more info: https://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/float/float.pdf
+
 \usepackage{float}
 \floatplacement{figure}{H} % ensure default position as H (exactly where the figure is in the text)
 


### PR DESCRIPTION
This works with the tutorial directory and the following frontmatter:

```yaml
---
title: "Pandoc and LaTeX Guide"
author:
  - The Zettlr Team
date: 2020-06-23
keywords:
  - Zettlr
  - Tutorial
subject: Zettlr Tutorial

title-page: true
block-subheadings: true
table-row-highlighting: true

---
```
You'll find that the title (etc) is overwritten because pandoc processes every YAML block that it encounters in order, but it provides a good example of what can be done. Most characters *should* work, but I haven't tested much other than latin characters and a few symbols at this point.

The default fonts for LaTeX export have been changed to Noto Sans (and variants) for mainfont (mostly to get glyph coverage), and Liberation Sans for headings. I've used Inconsolata (you will need v [2.0](https://github.com/googlefonts/Inconsolata/releases/tag/v2.012) for XeTeX) for the monotype font.

The template is pretty configurable, check out the comment block at the top - Some of the variables in the example yaml block are optional, but Title, Author, Date, and Keywords are not.

Some things aren't working yet, like for some reason the table row highlighting (that I've implemented so many times) and the footer page numbering. I figure that this is enough of a start to get some feedback on.

I've done my best to document what each option does, so that users can easily customise to suit their tastes.

Todo: 

- [x] Create a vector background image that can be optionally enabled to make the titlepage a little more flashy.
- [x] Draft flag implementation - should put the documentclass into `draft` mode and put a 'draft' watermark across each page. 
- [x] Fine Tune Image Placement (Zettlr differs from the pandoc default template, and I'm not sure why).
- [x] Fix Footer
- [x] Fix Table Row Highlighting (should alternate grey and white/transparent rows when enabled)

I note that pandoc on my system is broken and I've been using a docker-based pipeline to do my builds. The template does work. It may not work with Zettlr (yet), though I can't see any reason that it shouldn't.
