### PR TITLE
issue#1672: Fast new file and edit file by select filename without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ A few years ago we implemented auto-saving after a delay of five seconds with no
 - All windows will now remember their last position (new: log window and print window).
 - Some components of the renderer elements will now respect a given accent colour set by your operating system (only available for macOS and Windows).
 - You can now close files by middle-clicking their tabs.
-- New File and Edit File can now fast rename without select the type suffix
+- New File and Edit File can now fast rename without selecting the extension
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ A few years ago we implemented auto-saving after a delay of five seconds with no
 - All windows will now remember their last position (new: log window and print window).
 - Some components of the renderer elements will now respect a given accent colour set by your operating system (only available for macOS and Windows).
 - You can now close files by middle-clicking their tabs.
+- New File and Edit File can now fast rename without select the type suffix
 
 ## Under the Hood
 

--- a/source/win-main/file-manager/file-item-mock.vue
+++ b/source/win-main/file-manager/file-item-mock.vue
@@ -68,7 +68,11 @@ export default {
   methods: {
     focusInput: function () {
       this.$refs['name-input'].focus()
-      this.$refs['name-input'].select()
+      // Select from the beginning until the last dot
+      this.$refs['name-input'].setSelectionRange(
+        0,
+        this.$refs['name-input'].value.lastIndexOf('.')
+      )
     }
   }
 }

--- a/source/win-main/file-manager/tree-item.vue
+++ b/source/win-main/file-manager/tree-item.vue
@@ -265,7 +265,11 @@ export default {
             this.$refs['new-object-input'].value = generateFilename()
           }
           this.$refs['new-object-input'].focus()
-          this.$refs['new-object-input'].select()
+          // Select from the beginning until the last dot
+          this.$refs['new-object-input'].setSelectionRange(
+            0,
+            this.$refs['new-object-input'].value.lastIndexOf('.')
+          )
         })
       }
     }

--- a/source/win-main/file-manager/util/item-mixin.js
+++ b/source/win-main/file-manager/util/item-mixin.js
@@ -33,7 +33,11 @@ export default {
 
       this.$nextTick(() => {
         this.$refs['name-editing-input'].focus()
-        this.$refs['name-editing-input'].select()
+        // Select from the beginning until the last dot
+        this.$refs['name-editing-input'].setSelectionRange(
+          0,
+          this.$refs['name-editing-input'].value.lastIndexOf('.')
+        )
       })
     }
   },


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ X] I documented all behaviour as far as I could do.
  - [X ] I target the develop-branch, and *not* the master branch.
  - [ X] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ X] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ X] I have added an entry to the CHANGELOG.md.
  - [ X] I matched my code-style to the repository (as far as possible).
  - [ X] I do agree that my code will be published under the GNU GPL v3 license.
  - [X ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ X] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
New File and Edit File can now fast rename without selecting the extension

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Replaced [HTMLInputElement.select()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select) by [HTMLInputElement.setSelectionRange(start, end)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange)

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
mac-arm big sur 11.2.3
mac-x64 by rosetta-2 big sur 11.2.3
mac-x64 bir sur 11.3.1 (20E241)
win-x64 1909
linux-x64 ubuntu 20.04 
and Chrome supports the HTMLInputElement.setSelectionRange(start, end) since v33