### PR TITLE
Fix: Filemanager now shows character count or word count depending on preference setting, Fixes #3075

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - The file tree now expands when you are filtering for files/directories
 - Translate the auto dark mode start/end setting strings
 - The ToC now displays the currently active section
+- Fix file manager always showing word count, even if user selected character count in preferences
 
 ## Under the Hood
 

--- a/source/win-main/file-manager/file-item.vue
+++ b/source/win-main/file-manager/file-item.vue
@@ -53,7 +53,7 @@
         <div v-if="isDirectory">
           <span class="badge">{{ countDirs }}</span>
           <span class="badge">{{ countFiles }}</span>
-          <span class="badge">{{ countWords }}</span>
+          <span class="badge">{{ countWordsOrCharsOfDirectory }}</span>
         </div>
         <template v-else>
           <div v-if="hasTags">
@@ -89,7 +89,7 @@
               relation to a set writing target, if there is one.
             -->
             <span v-else-if="!hasWritingTarget" class="badge">
-              {{ formattedWordCount }}
+              {{ formattedWordCharCountOfFile }}
             </span>
             <span v-else class="badge">
               <svg
@@ -163,6 +163,9 @@ export default defineComponent({
     }
   },
   computed: {
+    shouldCountChars: function (): boolean {
+      return this.$store.state.config['editor.countChars']
+    },
     useH1: function (): boolean {
       return this.$store.state.config.fileNameDisplay.includes('heading')
     },
@@ -230,17 +233,24 @@ export default defineComponent({
       }
       return this.obj.children.filter((e: any) => [ 'file', 'code' ].includes(e.type)).length + ' ' + trans('system.files') || 0
     },
-    countWords: function () {
+    countWordsOrCharsOfDirectory: function () {
       if (this.obj.type !== 'directory') {
         return 0
       }
 
-      const wordCount = this.obj.children
-        .filter((file: any) => file.type === 'file')
-        .map((file: any) => file.wordCount)
-        .reduce((prev: number, cur: number) => prev + cur, 0)
-
-      return trans('gui.words', localiseNumber(wordCount))
+      if (this.shouldCountChars) {
+        const charCount = this.obj.children
+          .filter((file: any) => file.type === 'file')
+          .map((file: any) => file.charCount)
+          .reduce((prev: number, cur: number) => prev + cur, 0)
+        return trans('gui.chars', localiseNumber(charCount))
+      } else {
+        const wordCount = this.obj.children
+          .filter((file: any) => file.type === 'file')
+          .map((file: any) => file.wordCount)
+          .reduce((prev: number, cur: number) => prev + cur, 0)
+        return trans('gui.words', localiseNumber(wordCount))
+      }
     },
     countTags: function () {
       if (this.obj.type !== 'file') {
@@ -292,12 +302,15 @@ export default defineComponent({
 
       return `${localiseNumber(current)} / ${localiseNumber(this.obj.target.count)} ${label} (${progress} %)`
     },
-    formattedWordCount: function () {
+    formattedWordCharCountOfFile: function () {
       if (this.obj.type !== 'file') {
         return '' // Failsafe because code files don't have a word count.
       }
-      // TODO: Enable char count as well!!
-      return trans('gui.words', localiseNumber(this.obj.wordCount))
+      if (this.shouldCountChars) {
+        return trans('gui.chars', localiseNumber(this.obj.charCount))
+      } else {
+        return trans('gui.words', localiseNumber(this.obj.wordCount))
+      }
     },
     formattedSize: function () {
       return formatSize(this.obj.size)

--- a/source/win-main/file-manager/file-item.vue
+++ b/source/win-main/file-manager/file-item.vue
@@ -235,22 +235,14 @@ export default defineComponent({
     },
     countWordsOrCharsOfDirectory: function () {
       if (this.obj.type !== 'directory') {
-        return 0
+        return ''
       }
 
-      if (this.shouldCountChars) {
-        const charCount = this.obj.children
-          .filter((file: any) => file.type === 'file')
-          .map((file: any) => file.charCount)
-          .reduce((prev: number, cur: number) => prev + cur, 0)
-        return trans('gui.chars', localiseNumber(charCount))
-      } else {
-        const wordCount = this.obj.children
-          .filter((file: any) => file.type === 'file')
-          .map((file: any) => file.wordCount)
-          .reduce((prev: number, cur: number) => prev + cur, 0)
-        return trans('gui.words', localiseNumber(wordCount))
-      }
+      const wordOrCharCount = this.obj.children
+        .filter((file: any) => file.type === 'file')
+        .map((file: any) => this.shouldCountChars ? file.charCount : file.wordCount)
+        .reduce((prev: number, cur: number) => prev + cur, 0)
+      return trans((this.shouldCountChars ? 'gui.chars' : 'gui.words'), localiseNumber(wordOrCharCount))
     },
     countTags: function () {
       if (this.obj.type !== 'file') {


### PR DESCRIPTION

## Description
see #3075

## Changes
Reactively checking the user preferences and then either counting word or characters

## Additional information
* I spotted, that the filemanager numbers in word count and char count differ from the currently active and open files meta info shofing in the toolbar. But this diff was already in the word count stats. So not introduced and not fixed with this PR.

* Tested on: MacOS 12.1
