### PR TITLE
Correct bcp47 import. Issue #1851

### DIFF
--- a/source/app/service-providers/assets/get-config-template.ts
+++ b/source/app/service-providers/assets/get-config-template.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import bcp47 from 'bcp-47'
+import * as bcp47 from 'bcp-47'
 import { v4 as uuid4 } from 'uuid'
 import { getLanguageFile } from '../../../common/i18n'
 


### PR DESCRIPTION
  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
     - There are lint errors, but not due to my change
  - [ ] **N/A** I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

## Description
Correct bcp47 import that prevents Zettlr from running. Fixes Issue #1851

## Changes
Correct bcp47 import 

## Additional information

Tested on: Windows 10, Fedora 33
