### PR TITLE
downgrade electron to 14.1.1 (2) fixes #2643

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.4.0",
     "csso": "^4.2.0",
-    "electron": "^15.2.0",
+    "electron": "^14.1.1",
     "electron-builder": "22.13.1",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,7 +325,7 @@
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.0"
 
-"@electron/get@^1.13.0", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
+"@electron/get@^1.0.1", "@electron/get@^1.6.0", "@electron/get@^1.9.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
   integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
@@ -3505,12 +3505,12 @@ electron-to-chromium@^1.3.793:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz#bd74a4367902c9d432d129f265bf4542cddd9f54"
   integrity sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==
 
-electron@^15.2.0:
-  version "15.2.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.2.0.tgz#3068099d1e5c625d1708487de519c59d7c0a8e6e"
-  integrity sha512-kg0JdlsVbJgD/hO/A7o9VH8U44pQWkIsyt/sALxH6g8CiHQxMujLn2JfB2gyUfHXPT7m8vD4Z+CurS2KodEsWw==
+electron@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-14.1.1.tgz#643726fe1fd4ad77fbb3a75b211005ed01357485"
+  integrity sha512-eaqaxMq/auE5VDIzYYqDUgZg+68Uiv+8jAQUXqLh8G58kOxqRL9Jw4TJ/w2/KXwWGaVPaUStbvO9BtqVZant+A==
   dependencies:
-    "@electron/get" "^1.13.0"
+    "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
#2643 is high priority and we're all at a loss as to what causes the problem. The quickest fix is to downgrade from Electron 15 to Electron 14. Effectively this means Zettlr 2 goes from Electron 13 to 14 rather than from 13 to 15. So unless there are any other known problems with this version, this may be the best action to get this fixed for now.

Personally I consider the (merged) #2641 high priority too, so these two together can be a new Zettlr patch release.

It's probably never a good idea to upgrade a major version of crucial dependencies like Electron right after the last beta and before the final release. Consider locking major versions of dependencies by the time betas or release candidates are released for public testing.