### PR TITLE
add rounded colors to backtick codeblock similar to inline code; closes #2374

### DIFF
--- a/source/common/less/theme-berlin/dark.less
+++ b/source/common/less/theme-berlin/dark.less
@@ -112,6 +112,16 @@ body.dark {
       background-color: #333;
     }
 
+    .code-block-line-open {
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+    }
+
+    .code-block-line-close {
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
+
     /* LISTS */
     .cm-formatting-list-ul,
     .cm-formatting-list-ol {

--- a/source/common/less/theme-berlin/light.less
+++ b/source/common/less/theme-berlin/light.less
@@ -197,6 +197,16 @@ body {
       background-color: #eee;
     }
 
+    .code-block-line-open {
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+    }
+
+    .code-block-line-close {
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
+
     /* LISTS */
     .cm-formatting-list-ul,
     .cm-formatting-list-ol {

--- a/source/common/modules/markdown-editor/hooks/codeblock-classes.js
+++ b/source/common/modules/markdown-editor/hooks/codeblock-classes.js
@@ -26,6 +26,8 @@ function applyCodeblockClasses (cm) {
   let needsRefresh = false // Will be set to true if at least one line has been altered
   let isCodeBlock = false
   let codeblockClass = 'code-block-line'
+  let codeblockClassOpen = 'code-block-line-open'
+  let codeblockClassClose = 'code-block-line-close'
 
   // This matches a line that starts with at most three spaces, followed by at
   // least three backticks or tildes (fenced code block).
@@ -44,6 +46,14 @@ function applyCodeblockClasses (cm) {
     const line = info.text
     const wrapClass = (info.wrapClass !== undefined) ? String(info.wrapClass) : ''
     const isCurrentlyCode = wrapClass.includes(codeblockClass)
+
+    if (i > 0 && codeBlockRE.test(cm.lineInfo(i - 1).text)) {
+      cm.addLineClass(i, 'wrap', codeblockClassOpen)
+    }
+
+    if (i > 0 && i < cm.lineCount() - 1 && codeBlockRE.test(cm.lineInfo(i + 1).text)) {
+      cm.addLineClass(i, 'wrap', codeblockClassClose)
+    }
 
     // Second, check if we are NOT inside a fenced code block. If we're not, but
     // the line is indented by at least four spaces, we have an indented code


### PR DESCRIPTION
## Description

Make code block look more in line with inline code tag styling with rounded corners. For this, the first and last line of a code block need to be identified and tagged with a class.

![image](https://user-images.githubusercontent.com/1702193/135303926-496fd219-6117-49ac-ad3b-d15c59542441.png) 
![image](https://user-images.githubusercontent.com/1702193/135303986-7d7693fb-a6d7-4486-b886-4fd75c607ec8.png)


## Changes

Two new classes are introduced and ready for custom CSS. Styling with rounded colors is included with Berlin light and dark theme.

## Additional information

You can see that originally, attempts were made in `codeblock-classes.js` to do some conditional parsing to make sure the tagging of code blocks is efficient and doesn't do unnecessary passes. However, **prior to my PR, indented code blocks were broken. I did not touch this code**, nor did I fix the problem because I can't follow what the idea was exactly. I think this is best left to the original contributor to fix.

![image](https://user-images.githubusercontent.com/1702193/135304175-d9a034bd-c5b4-44fc-8686-cd59fd661cdf.png)
(Indented code block prior error left unchanged)

<!-- Please provide any testing system -->
Tested on: Linux Mint 20.2
