### PR TITLE
Stop marking correct uses of quotation marks as misspelled words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The Custom CSS can now be edited directly in the assets dialog where you can als
 - MDX supported as a type of markdown file
 - New File and Edit File can now fast rename without selecting the extension
 - Add a tray to the system notification area, off by default. To activate, see Preferences → Advanced → "Leave app running in the notification area" (or "Show app in the notification area" when using MacOS).
+- Fixed a bug that would mark some quotation marks as misspelled.
 
 ## Under the Hood
 

--- a/source/common/modules/markdown-editor/modes/spellchecker.js
+++ b/source/common/modules/markdown-editor/modes/spellchecker.js
@@ -163,10 +163,10 @@
         }
 
         // Prevent returning false results because of 'quoted' words.
-        if (allQuotes.includes(word[0])) {
+        while (allQuotes.includes(word[0])) {
           word = word.substr(1)
         }
-        if (allQuotes.includes(word[word.length - 1])) {
+        while (allQuotes.includes(word[word.length - 1])) {
           word = word.substr(0, word.length - 1)
         }
 

--- a/source/common/modules/markdown-editor/modes/spellchecker.js
+++ b/source/common/modules/markdown-editor/modes/spellchecker.js
@@ -34,7 +34,7 @@
   const zknTagRE = getZknTagRE()
   const footnoteRefRE = getFootnoteRefRE()
   // NOTE: The whitespace after ~ are first a normal space, then an NBSP
-  const delim = '¡!"#$%&()*+,-./:;<=>¿?@[\\]^_`{|}~  «„「『』–—…÷'
+  const delim = '¡!"“”#$%&()*+,-./:;<=>¿?@[\\]^_`{|}~  «„「『』–—…÷'
   // The following list should contain each and every quotation character
   const allQuotes = '‘’‚ ›‹«»„“”「」『』"\''
 

--- a/source/common/modules/markdown-editor/modes/spellchecker.js
+++ b/source/common/modules/markdown-editor/modes/spellchecker.js
@@ -62,6 +62,13 @@
     // Convert smart quotes into the default before checking the term, see #1948
     const saneTerm = term.replace(/’‘‚‹›»“”」/g, "'")
 
+    // Don't check the empty string, which can arise when
+    // a 'word' consists of just opening/closing quotes,
+    // which is then removed
+    if (term === '') {
+      return true
+    }
+
     // Return cache if possible
     if (spellcheckCache[saneTerm] !== undefined) {
       return spellcheckCache[saneTerm]

--- a/source/common/modules/markdown-editor/modes/spellchecker.js
+++ b/source/common/modules/markdown-editor/modes/spellchecker.js
@@ -34,7 +34,7 @@
   const zknTagRE = getZknTagRE()
   const footnoteRefRE = getFootnoteRefRE()
   // NOTE: The whitespace after ~ are first a normal space, then an NBSP
-  const delim = '!"#$%&()*+,-./:;<=>¿?@[\\]^_`{|}~  «„「『』–—…÷'
+  const delim = '¡!"#$%&()*+,-./:;<=>¿?@[\\]^_`{|}~  «„「『』–—…÷'
   // The following list should contain each and every quotation character
   const allQuotes = '‘’‚ ›‹«»„“”「」『』"\''
 


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
The spellchecker no longer marks certain instances of quotation marks as misspelled words. Also, the spellchecker no longer marks the use of the inverted exclamation point as incorrect (cf issue #1846). 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
1. Added the inverted exclamation point to the list of delimiters recognized by the spellchecker. 
2. Added smart double quotes to the list of delimiters. 
3. Previously, the spellchecker checked the first and last character of a token to see if it was a quotation mark, and if it found one, removes it. Now, it continues to check until the first and last remaining characters of a token are not quotation marks.
4. Previously, the spellchecker marked tokens consisting only of quotation marks as a misspelled word. Now, it ignores such tokens.

The result is that some constructions which used to be incorrectly marked as misspelled are recognized as correct, e.g.:
> “Smart-double-quoted phrase ending in punctuation.”
> ‘Smart-single-quoted phrase ending in punctuation.’
> 'Dumb-single-quoted phrase ending in punctuation.'
> “‘Nested quotes’ and variations”

No breaking changes.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

  - [X] I documented all behaviour as far as I could do.
  - [X] I target the develop-branch, and *not* the master branch.
  - [X] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [X] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
    - No new errors or warnings
  - [X] I have added an entry to the CHANGELOG.md.
  - [X] I matched my code-style to the repository (as far as possible).
  - [X] I do agree that my code will be published under the GNU GPL v3 license.
  - [X] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [X] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -> Windows 10
