### PR TITLE
fix: Simplify codeblock classes again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.2.6
+
+## GUI and Functionality
+
+(nothing here yet)
+
+## Under the Hood
+
+- Simplify the codeblock class hook again to significantly improve typing speed
+
 # 2.2.5
 
 ## GUI and Functionality

--- a/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
+++ b/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
@@ -60,6 +60,9 @@ function findCode (cm: CodeMirror.Editor): void {
         // Increment the lineCount and apply the code start line to that line
         cm.addLineClass(++i, 'wrap', codeblockClass)
         cm.addLineClass(i, 'wrap', codeblockClassOpen)
+        // Remove a potential close class, in case we have just one line of
+        // code block; found by @kyaso
+        cm.removeLineClass(i, 'wrap', codeblockClassClose)
       }
     } else if (codeBlockRE.test(line) && inCodeBlock) {
       // End a codeblock: Remove any codeblock class

--- a/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
+++ b/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
@@ -12,13 +12,9 @@
  * END HEADER
  */
 import CodeMirror from 'codemirror'
-// import { debounce, range } from 'lodash'
 const codeblockClass = 'code-block-line'
 const codeblockClassOpen = 'code-block-first-line'
 const codeblockClassClose = 'code-block-last-line'
-// The debounce timeout needs to be exactly the same as but no less than the
-// debounce timeout used in CodeMirror Markdown Mode.
-// const findCodeDebounced = debounce(findCode, 400, { leading: true })
 
 /**
  * Hooks onto the cursorActivity, optionChange and keyHandled event to apply
@@ -29,9 +25,7 @@ const codeblockClassClose = 'code-block-last-line'
  */
 export default function codeblockClassHook (cm: CodeMirror.Editor): void {
   cm.on('keyHandled', handleNewline)
-  // cm.on('cursorActivity', findCodeDebounced)
   cm.on('cursorActivity', findCode)
-  // cm.on('optionChange', findCodeDebounced)
   cm.on('optionChange', findCode)
 }
 

--- a/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
+++ b/source/common/modules/markdown-editor/hooks/codeblock-classes.ts
@@ -24,22 +24,8 @@ const codeblockClassClose = 'code-block-last-line'
  * @param   {CodeMirror.Editor}  cm  The instance
  */
 export default function codeblockClassHook (cm: CodeMirror.Editor): void {
-  cm.on('keyHandled', handleNewline)
-  cm.on('cursorActivity', findCode)
-  cm.on('optionChange', findCode)
-}
-
-/**
- * When pressing Enter inside a code block, do not debounce but make sure the
- * new line is styled properly immediately
- *
- * @param   {CodeMirror.Editor}  cm  The instance
- * @param   {string}  name  The key pressed
- */
-function handleNewline (cm: CodeMirror.Editor, name: string): void {
-  if (name === 'Enter') {
-    findCode(cm)
-  }
+  cm.on('change', findCode)
+  cm.on('swapDoc', findCode)
 }
 
 /**


### PR DESCRIPTION
## Description

This PR attempts to solve #3295 by simplifying the codeblock class application.

## Changes

* Remove the specific checks for certain Markdown mode classes in order to distinguish list items from indented code block lines
* Indented codeblocks will now no longer have the background classes applied under the assumption that most people will probably want to use fenced code blocks either way (or is this assumption wrong? Feedback very welcome)

## Additional information

@kyaso I noticed that you complained that `startOperation` and `endOperation` mingled with the VIM mode, correct? The problem is that we have to have those operations. Otherwise the lag will be even significantly worse than before, because CodeMirror will force a refresh once classes are being changed via `addLineClass` and `removeLineClass`. This almost sounds like an interference between the vim mode and CodeMirror itself, noting that the vim mode has no maintainer and the code is several years old now.

<!-- Please provide any testing system -->
Tested on: macOS Monterey 12.2.1, but really should be platform-agnostic I hope
