### PR TITLE
Always set global search field query on Ctrl+Shift+F

### DIFF
--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -251,7 +251,7 @@ class ZettlrRendererIPC {
 
       // TODO: What the heck is that a kind of "name"?
       case 'dir-find':
-        // User wants to search in current directory.
+      // User wants to search in current directory.
         this._app.getToolbar().focusSearch()
         break
 

--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -251,8 +251,13 @@ class ZettlrRendererIPC {
 
       // TODO: What the heck is that a kind of "name"?
       case 'dir-find':
-      // User wants to search in current directory.
-        this._app.getToolbar().focusSearch()
+        // User wants to search in current directory.
+        let query = ""
+        let selections = this._app.getEditor().getSelections()
+        if (selections.length > 0) {
+          query = selections[0]
+        }
+        this._app.getToolbar().focusSearch(query)
         break
 
       case 'workspace-open':

--- a/source/renderer/zettlr-rendereripc.js
+++ b/source/renderer/zettlr-rendereripc.js
@@ -252,12 +252,7 @@ class ZettlrRendererIPC {
       // TODO: What the heck is that a kind of "name"?
       case 'dir-find':
         // User wants to search in current directory.
-        let query = ""
-        let selections = this._app.getEditor().getSelections()
-        if (selections.length > 0) {
-          query = selections[0]
-        }
-        this._app.getToolbar().focusSearch(query)
+        this._app.getToolbar().focusSearch()
         break
 
       case 'workspace-open':

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -493,6 +493,7 @@ class ZettlrToolbar {
     * @return {ZettlrToolbar} Chainability.
     */
   focusSearch () {
+    // Let's prefill this with the selection from the editor if possible.
     let query = this._renderer.getEditor().getSelections().pop()
     this.searchBarInput.value = query
     this.searchBarInput.focus()

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -223,14 +223,7 @@ class ZettlrToolbar {
 
     this.searchBarInput.addEventListener('focus', () => {
       this._autocomplete = this._renderer.getFilesInDirectory()
-      if (this.searchBarInput.value === '') {
-        // Let's prefill this with the selection from the editor if possible.
-        let selections = this._renderer.getEditor().getSelections()
-        if (selections.length > 0) {
-          this.searchBarInput.value = selections[0]
-          this.searchBarInput.select() // Ease of access
-        }
-      }
+      this.searchBarInput.select() // Ease of access
     })
 
     this.searchBarInput.addEventListener('blur', () => {
@@ -499,7 +492,10 @@ class ZettlrToolbar {
     * Focuses the search area
     * @return {ZettlrToolbar} Chainability.
     */
-  focusSearch () {
+  focusSearch (query) {
+    if (query !== undefined) {
+      this.searchBarInput.value = query
+    }
     this.searchBarInput.focus()
     this.searchBarInput.select()
     return this

--- a/source/renderer/zettlr-toolbar.js
+++ b/source/renderer/zettlr-toolbar.js
@@ -492,10 +492,9 @@ class ZettlrToolbar {
     * Focuses the search area
     * @return {ZettlrToolbar} Chainability.
     */
-  focusSearch (query) {
-    if (query !== undefined) {
-      this.searchBarInput.value = query
-    }
+  focusSearch () {
+    let query = this._renderer.getEditor().getSelections().pop()
+    this.searchBarInput.value = query
     this.searchBarInput.focus()
     this.searchBarInput.select()
     return this


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

When pressing Cmd/Ctrl+Shift+F, the search field was previously filled with the selected text, but _only if empty_.

This change overwrites the search field with the selected text _every time_.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

Move the getSelections() call from onfocus handler to menu item command. This means that you can click the search field with the mouse, and the contents will _not_ be replaced, only selected.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Fixes #1346, replaces #1347

<!-- Please provide any testing system -->
Tested on: Windows 10