### PR TITLE
Fix translate key conflict

### DIFF
--- a/source/win-preferences/App.vue
+++ b/source/win-preferences/App.vue
@@ -174,7 +174,7 @@ export default defineComponent({
           icon: 'tools'
         },
         {
-          label: trans('dialog.preferences.toolbar'),
+          label: trans('dialog.preferences.toolbar.customize'),
           controls: 'tab-toolbar',
           id: 'tab-toolbar-control',
           icon: 'container'


### PR DESCRIPTION
## Description
Fix translate key conflict bug for this [PR](https://github.com/Zettlr/Zettlr/pull/3430) 
In `~/source/win-preferences/App.vue` line 177 use translate key as ``'dialog.preferences.toolbar'``, it is conflict with translate keys in file `~/source/win-preferences/schema/toolbar.ts` which like  `'dialog.preferences.toolbar.showOpenPreferencesButton'`.

## Changes
rename `'dialog.preferences.toolbar'` to `dialog.preferences.toolbar.customize`
