### PR TITLE
ctrl-T toggle between task-list, checked, no-task-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The Custom CSS can now be edited directly in the assets dialog where you can als
 - Add a tray to the system notification area, off by default. To activate, see Preferences → Advanced → "Leave app running in the notification area" (or "Show app in the notification area" when using MacOS).
 - Fixed a bug that would mark some quotation marks as misspelled.
 - Fix the visibility problems under night mode mentioned in issue #1845
+- `Cmd/Ctrl+T` now cycles between normal line/task list/checked task list to allow for ticking task list boxes using only the keyboard. Provided by Thaddäus Wiedemer (https://github.com/ThaddaeusWiedemer).
 
 ## Under the Hood
 

--- a/source/common/modules/markdown-editor/plugins/markdown-shortcuts.js
+++ b/source/common/modules/markdown-editor/plugins/markdown-shortcuts.js
@@ -523,10 +523,17 @@ const {
       cur.ch = 0
       cm.setCursor(cur)
       let line = cm.doc.getLineHandle(cur.line)
-      if (taskListRE.test(line.text)) {
-        // Line is already unordered -> remove
+      let match = taskListRE.exec(line.text)
+      if (match) {
         cm.doc.setSelection(cur, { 'line': cur.line, 'ch': line.text.length })
-        cm.doc.replaceSelection(cm.doc.getSelection().replace(taskListRE, ''))
+        // Line is already task item
+        if (match[2] === '- [ ]') {
+          // Line is un-checked task item -> check
+          cm.doc.replaceSelection(cm.doc.getSelection().replace('- [ ]', '- [x]'))
+        } else {
+          // Line is checked task item -> remove
+          cm.doc.replaceSelection(cm.doc.getSelection().replace(taskListRE, ''))
+        }
       } else {
         // Line is not a list -> Insert a task list item at cursor position
         let num = '- [ ]'
@@ -554,12 +561,19 @@ const {
         // bullets to them
         cm.doc.eachLine(lineFrom, lineTo, (line) => {
           let no = line.lineNo()
-          if (taskListRE.test(line.text)) {
-            // Line is already a task item -> remove
+          let match = taskListRE.exec(line.text)
+          if (match) {
+            // Line is already a task item
             cm.doc.setCursor(no, 0)
             let curFrom = cm.doc.getCursor()
             cm.doc.setSelection(curFrom, { 'line': no, 'ch': line.text.length })
-            cm.doc.replaceSelection(cm.doc.getSelection().replace(taskListRE, ''))
+            if (match[2] === '- [ ]') {
+              // Line is un-checked task item -> check
+              cm.doc.replaceSelection(cm.doc.getSelection().replace('- [ ]', '- [x]'))
+            } else {
+              // Line is checked task item -> remove
+              cm.doc.replaceSelection(cm.doc.getSelection().replace(taskListRE, ''))
+            }
           } else {
             // Just prepend task list items
             cm.doc.setCursor(no, 0)


### PR DESCRIPTION
This implements the enhancement I suggested a while ago in #1783. I saw it on the roadmap to Zettlr 2.0, figured it was rather easy to do myself, so here it is.

A related thing that keeps bugging me with task lists is how existing list items are treated. Currently, if the selection is a normal list item, it is changed from ` * list item` to ` - [ ] * list item`, rather than to ` - [ ] list item`, which I would find much more intuitive. On the other hand, the current behavior has the benefit that after removing the task, the line goes back to being a normal list item.

I still think it would be better to replace any existing bullet (or numbering) with the list item and just reverting to a normal line if the task list is removed. I could add that behavior to this PR unless the current treatment is the preferred workflow. What do you think?
