### PR TITLE
do not re-add tray on linux

### DIFF
--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -38,6 +38,9 @@ export default class TrayProvider extends EventEmitter {
   constructor () {
     super()
     global.log.verbose('Tray provider booting up ...')
+    if (this._tray != null) {
+      this._removeTray()
+    }
     this._tray = null
 
     global.tray = {
@@ -45,7 +48,15 @@ export default class TrayProvider extends EventEmitter {
        * Adds the Zettlr tray to the system notification area.
        */
       add: () => {
-        this._addTray()
+        // see  _removeTray ()
+        // this does not recreate the tray if there is already one to prevent duplicates
+        if (process.platform === 'linux') {
+          if (this._tray == null) {
+            this._addTray()
+          }
+        } else {
+          this._addTray()
+        }
       }
     }
 


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This is an attempt to work around an upstream-bug in electron where the trayicon cannot be closed properly.

## Changes
On linux, the tray icon is not recreated when added. If one exist, it is reused, otherwise a new one is created.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Kubuntu 20.04
