### PR TITLE
add lodash to package.json; #2637

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "joplin-turndown-plugin-gfm": "^1.0.12",
     "katex": "^0.13.18",
     "ky": "^0.28.6",
+    "lodash": "^4.17.21",
     "luxon": "^2.0.2",
     "md5": "^2.3.0",
     "mermaid": "^8.13.3",


### PR DESCRIPTION
This is a technicality. In case you want dependencies to be explicitly defined, even though they are already subdependencies.

@nathanlesage [commented](https://github.com/Zettlr/Zettlr/pull/2641#issuecomment-945740306):
> it might make sense to pull in the most recent version of it via package.json, so feel free to do so!

I'm not sure how this changes the compiled code since `lodash` is already `require`'able, but after compiling things still work the same so at least it doesn't change compiled code into a problem. :grin: 