### PR TITLE
Highlight neighboring ToC headings

### DIFF
--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -19,8 +19,7 @@
         v-bind:key="idx"
         class="toc-entry-container"
         v-bind:style="{
-          'margin-left': `${entry.level * 10}px`
-        }"
+          'margin-left': `${entry.level * 10}px`, 'background-color': tocEntryContainerShade(idx)}"
         v-on:click="($root as any).jtl(entry.line)"
       >
         <div class="toc-level">
@@ -162,7 +161,9 @@ export default defineComponent({
   data: function () {
     return {
       bibContents: undefined as undefined|any[],
-      relatedFiles: [] as RelatedFile[]
+      relatedFiles: [] as RelatedFile[],
+      // Contains the ToC index of the currently active section
+      activeTocEntryIdx: undefined as undefined|number
     }
   },
   computed: {
@@ -451,7 +452,30 @@ export default defineComponent({
       }
 
       // True, when cursor lies between current and next heading
-      return (cursorLine >= tocEntryLine && cursorLine < nextTocEntryLine)
+      const isActive = (cursorLine >= tocEntryLine && cursorLine < nextTocEntryLine)
+      if (isActive) {
+        this.activeTocEntryIdx = tocEntryIdx
+      }
+      return isActive
+    },
+    /**
+     * Applies a background shade to the entry container depending on the
+     * distance to the active heading.
+     *
+     * @param   {number}  tocEntryIdx           Index of heading in ToC
+     */
+    tocEntryContainerShade: function (tocEntryIdx: number) {
+      const dist = Math.abs(tocEntryIdx - this.activeTocEntryIdx)
+
+      if (dist === 0) {
+        return 'rgba(255,255,255,1)'
+      } else if (dist === 1) {
+        return 'rgba(255,255,255,0.5)'
+      } else if (dist === 2) {
+        return 'rgba(255,255,255,0.25)'
+      } else if (dist === 3) {
+        return 'rgba(255,255,255,0.125)'
+      }
     }
   }
 })


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
This draft PR implements highlighting of neighboring ToC sections as the cursor moves through the file. Currently, a static highlighting scheme is employed, i.e., a fixed amount of sections is always highlighted, regardless of section sizes. The following screencast shows it in action:



https://user-images.githubusercontent.com/18646029/151075190-9fd72cc3-4e04-4d70-86c2-1637c9b35af5.mp4





## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
In `MainSidebar.vue`:
* The ToC index of the currently active (i.e., where the cursor is) section is now stored in the Vue data object
* Added a function `tocEntryContainerShade()` that returns an `rgba` string
    - The alpha value depends on the distance (between indices) to the active reading
    - The return value (rgba) is used as the background color for the `toc-entry-container` divs
    - The upper and lower three neighbors of the active section will be highlighted (see video above)

## Additional information / Open points
This is still WIP. Things that need to be discussed:
- [ ] Background colors (should be more subtle than in the video)
- [ ] How many neighboring sections to highlight
- [ ] Whether to keep the static highlighting OR adjust the alpha values of the headings depending on the cursor's distance to the currently highlighted sections
    - With the _static_ highlighting, you won't see anything change when moving through a very long section. In contrast, a _dynamic_ highlighting scheme would adjust the alpha values, and you would notice a shift as you approach the next section.

Also, in the near term, we have intended to base the highlighting on the current _viewport_.

<!-- Please provide any testing system -->
Tested on: Linux manjaro 5.14.21-2
