### PR TITLE
Preference "Use the CodeMirror ... Home and End" works again on MacOS. Fixes #3050

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   silently
 - The log viewer now only displays errors and warnings initially
 - Fix a small visual glitch on macOS for toolbar searches
+- Fix `Use the CodeMirror default actions for Home and End` preference not working on MacOS
 
 ## Under the Hood
 

--- a/source/common/modules/markdown-editor/generate-keymap.ts
+++ b/source/common/modules/markdown-editor/generate-keymap.ts
@@ -39,6 +39,11 @@ export default function (): KeyMap {
   keymap['Alt-Up'] = 'swapLineUp'
   keymap['Alt-Down'] = 'swapLineDown'
 
+  // If homeEndBehaviour is true, use defaults (paragraph start/end), if it's
+  // false, use visible lines.
+  keymap['Home'] = (homeEndBehaviour) ? 'goLineStart' : 'goLineLeftMarkdown'
+  keymap['End'] = (homeEndBehaviour) ? 'golineEnd' : 'goLineRight'
+
   // macOS only shortcuts
   if (process.platform === 'darwin') {
     keymap['Cmd-F'] = false // Disable the internal search
@@ -74,10 +79,6 @@ export default function (): KeyMap {
       const plainText = clipboard.readText()
       cm.replaceSelection(plainText)
     }
-    // If homeEndBehaviour is true, use defaults (paragraph start/end), if it's
-    // false, use visible lines.
-    keymap['Home'] = (homeEndBehaviour) ? 'goLineStart' : 'goLineLeftMarkdown'
-    keymap['End'] = (homeEndBehaviour) ? 'golineEnd' : 'goLineRight'
     keymap['Ctrl-Alt-F'] = 'insertFootnote'
     keymap['Ctrl-T'] = 'markdownMakeTaskList'
     keymap['Shift-Ctrl-C'] = 'markdownComment'


### PR DESCRIPTION

  - [X] I documented all behaviour as far as I could do.
  - [X] I target the develop-branch, and *not* the master branch.
  - [X] I have tested this extensively and paid extra attention to
        potential cross-platform issues (e.g. Cmd/Ctrl/Super-key bindings)
  - [X] I have made use of ESLint using the provided configuration from the
        repository's .eslintrc.json file, and it did not complain.
  - [X] I have added an entry to the CHANGELOG.md.
  - [X] I matched my code-style to the repository (as far as possible).
  - [X] I do agree that my code will be published under the GNU GPL v3 license.
  - [X] As far as JS-files are concerned, I made sure to copy (in case of new files)
        or adapt (in case of existing files) the info in the header.
  - [X] I synced the latest commits to develop shortly before proposing
        so that no merge issues occur.

## Description
see #3050

## Changes
Code for Home/End key configuration was somehow moved to "Non Darwin" platforms only.
Now moved to the general section.

## Additional information
Tested on: MacOS
