### PR TITLE
Show full path on DocumentTab hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The full-text search doesn't skip files whose title and/or tags match the
   search terms anymore
+- Hovering the mouse over a document tab now shows the full path of the file
 
 ## Under the Hood
 

--- a/source/win-main/DocumentTabs.vue
+++ b/source/win-main/DocumentTabs.vue
@@ -7,7 +7,7 @@
         active: activeFile !== null && file.path === activeFile.path,
         modified: modifiedDocs.includes(file.path)
       }"
-      v-bind:title="file.name"
+      v-bind:title="file.path"
       v-bind:data-path="file.path"
       role="tab"
       draggable="true"


### PR DESCRIPTION
Closes #3179

<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Hovering over a document tab now shows the full file path.

## Changes
See #3179.

<!-- Please provide any testing system -->
Tested on: Linux manjaro 5.14.21-2
