### PR TITLE
don't render emphasis without whitespace boundary; touches #3200

### DIFF
--- a/source/common/modules/markdown-editor/plugins/render-emphasis.ts
+++ b/source/common/modules/markdown-editor/plugins/render-emphasis.ts
@@ -14,7 +14,7 @@
 
 import CodeMirror, { commands } from 'codemirror'
 
-const emphasisRE = /(?<![\\])(?<=\s)([*_]{1,3}|~{2})((?!\s)[^*_]+?(?<![\s\\]))(?:[*_]{1,3}|~{2})(?=\s)/g
+const emphasisRE = /(?<![\\])(?<=\s|^)([*_]{1,3}|~{2})((?!\s)[^*_]+?(?<![\s\\]))(?:[*_]{1,3}|~{2})(?=\s|$)/g
 
 /**
  * Declare the markdownRenderEmphasis command

--- a/source/common/modules/markdown-editor/plugins/render-emphasis.ts
+++ b/source/common/modules/markdown-editor/plugins/render-emphasis.ts
@@ -14,7 +14,7 @@
 
 import CodeMirror, { commands } from 'codemirror'
 
-const emphasisRE = /(?<![\\])([*_]{1,3}|~{2})((?!\s)[^*_]+?(?<![\s\\]))(?:[*_]{1,3}|~{2})/g
+const emphasisRE = /(?<![\\])(?<=\s)([*_]{1,3}|~{2})((?!\s)[^*_]+?(?<![\s\\]))(?:[*_]{1,3}|~{2})(?=\s)/g
 
 /**
  * Declare the markdownRenderEmphasis command


### PR DESCRIPTION
## Description

The emphasis renderer is breaking the markdown convention of _requiring a space_ before and after the marked phrase. For example, the middle part should not be in italics:

> test_italics_test

But in Zettlr, it is:

> ![image](https://user-images.githubusercontent.com/1702193/154372309-65724d86-a5fa-4f20-8761-c72941b8727c.png)

This PR fixes this.

## Changes

Add non-capturing whitespace lookahead and lookbehind.

## Additional information

Tested on: Linux Mint 20
