### PR TITLE
start minimized when --tray is in argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,6 @@ Use this switch to specify custom data directory, which holds your configuration
 
 This switch causes Zettlr to disable hardware acceleration, which could be necessary in certain setups. For more information on why this flag was added, see issue [#2127](https://github.com/Zettlr/Zettlr/issues/2127).
 
-
-#### `--tray`
-
-This will start Zettlr in Tray, without showing the userinterface. It is ignoring the checkbox in the settings, so that the tray is always created on startup, as to make the application not inaccessible.  
-
 ## VSCode Extension Recommendations
 
 This repository makes use of Visual Studio Code's [recommended extensions feature](https://go.microsoft.com/fwlink/?LinkId=827846). This means: If you use VS Code and open the repository for the first time, VS Code will tell you that the repository recommends to install a handful of extensions. These extensions are recommended if you work with Zettlr and will make contributing much easier. The recommendations are specified in the file `.vscode/extensions.json`.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Use this switch to specify custom data directory, which holds your configuration
 
 This switch causes Zettlr to disable hardware acceleration, which could be necessary in certain setups. For more information on why this flag was added, see issue [#2127](https://github.com/Zettlr/Zettlr/issues/2127).
 
+
 ## VSCode Extension Recommendations
 
 This repository makes use of Visual Studio Code's [recommended extensions feature](https://go.microsoft.com/fwlink/?LinkId=827846). This means: If you use VS Code and open the repository for the first time, VS Code will tell you that the repository recommends to install a handful of extensions. These extensions are recommended if you work with Zettlr and will make contributing much easier. The recommendations are specified in the file `.vscode/extensions.json`.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ Use this switch to specify custom data directory, which holds your configuration
 This switch causes Zettlr to disable hardware acceleration, which could be necessary in certain setups. For more information on why this flag was added, see issue [#2127](https://github.com/Zettlr/Zettlr/issues/2127).
 
 
+#### `--tray`
+
+This will start Zettlr in Tray, without showing the userinterface. It is ignoring the checkbox in the settings, so that the tray is always created on startup, as to make the application not inaccessible.  
+
 ## VSCode Extension Recommendations
 
 This repository makes use of Visual Studio Code's [recommended extensions feature](https://go.microsoft.com/fwlink/?LinkId=827846). This means: If you use VS Code and open the repository for the first time, VS Code will tell you that the repository recommends to install a handful of extensions. These extensions are recommended if you work with Zettlr and will make contributing much easier. The recommendations are specified in the file `.vscode/extensions.json`.

--- a/source/app/service-providers/assets/get-config-template.ts
+++ b/source/app/service-providers/assets/get-config-template.ts
@@ -230,6 +230,7 @@ export default function getConfigTemplate (): ConfigOptions {
     system: {
       deleteOnFail: false, // Whether to delete files if trashing them fails
       leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
+      leaveAppRunningOverride: false, // Whether to leave app running in the notification area (tray)
       avoidNewTabs: true, // Whether to avoid opening new tabs for documents if possible
       iframeWhitelist: [ 'www.youtube.com', 'player.vimeo.com' ] // Contains a list of whitelisted iFrame prerendering domains
     },

--- a/source/app/service-providers/assets/get-config-template.ts
+++ b/source/app/service-providers/assets/get-config-template.ts
@@ -230,7 +230,7 @@ export default function getConfigTemplate (): ConfigOptions {
     system: {
       deleteOnFail: false, // Whether to delete files if trashing them fails
       leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
-      leaveAppRunningOverride: false, // Whether to leave app running in the notification area (tray)
+      startInTray: false, // Whether to leave app running in the notification area (tray)
       avoidNewTabs: true, // Whether to avoid opening new tabs for documents if possible
       iframeWhitelist: [ 'www.youtube.com', 'player.vimeo.com' ] // Contains a list of whitelisted iFrame prerendering domains
     },

--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -55,12 +55,8 @@ export default class TrayProvider extends EventEmitter {
 
     global.config.on('update', (option: string) => {
       if (option === 'system.leaveAppRunning') {
-        // if this is changed during runtime, also update the override.
-        // this allows for the tray to be disabled during runtime.
-        const state = global.config.get('system.leaveAppRunning')
-        global.config.set('system.leaveAppRunningOverride', state)
-
-        if (global.config.get('system.leaveAppRunning') === true || global.config.get('system.leaveAppRunningOverride')) {
+        // even if the tray should not be shown, since we start in Tray we need to show it anyway
+        if (global.config.get('system.leaveAppRunning') === true || global.config.get('system.startInTray') === true) {
           this._addTray()
         } else {
           this._removeTray()
@@ -112,7 +108,7 @@ export default class TrayProvider extends EventEmitter {
    * @memberof TrayProvider
    */
   private _addTray (): void {
-    const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning')) || Boolean(global.config.get('system.leaveAppRunningOverride'))
+    const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning')) || Boolean(global.config.get('system.startInTray'))
 
     if (!leaveAppRunning) {
       return // No need to add a tray.

--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -55,7 +55,12 @@ export default class TrayProvider extends EventEmitter {
 
     global.config.on('update', (option: string) => {
       if (option === 'system.leaveAppRunning') {
-        if (global.config.get('system.leaveAppRunning') === true) {
+        // if this is changed during runtime, also update the override.
+        // this allows for the tray to be disabled during runtime.
+        const state = global.config.get('system.leaveAppRunning')
+        global.config.set('system.leaveAppRunningOverride', state)
+
+        if (global.config.get('system.leaveAppRunning') === true || global.config.get('system.leaveAppRunningOverride')) {
           this._addTray()
         } else {
           this._removeTray()
@@ -107,7 +112,7 @@ export default class TrayProvider extends EventEmitter {
    * @memberof TrayProvider
    */
   private _addTray (): void {
-    const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
+    const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning')) || Boolean(global.config.get('system.leaveAppRunningOverride'))
 
     if (!leaveAppRunning) {
       return // No need to add a tray.

--- a/source/app/service-providers/types/config-provider.d.ts
+++ b/source/app/service-providers/types/config-provider.d.ts
@@ -145,7 +145,7 @@ interface ConfigOptions {
   system: {
     deleteOnFail: boolean
     leaveAppRunning: boolean
-    leaveAppRunningOverride: boolean
+    startInTray: boolean
     avoidNewTabs: boolean
     iframeWhitelist: string[]
   }

--- a/source/app/service-providers/types/config-provider.d.ts
+++ b/source/app/service-providers/types/config-provider.d.ts
@@ -145,6 +145,7 @@ interface ConfigOptions {
   system: {
     deleteOnFail: boolean
     leaveAppRunning: boolean
+    leaveAppRunningOverride: boolean
     avoidNewTabs: boolean
     iframeWhitelist: string[]
   }

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -116,10 +116,8 @@ export default class WindowManager extends EventEmitter {
       .then(() => {
         global.log.info('[Window Manager] Window Manager booted. Opening main window.')
         this.showMainWindow()
-        if (process.argv.includes('--tray')) {
-          global.config.set('system.leaveAppRunningOverride', true)
-        }
-        if (global.config.get('system.leaveAppRunningOverride')) {
+        if (process.argv.includes('--tray') || Boolean(global.config.get('system.startInTray'))) {
+          global.log.info('[Window Manager] Application should start in Tray. Main Window is minimized to tray on startup.')
           global.tray.add()
           this.getMainWindow()?.hide()
         }

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -117,6 +117,7 @@ export default class WindowManager extends EventEmitter {
         global.log.info('[Window Manager] Window Manager booted. Opening main window.')
         this.showMainWindow()
         if (process.argv.includes('--tray')) {
+          global.config.set('system.leaveAppRunningOverride', true)
           global.tray.add()
           this.getMainWindow()?.hide()
         }

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -116,7 +116,7 @@ export default class WindowManager extends EventEmitter {
       .then(() => {
         global.log.info('[Window Manager] Window Manager booted. Opening main window.')
         this.showMainWindow()
-        if (process.argv.includes('--tray') || Boolean(global.config.get('system.startInTray'))) {
+        if (global.config.get('system.startInTray')) {
           global.log.info('[Window Manager] Application should start in Tray. Main Window is minimized to tray on startup.')
           global.tray.add()
           this.getMainWindow()?.hide()

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -118,6 +118,8 @@ export default class WindowManager extends EventEmitter {
         this.showMainWindow()
         if (process.argv.includes('--tray')) {
           global.config.set('system.leaveAppRunningOverride', true)
+        }
+        if (global.config.get('system.leaveAppRunningOverride')) {
           global.tray.add()
           this.getMainWindow()?.hide()
         }

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -116,6 +116,10 @@ export default class WindowManager extends EventEmitter {
       .then(() => {
         global.log.info('[Window Manager] Window Manager booted. Opening main window.')
         this.showMainWindow()
+        if (process.argv.includes('--tray')) {
+          global.tray.add()
+          this.getMainWindow()?.hide()
+        }
       })
       .catch((err: Error) => global.log.error(`[Window Manager] Could not load data: ${err.message}`, err))
 

--- a/source/win-preferences/schema/advanced.ts
+++ b/source/win-preferences/schema/advanced.ts
@@ -58,6 +58,13 @@ export default function (): any {
             ? trans('dialog.preferences.show_app_in_the_notification_area')
             : trans('dialog.preferences.leave_app_running_in_the_notification_area'),
           model: 'system.leaveAppRunning'
+        },
+        {
+          type: 'checkbox',
+          label: process.platform === 'darwin'
+            ? trans('dialog.preferences.show_app_in_the_notification_area_on_startup')
+            : trans('dialog.preferences.leave_app_running_in_the_notification_area_on_startup'),
+          model: 'system.startInTray'
         }
       ],
       [


### PR DESCRIPTION
## Description
Fix #2840 

## Changes
Add a check that checks for --tray in argv and then minimizes the main window and creates a tray icon, regardless of "use tray" setting

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: KDE 20.04
