### PR TITLE
Typed version of IPC

### DIFF
--- a/source/app/ipcRenderer.ts
+++ b/source/app/ipcRenderer.ts
@@ -1,0 +1,25 @@
+import { IpcRenderer } from 'electron'
+import { PromisfiedProtocol } from './ipc'
+
+export const ipcRenderer: PromisfiedProtocol & IpcRenderer = new Proxy({}, {
+  get (target: any, propChannel: PropertyKey, receiver: any): any {
+    const electronIpcRenderer = (window as any).ipc as Electron.IpcRenderer
+
+    const channel = propChannel.toString()
+    // For backwards compatibility
+    if (channel === 'invoke') {
+      return electronIpcRenderer.invoke
+    } else if (channel === 'on') {
+      return electronIpcRenderer.on
+    }
+
+    return new Proxy({}, {
+      get (target: any, propMessage: PropertyKey, receiver: any): any {
+        const message = propMessage.toString()
+        return async function (...args: any[]) {
+          return await electronIpcRenderer.invoke(channel, { command: message, payload: args })
+        }
+      }
+    })
+  }
+})

--- a/source/app/service-providers/tag-provider.ts
+++ b/source/app/service-providers/tag-provider.ts
@@ -17,7 +17,7 @@ import path from 'path'
 import { app } from 'electron'
 import broadcastIpcMessage from '@common/util/broadcast-ipc-message'
 import { ColouredTag, TagDatabase } from '@dts/common/tag-provider'
