### PR TITLE
Re-enable global search when following ZKN links

### DIFF
--- a/source/win-main/Editor.vue
+++ b/source/win-main/Editor.vue
@@ -408,7 +408,7 @@ export default {
         .catch(err => console.error(err))
 
       if (global.config.get('zkn.autoSearch')) {
-        this.$root.$emit('start-global-search', linkContents)      
+        this.$root.$emit('start-global-search', linkContents)
       }
     })
     this.editor.on('zettelkasten-tag', (tag) => {

--- a/source/win-main/Editor.vue
+++ b/source/win-main/Editor.vue
@@ -406,6 +406,10 @@ export default {
         payload: linkContents
       })
         .catch(err => console.error(err))
+
+      if (global.config.get('zkn.autoSearch')) {
+        this.$root.$emit('start-global-search', linkContents)      
+      }
     })
     this.editor.on('zettelkasten-tag', (tag) => {
       this.$root.$emit('start-global-search', tag)


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
This PR addresses #1989.

## Changes
In `Editor.vue`, where the `zettelkasten-link` event is handled, additionally start a global search (provided the user has enabled this behaviour in the settings).

## Additional Info
I haven't added the fix to the CHANGELOG yet, shall I do it?

---

<!-- Please provide any testing system -->
**Tested on**: Manjaro Linux
