### PR TITLE
Do not preventDefault on middle mouse click for closing tabs on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Display inline math using monospaced font
 - Right-clicking citations doesn't select parts of it anymore
 - Inline-equations are now properly syntax highlighted
+- Fixed an error that caused a paste action when using middle mouse button to close a tab on Linux
 
 ## Under the Hood
 

--- a/source/win-main/DocumentTabs.vue
+++ b/source/win-main/DocumentTabs.vue
@@ -243,8 +243,10 @@ export default defineComponent({
       if (event.button === 1) {
         // It was a middle-click (auxiliary button), so we should instead close
         // the file.
-        event.preventDefault() // Otherwise, on Windows we'd have a middle-click-scroll
-        event.stopPropagation() // In response to #2663
+        if (process.platform !== 'linux') {
+          // Otherwise, on Windows we'd have a middle-click-scroll
+          event.preventDefault()
+        }
         this.handleClickClose(event, file)
       } else if (event.button === 0) {
         // It was a left-click. (We must check because otherwise we would also


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
This PR adds a platform check to determine whether or not to call `event.preventDefault` when someone used the middle mouse button to close a tab. There was a fix in place to prevent a scroll action when using middle mouse on windows but this fix caused middle mouse click to malfunction on Linux.  
It also removes the call to `event.stopPropagation` which was added to resolve this very issue but didn't do anything.

Currently the platform is `!== 'linux'` which means that on mac, `preventDefault` will still be called (just like on Windows). This could also be changed to only check for Windows but for that someone needs to test how OSX behaves currently.

Closes #2663 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

This shouldn't be a breaking change unless someone out there used this handy-dandy feature to paste something and close a tab in the same action.. 🤔 Let's say no breaking changes :)

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Comment of origin: https://github.com/Zettlr/Zettlr/issues/2663#issuecomment-1013676075

<!-- Please provide any testing system -->
Tested on: 5.15.12-1-MANJARO (arch based Linux) with KDE desktop environment

It would be good if at least one Windows user, one OSX user and some other Linux users with different distros and DEs could test this before merging.