### PR TITLE
Remove basic markdown colors from Berlin; close #2243

### DIFF
--- a/source/common/less/theme-berlin/dark.less
+++ b/source/common/less/theme-berlin/dark.less
@@ -8,13 +8,13 @@ body.dark {
   #editor .CodeMirror,
   .quicklook .body .CodeMirror,
   .dialog .CodeMirror {
-    color: var(--grey-2);
+    color: var(--grey-0);
 
     // First the code blocks
     .cm-comment,
     .cm-fenced-code,
     .cm-inline-math {
-      color: var(--grey-1);
+      color: var(--grey-0);
     }
 
     .cm-fenced-code {
@@ -123,7 +123,7 @@ body.dark {
     .cm-link,
     .cm-strong,
     .cm-em {
-      color: var(--c-primary-shade);
+      color: var(--grey-0);
     }
 
     .cm-spell-error {
@@ -246,7 +246,7 @@ body.dark {
 
     // Code background
     .cm-comment:not(.cm-formatting):not(.cm-fenced-code) {
-      background-color: var(--beige-5);
+      background-color: var(--grey-5);
     }
   }
 

--- a/source/common/less/theme-berlin/dark.less
+++ b/source/common/less/theme-berlin/dark.less
@@ -118,14 +118,6 @@ body.dark {
       color: var(--c-primary-shade);
     }
 
-    /* TYPOGRAPHY */
-    .cm-quote,
-    .cm-link,
-    .cm-strong,
-    .cm-em {
-      color: var(--grey-0);
-    }
-
     .cm-spell-error {
       text-decoration-color: var(--bg-error);
     }

--- a/source/common/less/theme-berlin/light.less
+++ b/source/common/less/theme-berlin/light.less
@@ -203,14 +203,6 @@ body {
       color: var(--c-primary);
     }
 
-    /* TYPOGRAPHY */
-    .cm-quote,
-    .cm-link,
-    .cm-strong,
-    .cm-em {
-      color: var(--grey-5);
-    }
-
     .cm-spell-error {
       text-decoration: dashed underline;
       text-decoration-color: var(--orange-2);

--- a/source/common/less/theme-berlin/light.less
+++ b/source/common/less/theme-berlin/light.less
@@ -13,7 +13,7 @@ body {
   #editor .CodeMirror,
   /*.quicklook .body .CodeMirror,*/
   .dialog .CodeMirror {
-    color: rgb(46, 56, 60);
+    color: var(--grey-5);
 
     &.cm-s-zettlr-code {
       // Code files have this theme applied (others have cm-s-zettlr-markdown)
@@ -80,7 +80,7 @@ body {
     .cm-comment,
     .cm-fenced-code,
     .cm-inline-math {
-      color: var(--grey-3);
+      color: var(--grey-5);
     }
 
     .cm-highlight {
@@ -208,7 +208,7 @@ body {
     .cm-link,
     .cm-strong,
     .cm-em {
-      color: var(--c-primary);
+      color: var(--grey-5);
     }
 
     .cm-spell-error {


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
Remove diverging colors from simple markdown in Berlin light and dark

## Changes
css only

<!-- Please provide any testing system -->
Tested on: Linux Mint 20.2
