### PR TITLE
Manage uri logic when opening markdown links in main process

### DIFF
--- a/source/common/modules/markdown-editor/plugins/render-links.js
+++ b/source/common/modules/markdown-editor/plugins/render-links.js
@@ -25,7 +25,8 @@
   'use strict'
 
   const makeAbsoluteURL = require('../../../util/make-absolute-url')
-  const openMarkdownLink = require('../open-markdown-link')
+  // const openMarkdownLink = require('../open-markdown-link')
+  const ipcRenderer = window.ipc
 
   // This regular expression matches three different kinds of URLs:
   // 1. Linked images in the format [![Alt text](image/path.png)](www.link-target.tld)
@@ -225,7 +226,17 @@
             // On ALT-Clicks, use the callback to have the user decide
             // what should happen when they click on links, defined
             // in the markdownOnLinkOpen option.
-            openMarkdownLink(renderedLinkTarget, cm)
+
+            // removing call
+            // openMarkdownLink(renderedLinkTarget, cm)
+            ipcRenderer.invoke('application', {
+              command: 'uri-logic',
+              payload: {
+                path: renderedLinkTarget,
+                cm: cm,
+                newTab: false
+              }
+            })
           } else {
             // Clear the textmarker and set the cursor to where the
             // user has clicked the link.

--- a/source/common/modules/markdown-editor/plugins/render-links.js
+++ b/source/common/modules/markdown-editor/plugins/render-links.js
@@ -230,7 +230,7 @@
             // removing call
             // openMarkdownLink(renderedLinkTarget, cm)
             ipcRenderer.invoke('application', {
-              command: 'uri-logic',
+              command: 'open-markdown-link',
               payload: {
                 path: renderedLinkTarget,
                 cm: cm,

--- a/source/main/commands/open-markdown-link.ts
+++ b/source/main/commands/open-markdown-link.ts
@@ -2,12 +2,12 @@
  * @ignore
  * BEGIN HEADER
  *
- * Contains:        UriLogic command
+ * Contains:        OpenMarkdownLink command
  * CVM-Role:        <none>
  * Maintainer:      Hendrik Erz
  * License:         GNU GPL v3
  *
- * Description:     This command ...
+ * Description:     This new command manages the uri logic
  *
  * END HEADER
  */
@@ -17,9 +17,9 @@ import path from 'path'
 import fileExists from '../../common/util/is-file'
 import { getProtocolRE, getLinkRE, getMarkDownFileRE } from '../../common/regular-expressions'
 
-export default class UriLogic extends ZettlrCommand {
+export default class OpenMarkdownLink extends ZettlrCommand {
   constructor (app: any) {
-    super(app, 'uri-logic')
+    super(app, 'open-markdown-link')
   }
 
   /**

--- a/source/main/commands/uri-logic.ts
+++ b/source/main/commands/uri-logic.ts
@@ -1,0 +1,196 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        UriLogic command
+ * CVM-Role:        <none>
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This command ...
+ *
+ * END HEADER
+ */
+
+import ZettlrCommand from './zettlr-command'
+import path from 'path'
+import fileExists from '../../common/util/is-file'
+import { getProtocolRE, getLinkRE, getMarkDownFileRE } from '../../common/regular-expressions'
+
+export default class UriLogic extends ZettlrCommand {
+  constructor (app: any) {
+    super(app, 'uri-logic')
+  }
+
+  /**
+   * Uri logic ...
+   * @param {String} uri A uri from a markdown link
+   * @param  {CodeMirror} cm   The instance to use if it's a heading link
+   */
+  async run (url: string, cm: CodeMirror.Editor): Promise<void> {
+
+    const { mdFileExtensions } = require('../../get-file-extensions')
+    const VALID_FILETYPES = mdFileExtensions(true)
+
+    const ipcRenderer = window.ipc
+
+    if (url[0] === '#') {
+      // We should open an internal link
+      let re = new RegExp('#\\s[^\\r\\n]*?' +
+      url.replace(/-/g, '[^\\r\\n]+?').replace(/^#/, ''), 'i')
+      // The new regex should now match the corresponding heading in the document
+      for (let i = 0; i < cm.lineCount(); i++) {
+        let line = cm.getLine(i)
+        if (re.test(line)) {
+          cm.setCursor({ 'line': i, 'ch': 0 })
+          cm.refresh()
+          break
+        }
+      }
+    } else {
+      // It is valid Markdown to surround the URL with < and >
+      url = url.replace(/^<(.+)>$/, '$1') // Looks like an Emoji!
+      // We'll be making use of a helper function here, because
+      // we cannot rely on the errors thrown by new URL(), as,
+      // e.g., file://./relative.md will not throw an error albeit
+      // we need to convert it to absolute.
+      let base = cm.getOption('zettlr').markdownImageBasePath
+      let validURI = makeValidUri(url, base)
+  
+      // Now we have a valid link. Finally, let's check if we can open the file
+      // internally, without having to switch to an external program.
+      const localPath = validURI.replace('file://', '')
+      const isValidFile = VALID_FILETYPES.includes(path.extname(localPath))
+      const isLocalMdFile = path.isAbsolute(localPath) === true && isValidFile
+  
+      if (isLocalMdFile) {
+        // Attempt to open internally
+        ipcRenderer.invoke('application', {
+          command: 'open-file',
+          payload: {
+            path: localPath,
+            newTab: false
+          }
+        })
+          .catch(e => console.error(e))
+      } else {
+        window.location.assign(validURI) // Handled by the event listener in the main process
+      }
+    }
+}
+
+function makeValidUri (uri: string, base: string): string {
+// module.exports = function (uri, base = '') {
+  // Why do we need a helper function for this?
+  // Because it's not only hard to distinguish
+  // a URL from a file path, but also there are
+  // a lot of variables to account for.
+  //
+  // Examples:
+  // github.com --> is a valid hostname, but has no protocol and no "www"
+  // subdomain.toplevel.tld --> also valid, but without "www" and protocol
+  // ./path/file.md --> Valid file path, but relative
+  // path/file.md --> Also valid, also relative, but without the dot indicator
+  // path/to/.htaccess --> Valid extension-only filepath
+  //
+  // All of these examples can (in case of rel. paths with the base) be
+  // resolved perfectly. The first two examples only need the http(s) protocol,
+  // the other three examples need the base and file:// prepended.
+  //
+  // So what we need to do first is distinguish between a URL and a Path.
+
+  const protocolRE = getProtocolRE()
+  const linkRE = getLinkRE()
+  const mdFileRE = getMarkDownFileRE()
+
+  if (uri.startsWith('mailto:')) {
+    // Shortcut for mailto-links, as these have a protocol (mailto) but with
+    // *only* a colon, not the double-slash (//).
+    return uri
+  }
+
+  // Set the isFile var to undefined
+  let isFile
+
+  // First, remove a potential protocol and save it for later use
+  let protocol = protocolRE.exec(uri)
+  // If there was a protocol, extract the capturing group
+  if (protocol !== null) {
+    protocol = protocol[1]
+  }
+
+  if (protocol === 'file') {
+    // We know it's a file
+    isFile = true
+  } else if (uri.startsWith('//') || uri.startsWith('./') || uri.startsWith('../')) {
+    // We know it's a file (shared drive, or relative to this directory)
+    isFile = true
+  } else if (path.isAbsolute(uri) && fileExists(uri)) {
+    // The link is already absolute and exists
+    isFile = true
+  } else if (!path.isAbsolute(uri) && fileExists(path.join(base, uri))) {
+    // The link is relative and exists
+    isFile = true
+  }
+
+  // At this point, it might be that isFile is still undefined. If so,
+  // no protocol was being extracted, and it's up to us to find out
+  // more.
+  if (isFile === undefined) {
+    // So, no explicit file protocol, which means we have to
+    // check the first part of the URI. If it resembles a
+    // valid URI, that is: something in the form <sub>.<host>.<tld>,
+    // we assume a link. If not, we assume a file. Remember
+    // that the subdomain may be omitted. So what we're really
+    // searching for is <host>.<tld>.
+    if (protocol !== null) {
+      // It may be that the protocol is given, but not a file
+      // In this case, it's not a file, but we don't care which
+      // protocol it uses.
+      isFile = false
+    } else if (linkRE.test(uri) && !mdFileRE.test(uri)) {
+      // NOTE: The regular expression will also test true for
+      // relative paths without ./ at the beginning and a folder
+      // containing a full stop. But remedification by adding ./
+      // is easy in this case for the user.
+      // NOTE: Using mdFileRE we prevent this behaviour for markdown-files
+      // BUT beware: This will treat moldovian TLD domains as Markdown
+      // files. Here, a trailing slash will remedify this.
+      isFile = false
+    } else {
+      isFile = true
+    }
+  }
+
+  // At this point, we definitely know the isFile. If the protocol
+  // is still not known we can now derive it from the information
+  // we have gathered so far.
+  if (protocol === null) {
+    if (isFile) {
+      protocol = 'file'
+    } else {
+      // For links we assume HTTPS. Websites that still
+      // don't use HTTPS by 2020 can go home.
+      protocol = 'https'
+    }
+  }
+
+  // Now we have both the protocol and whether it's a file
+  // or not. If it's a file, one last thing we need to do
+  // is check if we have to convert the path to absolute
+  // using the current base.
+  if (isFile) {
+    // Again, extract a possible file-protocol
+    if (uri.indexOf('file://') === 0) uri = uri.substr(7)
+    // We've got a relative path
+    if (!path.isAbsolute(uri)) uri = path.join(base, uri)
+    uri = 'file://' + uri
+  }
+
+  // Now we can return the correct uri, made absolute
+  if (!protocolRE.test(uri)) {
+    return protocol + '://' + uri
+  } else {
+    return uri
+  }
+}


### PR DESCRIPTION
## Description
Creates a new command for managing uri logic directly in the main process when trying to open markdown  (Issue #2503).

## Changes
Moved IPC call from `open-markdown-link.js` directly in `render-links.js`.
Created the `open-markdown-link.ts`command regrouping old `makeValidUri()` and `openMarkdownLink()` logic.

## Additional information
This is a work in progress.
