### PR TITLE
cURL needs to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ After you have installed Zettlr, [head over to our documentation](https://docs.z
 
 ## Contributing
 
-Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have:
+Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have installed on your computer:
 
-1. A [NodeJS](https://nodejs.org/)-stack installed on your computer. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
+1. A [NodeJS](https://nodejs.org/)-stack. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
 2. [Yarn](https://yarnpkg.com/en/). This is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
 3. [cURL](https://curl.se/download.html). This library is required to fetch Pandoc in the background.
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ After you have installed Zettlr, [head over to our documentation](https://docs.z
 Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have:
 
 1. A [NodeJS](https://nodejs.org/)-stack installed on your computer. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
-2. [Yarn](https://yarnpkg.com/en/) installed. Yarn is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
-3. [cURL](https://curl.se/download.html). This is required to fetch Pandoc in the background.
+2. [Yarn](https://yarnpkg.com/en/). This is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
+3. [cURL](https://curl.se/download.html). This library is required to fetch Pandoc in the background.
 
 Then, simply clone the repository and install the dependencies on your local computer:
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start deve
 
 1. A [NodeJS](https://nodejs.org/)-stack installed on your computer. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
 2. [Yarn](https://yarnpkg.com/en/) installed. Yarn is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
-
-Note that [cURL](https://curl.se/download.html) library needs to be installed on your computer.
+3. [cURL](https://curl.se/download.html). This is required to fetch Pandoc in the background.
 
 Then, simply clone the repository and install the dependencies on your local computer:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start deve
 1. A [NodeJS](https://nodejs.org/)-stack installed on your computer. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
 2. [Yarn](https://yarnpkg.com/en/) installed. Yarn is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
 
+Note that [cURL](https://curl.se/download.html) library needs to be installed on your computer.
+
 Then, simply clone the repository and install the dependencies on your local computer:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ After you have installed Zettlr, [head over to our documentation](https://docs.z
 
 ## Contributing
 
-Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have installed on your computer:
+Zettlr is an [Electron](https://www.electronjs.org/)-based app, so to start developing, you'll need to have the following installed on your computer:
 
 1. A [NodeJS](https://nodejs.org/)-stack. Make sure it's at least Node 14 (`lts/fermium`). To test what version you have, run `node -v`.
-2. [Yarn](https://yarnpkg.com/en/). This is the required package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
-3. [cURL](https://curl.se/download.html). This library is required to fetch Pandoc in the background.
+2. [Yarn](https://yarnpkg.com/en/). This is the package manager for the project, as we do not commit `package-lock.json`-files and many commands require yarn. You can install this globally using `npm install -g yarn` or Homebrew, if you are on macOS.
+3. [cURL](https://curl.se/download.html). This library is required to fetch Pandoc in the background. (This is already installed on some \*nix-platforms.)
 
 Then, simply clone the repository and install the dependencies on your local computer:
 


### PR DESCRIPTION
## Description
A little add to the `README.md` file to signal cURL needs to be installed. Otherwise, yarn can't run `/script/get-pandoc.sh` at line 98.
