### PR TITLE
Fixes 1622 - Prevent file from getting deleted if renamed as itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ No 32 bit builds are now available anymore. Only 64 bit (Intel and ARM) are supp
 - 32 bit AppImages and Windows are no longer supported.
 - Removed the Pandoc installation item from the help menu.
 - Moved the Pandoc and XeLaTeX settings to the export tab in preferences.
+- Fixed a bug that would delete file if it got renamed as itself
 
 ## Under the Hood
 

--- a/source/main/commands/file-rename.ts
+++ b/source/main/commands/file-rename.ts
@@ -49,7 +49,7 @@ export default class FileRename extends ZettlrCommand {
     // Test if we are about to override a file
     const dir = file.parent
     let found = dir?.children.find(e => e.name.toLowerCase() === newName.toLowerCase())
-    if (found !== undefined && found.type !== 'directory') {
+    if (found !== undefined && found.type !== 'directory' && file.name !== found.name) {
       // Ask for override
       if (!await this._app.shouldOverwriteFile(newName)) {
         return // No override wanted

--- a/source/main/commands/file-rename.ts
+++ b/source/main/commands/file-rename.ts
@@ -49,7 +49,7 @@ export default class FileRename extends ZettlrCommand {
     // Test if we are about to override a file
     const dir = file.parent
     let found = dir?.children.find(e => e.name.toLowerCase() === newName.toLowerCase())
-    if (found !== undefined && found.type !== 'directory' && file.name !== found.name) {
+    if (found !== undefined && found.type !== 'directory' && file !== found) {
       // Ask for override
       if (!await this._app.shouldOverwriteFile(newName)) {
         return // No override wanted


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

As illustrated in issue #1622 when renaming a file as itself (or as itself with a different capitalization) it gets deleted. 

This PR aimes at fixing this exact issue.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

This PR adds a condition to ensure that the original file (the one which is getting renamed) isn't counted (and found) as file that needs to be overwritten/deleted (to make "space" for the renamed file). 

In doing so it preserves the original file, thus allowing any file to be renamed as itself (or as itself with a different capitalization).

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

This approach should work on Linux (or any other OS with a case-sensitive File System). 

To roughly test this I made the Zettlr workspace folder case-sensitive (using `fsutil.exe file setCaseSensitiveInfo "path" enable`) and didn't encounter any issues.

Sadly, I was not able to run the mocha tests (using `yarn test`) even on the master branch. Therefore, more testing is obviously required (especially on Linux/OSX).

<!-- Please provide any testing system -->
Tested on: Microsoft Windows 10 Pro (version 10.0.18363) 
