### PR TITLE
Fix #3000

### DIFF
--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -448,6 +448,11 @@ export default {
     },
     emptySearchResults: function () {
       this.searchResults = []
+
+      // Clear indeces of active search result
+      this.activeFileIdx = -1
+      this.activeLineIdx = -1
+
       // Also, for convenience, re-focus and select the input
       this.$refs['query-input'].focus()
       this.$refs['query-input'].select()


### PR DESCRIPTION
The two index variables (`activeFileIdx`, and `activeLineIdx`) are now reset to -1 in `emptySearchResults()`.

<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
