### PR TITLE
Fix related files latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a small visual glitch on Linux where the selected file was not
   highlighted in the file list in the thin or expanded file manager modes
 - Fixed heading ID links not working with, e.g., accents
+- Fixed heavy latency when working on a file with many related files
 
 ## Under the Hood
 

--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -609,19 +609,22 @@ body {
       padding: 10px;
 
       div.related-file {
+        // NOTE: The margin + height equal 42, which was the automatic height
+        // before we fixed it here. We have to fix it because the Recycle
+        // scroller requires completely fixed heights.
         margin-bottom: 10px;
         display: flex;
         align-items: center;
+        padding: 10px 5px;
+        height: 32px;
 
-        &:hover {
-          background-color: rgb(200, 200, 200);
-        }
+        &:hover { background-color: rgb(200, 200, 200); }
 
         span.filename {
           display: inline-block;
           font-size: 11px;
-          padding: 10px 5px;
           flex-grow: 8;
+          overflow: hidden;
         }
 
         span.icons {

--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -190,6 +190,15 @@ export default defineComponent({
     }
   },
   computed: {
+    /**
+     * The Vue Virtual Scroller component expects an array of objects which
+     * expose two properties: id and "props". The latter contains the actual
+     * object (i.e. the RelatedFile). We may want to merge this functionality
+     * into the RelatedFiles generation later on, but this is the safest way
+     * for now.
+     *
+     * @return  {{ id: number, props: RelatedFile }}  The data for the scroller
+     */
     scrollerRelatedFiles: function (): any {
       return this.relatedFiles.map((elem, idx) => {
         return { id: idx, props: elem }

--- a/source/win-main/MainSidebar.vue
+++ b/source/win-main/MainSidebar.vue
@@ -54,46 +54,53 @@
           {{ noRelatedFilesMessage }}
         </div>
         <div v-else>
-          <div
-            v-for="fileRecord, idx in relatedFiles"
-            v-bind:key="idx"
-            v-bind:class="{
-              'related-file': true,
-              'tags': fileRecord.tags.length > 0,
-              'inbound': fileRecord.link === 'inbound',
-              'outbound': fileRecord.link === 'outbound',
-              'bidirectional': fileRecord.link === 'bidirectional'
-            }"
+          <RecycleScroller
+            v-slot="{ item, index }"
+            v-bind:items="scrollerRelatedFiles"
+            v-bind:item-size="43"
+            v-bind:emit-update="true"
+            v-bind:page-mode="true"
           >
-            <span
-              class="filename"
-              draggable="true"
-              v-on:mousedown.stop="requestFile($event, fileRecord.path)"
-              v-on:dragstart="beginDragRelatedFile($event, fileRecord.path)"
-            >{{ getRelatedFileName(fileRecord.path) }}</span>
-            <span class="icons">
-              <clr-icon
-                v-if="fileRecord.tags.length > 0"
-                shape="tag"
-                title="This relation is based on tag similarity."
-              ></clr-icon>
-              <clr-icon
-                v-if="fileRecord.link === 'inbound'"
-                shape="arrow left"
-                title="This relation is based on a backlink."
-              ></clr-icon>
-              <clr-icon
-                v-else-if="fileRecord.link === 'outbound'"
-                shape="arrow right"
-                title="This relation is based on an outbound link."
-              ></clr-icon>
-              <clr-icon
-                v-else-if="fileRecord.link === 'bidirectional'"
-                shape="two-way-arrows"
-                title="This relation is based on a bidirectional link."
-              ></clr-icon>
-            </span>
-          </div>
+            <div
+              v-bind:key="index"
+              v-bind:class="{
+                'related-file': true,
+                'tags': item.props.tags.length > 0,
+                'inbound': item.props.link === 'inbound',
+                'outbound': item.props.link === 'outbound',
+                'bidirectional': item.props.link === 'bidirectional'
+              }"
+              v-on:mousedown.stop="requestFile($event, item.props.path)"
+              v-on:dragstart="beginDragRelatedFile($event, item.props.path)"
+            >
+              <span
+                class="filename"
+                draggable="true"
+              >{{ getRelatedFileName(item.props.path) }}</span>
+              <span class="icons">
+                <clr-icon
+                  v-if="item.props.tags.length > 0"
+                  shape="tag"
+                  title="This relation is based on tag similarity."
+                ></clr-icon>
+                <clr-icon
+                  v-if="item.props.link === 'inbound'"
+                  shape="arrow left"
+                  title="This relation is based on a backlink."
+                ></clr-icon>
+                <clr-icon
+                  v-else-if="item.props.link === 'outbound'"
+                  shape="arrow right"
+                  title="This relation is based on an outbound link."
+                ></clr-icon>
+                <clr-icon
+                  v-else-if="item.props.link === 'bidirectional'"
+                  shape="two-way-arrows"
+                  title="This relation is based on a bidirectional link."
+                ></clr-icon>
+              </span>
+            </div>
+          </RecycleScroller>
         </div>
       </div>
     </div>
@@ -156,6 +163,7 @@ import { trans } from '@common/i18n-renderer'
 import { ClarityIcons } from '@clr/icons'
 import TabBar from '@common/vue/TabBar.vue'
 import { defineComponent } from 'vue'
+import { RecycleScroller } from 'vue-virtual-scroller'
 import { DirMeta, MDFileMeta, OtherFileMeta } from '@dts/common/fsal'
 import { TabbarControl } from '@dts/renderer/window'
 
@@ -172,7 +180,8 @@ interface RelatedFile {
 export default defineComponent({
   name: 'MainSidebar',
   components: {
-    TabBar
+    TabBar,
+    RecycleScroller
   },
   data: function () {
     return {
@@ -181,6 +190,11 @@ export default defineComponent({
     }
   },
   computed: {
+    scrollerRelatedFiles: function (): any {
+      return this.relatedFiles.map((elem, idx) => {
+        return { id: idx, props: elem }
+      })
+    },
     currentTab: function (): string {
       return this.$store.state.config['window.currentSidebarTab']
     },
@@ -599,15 +613,15 @@ body {
         display: flex;
         align-items: center;
 
+        &:hover {
+          background-color: rgb(200, 200, 200);
+        }
+
         span.filename {
           display: inline-block;
           font-size: 11px;
           padding: 10px 5px;
           flex-grow: 8;
-
-          &:hover {
-            background-color: rgb(200, 200, 200);
-          }
         }
 
         span.icons {
@@ -627,10 +641,8 @@ body {
       background-color: rgba(30, 30, 30, 1);
       color: rgb(230, 230, 230);
 
-      div.related-files-container {
-        div.related-file {
-          span.filename:hover { background-color: rgb(80, 80, 80); }
-        }
+      div.related-files-container div.related-file:hover {
+        background-color: rgb(80, 80, 80);
       }
     }
   }
@@ -644,7 +656,7 @@ body.darwin {
     background-color: transparent;
 
     div.related-files-container {
-      div.related-file span.filename { border-radius: 4px; }
+      div.related-file { border-radius: 4px; }
     }
   }
 


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

This PR attempts to fix #3399 by reducing the workload the DOM has to do with regard to repainting.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

Instead of vomiting the 2000+ files that may be related directly into the DOM of the sidebar, this PR makes use of the `RecycleScroller` which is already in use in the file list. The idea: While calculating the related files is very fast, displaying each on the DOM is very computation-heavy. This PR does not change the generation of related files, but only its display.

I tested this out with the quick and dirty file generation script from @Redsandro both with autosave off and autosave immediately. The lag was gone and while the related files still flicker a little bit, typing is as quick as it can possibly get.

To make sure, I also tested out the very same files on the older branch, and could confirm that there was suddenly some lag.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

**I noticed a few other things we have to do later**

1. Disaggregate the sidebar. It's way too full. And iirc someone even called me out for this before 🙈 
2. Finally fix the sidebar in so far that the tab bar and the panel header always stay fixed and only the content scrolls.

But that is for another PR.

**Edit: What I must fix before merging is that the related file items can currently be of variable height (e.g. for longer file names). Recyclescroller doesn't like that. Ideas on how to do that design-wise welcome.**

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS Monterey 12.3.1
