### PR TITLE
Added support for JabRef fileDirectory directive in BibTeX files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ body div#tab-container {
 - Update most pure Node scripts from CommonJS to ESM in order to support the new
   versions of csso, chalk, and got
 - FINALLY managed to get fsevents to run! After about three years or so.
+- Add support for JabRef `fileDirectory`-style comments
 
 # 2.2.3
 

--- a/source/app/service-providers/citeproc/extract-bibtex-attachments.ts
+++ b/source/app/service-providers/citeproc/extract-bibtex-attachments.ts
@@ -14,6 +14,7 @@
 
 import path from 'path'
 import { bibtex } from 'astrocite'
+import { BracedComment } from 'astrocite-bibtex'
 import pdfSorter from '@common/util/sort-by-pdf'
 
 const AstrociteAST = bibtex.AST
@@ -37,14 +38,13 @@ export default function extractBibtexAttachments (
   let files = Object.create(null)
 
   // First we search for the jabref comments containing the files' root directories
-  for (let entry of ast.children) {
-    if (entry.kind !== 'BracedComment') {
-      continue
-    }
-
-    // The format of the value field is 'jabref-meta: fileDirectory*:<path>;'
-    if (entry.value.split(':')[1].trim().startsWith('fileDirectory')) {
-      baseDir = entry.value.split(':')[2].trim().replace(/;/g, '')
+  const comments = ast.children.filter(item => item.kind === 'BracedComment') as BracedComment[]
+  // The format of the value field is 'jabref-meta: fileDirectory*:<path>;'
+  const jabrefComments = comments.filter(item => item.value.startsWith('jabref-meta:'))
+  for (let entry of jabrefComments) {
+    const value = entry.value.split(':').map(e => e.trim())
+    if (value[1].startsWith('fileDirectory')) {
+      baseDir = value[2].replace(/;/g, '')
     }
   }
 

--- a/source/app/service-providers/citeproc/extract-bibtex-attachments.ts
+++ b/source/app/service-providers/citeproc/extract-bibtex-attachments.ts
@@ -36,6 +36,18 @@ export default function extractBibtexAttachments (
   // Return value will be a fast-access dictionary
   let files = Object.create(null)
 
+  // First we search for the jabref comments containing the files' root directories
+  for (let entry of ast.children) {
+    if (entry.kind !== 'BracedComment') {
+      continue
+    }
+
+    // The format of the value field is 'jabref-meta: fileDirectory*:<path>;'
+    if (entry.value.split(':')[1].trim().startsWith('fileDirectory')) {
+      baseDir = entry.value.split(':')[2].trim().replace(/;/g, '')
+    }
+  }
+
   // Now let's see what entries have files attached.
   // Such attributes are stored in properties within the entry.
   for (let entry of ast.children) {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
This PR adds parsing for `fileDirectory` comments in BibTeX files written by Jabref in order to correctly reference these files.

## Changes
I implemented a small parsing operation before the parsing of the entries to find the comments and extract the paths.

## Additional information
This is a first iteration, some additional features to discuss might be:

- more fine-grained control over which `fileDirectory`-paths get added (there are global and local ones, atm I just take the last)
- maybe a option in the settings to manually set a path if none is specified (potentially even overriding the `fileDirectory` paths)

<!-- Please provide any testing system -->
Tested on:  Arch Linux  5.16.11-arch1-1

Closes #619