### PR TITLE
Fix the whitespace removal issue in HTML-to-MD

### DIFF
--- a/source/common/util/html-to-md.js
+++ b/source/common/util/html-to-md.js
@@ -5,7 +5,16 @@ const turndownGfm = require('joplin-turndown-plugin-gfm')
 // HTML to Markdown conversion is better done with Turndown.
 const converter = new Turndown({
   headingStyle: 'atx',
-  hr: '---'
+  hr: '---',
+  blankReplacement: function (content, node) {
+    // A workaround solution for the whitespace deletion issue when copying HTML content
+    // from Chromium-based browsers. This method extends the default blankReplacement 
+    // rule of Joplin-Turndown, all '<span> </span>' will not be replaced.
+    if (node.nodeName === 'SPAN'){
+      return ' ';
+    }
+    return node.isBlock ? '\n\n' : ''
+  }
 })
 
 // Switch to GithubFlavored Markdown

--- a/source/common/util/html-to-md.js
+++ b/source/common/util/html-to-md.js
@@ -8,10 +8,10 @@ const converter = new Turndown({
   hr: '---',
   blankReplacement: function (content, node) {
     // A workaround solution for the whitespace deletion issue when copying HTML content
-    // from Chromium-based browsers. This method extends the default blankReplacement 
+    // from Chromium-based browsers. This method extends the default blankReplacement
     // rule of Joplin-Turndown, all '<span> </span>' will not be replaced.
-    if (node.nodeName === 'SPAN'){
-      return ' ';
+    if (node.nodeName === 'SPAN') {
+      return ' '
     }
     return node.isBlock ? '\n\n' : ''
   }


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below. 

But, most importantly, please make sure you can say "I did so!" to the
following points: 

  - [ ] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

This is a change is for a known whitespace removal bug. (#1937)

It can help to fix the problem that Joplin-Turndown will removed whitespaces around some specified tags like `<code>`. This change can provide workaround solution for Zettlr users until Joplin-Turndown delivered a permanent fix.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

- Updated `/source/common/util/html-to-md.js` to extend the `blankReplacement` rule of Joplin-Turndown.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: 

<!-- OS including version -->

**OS**: Mac OS 10.15

**Browser**: 

- Chrome 89
- Firefox 88.0
- Safari 13.1

**Test Webpages**:

- https://guides.github.com/features/mastering-markdown/
- http://spark.apache.org/docs/latest/rdd-programming-guide.html
