### PR TITLE
Fix for bug #2365 (Problem creating and deleting files when a workspace name is a substring of another)

### DIFF
--- a/source/win-main/store.ts
+++ b/source/win-main/store.ts
@@ -57,10 +57,7 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
       if (targetPath === descriptor.path) {
         // We have the correct element
         return descriptor
-        // I "fixed" eslint's complaint that both descriptor.path and path.sep must be explicit strings, but since I am new to JavaScript and 
-        // its relationship to node.js, why do I need to do this? Isn't path.sep defined in node.js as to return a string? Perhaps, when building the 
-        // directory "tree" should paths be coerced to strings there? 
-      } else if (targetPath.startsWith((descriptor.path as string) + (path.sep as string)) && descriptor.type === 'directory') {
+      } else if (targetPath.startsWith(String(descriptor.path) + String(path.sep)) && descriptor.type === 'directory') {
         // We have the correct tree
         return findPathDescriptor(targetPath, descriptor[prop], treatAsAttachment)
       }
@@ -76,7 +73,7 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
       if (targetPath === child.path) {
         // We got the correct child
         return child
-      } else if (targetPath.startsWith((child.path as string) + (path.sep as string)) && child.type === 'directory') {
+      } else if (targetPath.startsWith(String(child.path) + String(path.sep)) && child.type === 'directory') {
         // Traverse further down
         return findPathDescriptor(targetPath, child[prop], treatAsAttachment)
       }

--- a/source/win-main/store.ts
+++ b/source/win-main/store.ts
@@ -25,7 +25,6 @@ import { MDFileMeta, CodeFileMeta, DirMeta } from '../main/modules/fsal/types'
 const path = (window as any).path
 const ipcRenderer = (window as any).ipc as Electron.IpcRenderer
 
-
 interface FSALEvent {
   event: 'remove'|'add'|'change'
   path: string
@@ -58,7 +57,10 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
       if (targetPath === descriptor.path) {
         // We have the correct element
         return descriptor
-      } else if (targetPath.startsWith(descriptor.path+path.sep) && descriptor.type === 'directory') {
+        // I "fixed" eslint's complaint that both descriptor.path and path.sep must be explicit strings, but since I am new to JavaScript and 
+        // its relationship to node.js, why do I need to do this? Isn't path.sep defined in node.js as to return a string? Perhaps, when building the 
+        // directory "tree" should paths be coerced to strings there? 
+      } else if (targetPath.startsWith((descriptor.path as string) + (path.sep as string)) && descriptor.type === 'directory') {
         // We have the correct tree
         return findPathDescriptor(targetPath, descriptor[prop], treatAsAttachment)
       }
@@ -74,7 +76,7 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
       if (targetPath === child.path) {
         // We got the correct child
         return child
-      } else if (targetPath.startsWith(child.path+path.sep) && child.type === 'directory') {
+      } else if (targetPath.startsWith((child.path as string) + (path.sep as string)) && child.type === 'directory') {
         // Traverse further down
         return findPathDescriptor(targetPath, child[prop], treatAsAttachment)
       }

--- a/source/win-main/store.ts
+++ b/source/win-main/store.ts
@@ -25,6 +25,7 @@ import { MDFileMeta, CodeFileMeta, DirMeta } from '../main/modules/fsal/types'
 const path = (window as any).path
 const ipcRenderer = (window as any).ipc as Electron.IpcRenderer
 
+
 interface FSALEvent {
   event: 'remove'|'add'|'change'
   path: string
@@ -54,10 +55,11 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
   // We need to find a target
   if (Array.isArray(tree)) {
     for (const descriptor of tree) {
+      console.warn(`Descriptor path ${String(descriptor.path)}, target ${String(targetPath)}`)
       if (targetPath === descriptor.path) {
         // We have the correct element
         return descriptor
-      } else if (targetPath.startsWith(descriptor.path) && descriptor.type === 'directory') {
+      } else if (targetPath.startsWith(descriptor.path+path.sep) && descriptor.type === 'directory') {
         // We have the correct tree
         return findPathDescriptor(targetPath, descriptor[prop], treatAsAttachment)
       }
@@ -73,7 +75,7 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
       if (targetPath === child.path) {
         // We got the correct child
         return child
-      } else if (targetPath.startsWith(child.path) && child.type === 'directory') {
+      } else if (targetPath.startsWith(child.path+path.sep) && child.type === 'directory') {
         // Traverse further down
         return findPathDescriptor(targetPath, child[prop], treatAsAttachment)
       }

--- a/source/win-main/store.ts
+++ b/source/win-main/store.ts
@@ -55,7 +55,6 @@ function findPathDescriptor (targetPath: string, tree: any, treatAsAttachment: b
   // We need to find a target
   if (Array.isArray(tree)) {
     for (const descriptor of tree) {
-      console.warn(`Descriptor path ${String(descriptor.path)}, target ${String(targetPath)}`)
       if (targetPath === descriptor.path) {
         // We have the correct element
         return descriptor


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
When two workspaces located in the same directory are such that the name corresponds to the initial substring of the other, i.e. ZKM and ZKM_Work,  inserting files or deleting files in the latter will fail to be shown in the file browser.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
A change was made such that initial substrings should math a propper sub-path.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on:  Linux and Win64