-import { ipcMain } from '@common/ipc'
+import { ipcMain } from '../ipc'
 
 interface InternalTagRecord {
   text: string

--- a/source/common/ipc.ts
+++ b/source/common/ipc.ts
@@ -1,0 +1,138 @@
+import { TagProviderProtocol } from '@providers/tag-provider'
+import { IpcMainInvokeEvent, ipcMain as electronIpcMain, ipcRenderer as electronIpcRenderer, IpcRenderer } from 'electron'
+
+/**
+ * Defines all channels of the Ipc, and which commands are supported on this channel.
+ */
+interface IpcProtocol {
+  tagProvider: TagProviderProtocol
+}
+
+/**
+ * Union of all names of functions defined in the given type.
+ */
+type FunctionPropertyNames<T> = {
+  [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T]
+
+/**
+ * All functions defined in the given type.
+ */
+type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>
+
+/**
+ * Converts a union type to an intersection type.
+ */
+type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never
+
+/**
+ * If T is a function returning R, then Promisified<T> is a function with the same arguments returning Promise<R>
+ * (or simply the function T if R is already a promise).
+ */
+type Promisified<T extends Function> =
+ T extends (...args: infer P) => infer R
+   ? (R extends Promise<any>
+       ? (...args: P) => R
+       : (...args: P) => Promise<R>
+     )
+   : never
+
+/**
+* Replaces all functions of T by functions that return a Promise.
+*/
+type PromisfiedAll<T> = {
+  [K in keyof T]: T[K] extends Function ? Promisified<T[K]> : never;
+}
+
+/**
+ * Replaces all functions in all channels by functions that return a Promise.
+ */
+type PromisfiedProtocol = {
+  [K in keyof IpcProtocol]: PromisfiedAll<IpcProtocol[K]>
+}
+
+/**
+ * The name of the channel.
+ */
+type IpcChannel = keyof IpcProtocol
+
+/**
+ * The protocol (i.e. all possible commands) of the given channel.
+ */
+type ProtocolType<Channel extends IpcChannel> = FunctionProperties<IpcProtocol[Channel]>
+
+/**
+ * Union of all names of functions defined in the given channel.
+ */
+type MessageNameType<Channel extends IpcChannel> = keyof ProtocolType<Channel>
+
+/**
+ * The function of the given message (in the given channel).
+ */
+type MessageFunctionType<Channel extends IpcChannel, Message extends MessageNameType<Channel>> = ProtocolType<Channel>[Message]
+
+/**
+ * The parameters of the given message (in the given channel).
+ */
+type MessageParamsType<Channel extends IpcChannel, Message extends MessageNameType<Channel>> = MessageFunctionType<Channel, Message> extends (args: infer P) => any ? P : never
+
+/**
+ * The return type of the given message (in the given channel).
+ */
+type MessageReturnType<Channel extends IpcChannel, Message extends MessageNameType<Channel>> = MessageFunctionType<Channel, Message> extends (...args: any) => infer R ? R : never
+
+/**
+ * The message passed around on the Ipc.
+ */
+interface IpcMessage<Channel extends IpcChannel, Message extends MessageNameType<Channel>> {
+  command: Message
+  payload: MessageParamsType<Channel, Message>
+}
+
+/**
+ * The listener reacting to the Ipc message.
+ *
+ * In principle it should also work without the any return type at the end, in which case the GetListenerType type below would be treated as a function overload.
+ * However I couldn't find a way to convert an intersection of functions to a proper function overload.
+ */
+type IpcListener<Channel extends IpcChannel, Message extends MessageNameType<Channel>> = (event: IpcMainInvokeEvent, message: IpcMessage<Channel, Message>) => MessageReturnType<Channel, Message> | any
+
+/**
+ * Wraps the given message (as string) as a listener function reacting only to exactly this message.
+ */
+type ToListener<Channel extends IpcChannel, Message> = Message extends MessageNameType<Channel> ? IpcListener<Channel, Message> : never
+
+/**
+ * The listener reacting to possibly all messages in the given channel.
+ */
+type ListenerType<Channel extends IpcChannel> = UnionToIntersection<ToListener<Channel, MessageNameType<Channel>>>
+
+class IpcMain {
+  handle<Channel extends IpcChannel> (
+    channel: Channel,
+    listener: ListenerType<Channel>
+  ): void {
+    // @ts-expect-error: we know that the listener is a function
+    electronIpcMain.handle(channel, listener)
+  }
+}
+export const ipcMain = new IpcMain()
+
+export const ipcRenderer: PromisfiedProtocol & IpcRenderer = new Proxy({}, {
+  get (target: any, propChannel: PropertyKey, receiver: any): any {
+    const channel = propChannel.toString()
+    if (channel === 'invoke') {
+      // For backwards compatibility
+      return electronIpcRenderer.invoke
+    }
+
+    return new Proxy({}, {
+      get (target: any, propMessage: PropertyKey, receiver: any): any {
+        const message = propMessage.toString()
+        return async function (...args: any[]) {
+          return await electronIpcRenderer.invoke(channel, { command: message, payload: args })
+        }
+      }
+    })
+  }
+})

--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -141,11 +141,9 @@ import { ClarityIcons } from '@clr/icons'
 import TabBar from '@common/vue/TabBar.vue'
 import { defineComponent } from 'vue'
 import path from 'path'
-import { IpcRenderer } from 'electron'
 import { MDFileMeta, OtherFileMeta } from '@dts/common/fsal'
 import { TabbarControl } from '@dts/renderer/window'
-
-const ipcRenderer: IpcRenderer = (window as any).ipc
+import { ipcRenderer } from '@common/ipc'
 
 interface RelatedFile {
   file: string
@@ -341,10 +339,9 @@ export default defineComponent({
       // The second way files can be related to each other is via shared tags.
       // This relation is not as important as explicit links, so they should
       // be below the inbound linked files.
-      const recommendations = await ipcRenderer.invoke('tag-provider', {
-        command: 'recommend-matching-files',
-        payload: this.activeFile.tags.map(tag => tag) // De-proxy
-      })
+      const recommendations = await ipcRenderer.tagProvider.recommendMatchingFiles(
+        this.activeFile.tags.map(tag => tag) // De-proxy
+      )
 
       // Recommendations come in the form of [file: string]: string[]
       for (const filePath of Object.keys(recommendations)) {

--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -143,7 +143,7 @@ import { defineComponent } from 'vue'
 import path from 'path'
 import { MDFileMeta, OtherFileMeta } from '@dts/common/fsal'
 import { TabbarControl } from '@dts/renderer/window'
-import { ipcRenderer } from '@common/ipc'
+import { ipcRenderer } from '../app/ipcRenderer'
 
 interface RelatedFile {
   file: string

--- a/source/win-main/index.ts
+++ b/source/win-main/index.ts
@@ -63,8 +63,8 @@ document.addEventListener('drop', (event) => {
  * Listen to update events
  */
 function updateColouredTags (): void {
-  ipcRenderer.invoke('tag-provider', {
-    command: 'get-coloured-tags'
+  ipcRenderer.invoke('tagProvider', {
+    command: 'getColouredTags'
   })
     .then(tags => {
       app.$store.commit('colouredTags', tags)
@@ -111,7 +111,7 @@ ipcRenderer.on('config-provider', (event, { command, payload }) => {
 
 // Listen for updates to the tag database
 ipcRenderer.on('tags', (event) => {
-  ipcRenderer.invoke('tag-provider', { command: 'get-tags-database' })
+  ipcRenderer.invoke('tagProvider', { command: 'getTagsDatabase' })
     .then(tags => {
       app.$store.commit('updateTagDatabase', tags)
     })
@@ -119,7 +119,7 @@ ipcRenderer.on('tags', (event) => {
 })
 
 // Also send an initial update
-ipcRenderer.invoke('tag-provider', { command: 'get-tags-database' })
+ipcRenderer.invoke('tagProvider', { command: 'getTagsDatabase' })
   .then(tags => {
     app.$store.commit('updateTagDatabase', tags)
   })

--- a/source/win-tag-manager/App.vue
+++ b/source/win-tag-manager/App.vue
@@ -120,8 +120,8 @@ export default defineComponent({
     }
   },
   created: function () {
-    ipcRenderer.invoke('tag-provider', {
-      command: 'get-coloured-tags'
+    ipcRenderer.invoke('tagProvider', {
+      command: 'getColouredTags'
     })
       .then((tags) => {
         this.tags = tags
@@ -131,8 +131,8 @@ export default defineComponent({
   methods: {
     handleClick: function (controlID: string) {
       if (controlID === 'save') {
-        ipcRenderer.invoke('tag-provider', {
-          command: 'set-coloured-tags',
+        ipcRenderer.invoke('tagProvider', {
+          command: 'setColouredTags',
           payload: this.tags.map(tag => {
             // De-proxy the tags so they can be sent over IPC
             return {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Second try at a typed IPC, superseding https://github.com/Zettlr/Zettlr/pull/1048. The problem with that PR was that the IPC provider had to be a class implementing an interface. In this new version, we essentially don't change anything how IPC providers are defined.

With these changes everything in the IPC is now strongly typed: the caller as well as the definition of the provider. The only thing that didn't work was to properly check for the return type of the provider (so you can return something else than what is defined in the protocol). I tried several things, but fear that's a current limitation with typescript; will open an issue at the ts repo.

Inspiration came from https://github.com/antfu/webext-bridge#type-safe-protocols.
## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

- Create drop-in replacement of the `ipcMain` object from electron, with the only change that the `handle` method is now strongly typed.
- Create `ipcRenderer` object that acts as a proxy to create a more readable version to invoke ipc methods.
- Illustrate the process at the example of the tag provider. Only change necessary was to rename the commands to use pascal case, so that they fit the javascript convention of real names.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Cannot currently run it, because it fails with the following error:
```
WARNING in ./node_modules/electron/index.js
Invalid dependencies have been reported by plugins or loaders for this module. All reported dependencies need to be absolute paths.
Invalid dependencies may lead to broken watching and caching.
As best effort we try to convert all invalid values to absolute paths and converting globs into context dependencies, but this is deprecated behavior.
Loaders: Pass absolute paths to this.addDependency (existing files), this.addMissingDependency (not existing files), and this.addContextDependency (directories).
Plugins: Pass absolute paths to fileDependencies (existing files), missingDependencies (not existing files), and contextDependencies (directories).
Globs: They are not supported. Pass absolute path to the directory as context dependencies.
The following invalid values have been reported:
 * "D:/Programming/Zettlr/node_modules/electron/dist/LICENSE"
 * "D:/Programming/Zettlr/node_modules/electron/dist/LICENSES.chromium.html"
 * "D:/Programming/Zettlr/node_modules/electron/dist/chrome_100_percent.pak"
 * and more ...
 @ ./source/common/ipc.ts 4:19-38
 @ ./node_modules/ts-loader/index.js??clonedRuleSet-8.use!./node_modules/vue-loader/dist/index.js??ruleSet[0]!./source/win-main/MainSidebar.vue?vue&type=script&lang=ts 24:14-36
```
any idea what's going on? Is it not possible to use imports from electron in the renderer? The same issue for the language files had been reported before in https://github.com/Zettlr/Zettlr/issues/2029, but that doesn't seem relevant.

<!-- Please provide any testing system -->
Tested on: Win 11
