### PR TITLE
Follow ZTN links on middle click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error in the link filtering process that would throw an error when
   you attempted to remove internal links completely upon export
+- Follow zettelkasten links on middle clicks
 
 ## Under the Hood
 

--- a/source/common/modules/markdown-editor/index.js
+++ b/source/common/modules/markdown-editor/index.js
@@ -219,7 +219,7 @@ module.exports = class MarkdownEditor extends EventEmitter {
     })
 
     this._instance.on('mousedown', (cm, event) => {
-      // Open links on both Cmd and Ctrl clicks - otherwise stop handling event
+      // Open links on Cmd clicks, Ctrl clicks and middle clicks - otherwise stop handling event
       if (process.platform === 'darwin' && !event.metaKey && event.button !== 1) return true
       if (process.platform !== 'darwin' && !event.ctrlKey && event.button !== 1) return true
 

--- a/source/common/modules/markdown-editor/index.js
+++ b/source/common/modules/markdown-editor/index.js
@@ -220,8 +220,8 @@ module.exports = class MarkdownEditor extends EventEmitter {
 
     this._instance.on('mousedown', (cm, event) => {
       // Open links on both Cmd and Ctrl clicks - otherwise stop handling event
-      if (process.platform === 'darwin' && !event.metaKey) return true
-      if (process.platform !== 'darwin' && !event.ctrlKey) return true
+      if (process.platform === 'darwin' && !event.metaKey && event.button !== 1) return true
+      if (process.platform !== 'darwin' && !event.ctrlKey && event.button !== 1) return true
 
       let cursor = this._instance.coordsChar({ left: event.clientX, top: event.clientY })
       let tokenInfo = this._instance.getTokenAt(cursor)


### PR DESCRIPTION
Follow ZTN links on middle click, for https://github.com/Zettlr/Zettlr/issues/2874

<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [x] I documented all behaviour as far as I could do.
  - [x] I target the develop-branch, and *not* the master branch.
  - [x] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [x] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [x] I have added an entry to the CHANGELOG.md.
  - [x] I matched my code-style to the repository (as far as possible).
  - [x] I do agree that my code will be published under the GNU GPL v3 license.
  - [x] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [x] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Previously, ZTN links are followed when ctrl/cmd clicking on them. With this patch, the links are also followed with middle clicks, thus enabling keyboard-free navigation.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Simply taking middle clicks into consideration when deciding whether to follow links

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

This is consistent with expected behaviour in browsers where ctrl/cmd clicks on links are equivalent to middle clicks (open link in new tab in the background in Chrome)

<!-- Please provide any testing system -->
Tested on: MacOS 12, Windows 10