### PR TITLE
Fix #2663

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Display inline math using monospaced font
 - Right-clicking citations doesn't select parts of it anymore
 - Inline-equations are now properly syntax highlighted
+- Fixed a bug that caused unintentional pastes when closing a tab using the
+  middle mouse button on Linux
 
 ## Under the Hood
 

--- a/source/win-main/DocumentTabs.vue
+++ b/source/win-main/DocumentTabs.vue
@@ -15,6 +15,7 @@
       v-on:drag="handleDrag"
       v-on:dragend="handleDragEnd"
       v-on:contextmenu="handleContextMenu($event, file)"
+      v-on:mouseup="handleMiddleMouseClick($event, file)"
       v-on:mousedown="handleClickFilename($event, file)"
     >
       <span
@@ -240,17 +241,28 @@ export default defineComponent({
      * @param   {any}         file   The file descriptor
      */
     handleClickFilename: function (event: MouseEvent, file: any) {
-      if (event.button === 1) {
-        // It was a middle-click (auxiliary button), so we should instead close
-        // the file.
-        event.preventDefault() // Otherwise, on Windows we'd have a middle-click-scroll
-        event.stopPropagation() // In response to #2663
-        this.handleClickClose(event, file)
-      } else if (event.button === 0) {
+      if (event.button === 0) {
         // It was a left-click. (We must check because otherwise we would also
         // perform this action on a right-click (button === 2), but that event
         // must be handled by the container).
         this.selectFile(file)
+      }
+    },
+    /**
+     * Handles a middle-mouse click on the filename
+     *
+     * Middle-mouse clicks are handled separately through a `mouseup` event,
+     * to prevent unintentional pasting on Linux systems (#2663).
+     *
+     * @param   {MouseEvent}  event  The triggering event
+     * @param   {any}         file   The file descriptor
+     */
+    handleMiddleMouseClick: function (event: MouseEvent, file: any) {
+      if (event.button === 1) {
+        // It was a middle-click (auxiliary button), so we should close
+        // the file.
+        event.preventDefault() // Otherwise, on Windows we'd have a middle-click-scroll
+        this.handleClickClose(event, file)
       }
     },
     selectFile: function (file: any) {


### PR DESCRIPTION
<!-- Thank you for opening up this pull request! Please make sure to fill out as
much information as you can below.

But, most importantly, please make sure you can say "I did so!" to the
following points:

  - [ ] I documented all behaviour as far as I could do.
  - [ ] I target the develop-branch, and *not* the master branch.
  - [ ] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [ ] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [ ] I have added an entry to the CHANGELOG.md.
  - [ ] I matched my code-style to the repository (as far as possible).
  - [ ] I do agree that my code will be published under the GNU GPL v3 license.
  - [ ] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [ ] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

  N.B.: Of course you can open a Pull Request and ask for certain things
  such as file structure later on! It does not need to be perfect on the first
  try :)
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
My proposal for fixing #2663. The idea was to react to middle-mouse clicks only when a _mouseup_ (instead of previously _mousedown_) event is detected. That way, an accidental paste into the new tab (that gets opened after the closed tab) is prevented.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
* Added a `mouseup` event in `DocumentTabs.vue`
* Added a handler `handleMiddleMouseClick()` for the `mouseup` event
* Moved code related to middle-mouse click from `handleClickFilename()` into the new handler
* Removed the previous attempt to fix #2663 (the `event.stopPropagation()`)

<!-- Please provide any testing system -->
Tested on: Linux manjaro 5.14.21-2-MANJARO

## Additional info
It would be great if this could be tested by Windows, Mac, and other Linux users!
