### PR TITLE
Added test case and improved error message to be more descriptive.

### DIFF
--- a/test/count-words.spec.ts
+++ b/test/count-words.spec.ts
@@ -18,6 +18,11 @@ import { strictEqual } from 'assert'
 
 const countWordsTesters = [
   {
+    input: '',
+    expectedWords: 0,
+    expectedChars: 0
+  },
+  {
     input: 'Lorem\n\n# Ipsum',
     expectedWords: 2,
     expectedChars: 12
@@ -61,12 +66,15 @@ const countWordsTesters = [
 
 describe('Utility#countWords()', function () {
   for (let test of countWordsTesters) {
-    it(`should return ${test.expectedWords} words`, function () {
-      strictEqual(countWords(test.input, false), test.expectedWords)
+    let wordCount = countWords(test.input, false)
+    let charCount = countWords(test.input, true)
+
+    it(`should return ${test.expectedWords} words` + (wordCount !== test.expectedWords ? ` but returned ${wordCount}` : ''), function () {
+      strictEqual(wordCount, test.expectedWords)
     })
 
-    it(`should return ${test.expectedChars} characters`, function () {
-      strictEqual(countWords(test.input, true), test.expectedChars)
+    it(`should return ${test.expectedChars} characters` + (charCount !== test.expectedChars ? ` but returned ${charCount}` : ''), function () {
+      strictEqual(charCount, test.expectedChars)
     })
   }
 })

--- a/test/count-words.spec.ts
+++ b/test/count-words.spec.ts
@@ -66,26 +66,12 @@ const countWordsTesters = [
 
 describe('Utility#countWords()', function () {
   for (let test of countWordsTesters) {
-    const wordCount = countWords(test.input, false)
-    const charCount = countWords(test.input, true)
-
-    let wordCountMessage = `should return ${test.expectedWords} words`
-    let charCountMessage = `should return ${test.expectedChars} characters`
-
-    if (wordCount !== test.expectedWords) {
-      wordCountMessage += ` but returned ${wordCount} words`
-    }
-
-    if (charCount !== test.expectedChars) {
-      charCountMessage += ` but returned ${charCount} characters`
-    }
-
-    it(wordCountMessage, function () {
-      strictEqual(wordCount, test.expectedWords)
+    it(`should return ${test.expectedWords} words`, function () {
+      strictEqual(countWords(test.input, false), test.expectedWords)
     })
 
-    it(charCountMessage, function () {
-      strictEqual(charCount, test.expectedChars)
+    it(`should return ${test.expectedChars} characters`, function () {
+      strictEqual(countWords(test.input, true), test.expectedChars)
     })
   }
 })

--- a/test/count-words.spec.ts
+++ b/test/count-words.spec.ts
@@ -66,8 +66,8 @@ const countWordsTesters = [
 
 describe('Utility#countWords()', function () {
   for (let test of countWordsTesters) {
-    let wordCount = countWords(test.input, false)
-    let charCount = countWords(test.input, true)
+    const wordCount = countWords(test.input, false)
+    const charCount = countWords(test.input, true)
 
     it(`should return ${test.expectedWords} words` + (wordCount !== test.expectedWords ? ` but returned ${wordCount}` : ''), function () {
       strictEqual(wordCount, test.expectedWords)

--- a/test/count-words.spec.ts
+++ b/test/count-words.spec.ts
@@ -69,11 +69,22 @@ describe('Utility#countWords()', function () {
     const wordCount = countWords(test.input, false)
     const charCount = countWords(test.input, true)
 
-    it(`should return ${test.expectedWords} words` + (wordCount !== test.expectedWords ? ` but returned ${wordCount}` : ''), function () {
+    let wordCountMessage = `should return ${test.expectedWords} words`
+    let charCountMessage = `should return ${test.expectedChars} characters`
+
+    if (wordCount !== test.expectedWords) {
+      wordCountMessage += ` but returned ${wordCount} words`
+    }
+
+    if (charCount !== test.expectedChars) {
+      charCountMessage += ` but returned ${charCount} characters`
+    }
+
+    it(wordCountMessage, function () {
       strictEqual(wordCount, test.expectedWords)
     })
 
-    it(`should return ${test.expectedChars} characters` + (charCount !== test.expectedChars ? ` but returned ${charCount}` : ''), function () {
+    it(charCountMessage, function () {
       strictEqual(charCount, test.expectedChars)
     })
   }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Added code that will append a string to the test output if the word/char count is not equal to the expected values.
This appended string will state what the actual word/char count value is.
Also added a test case with an empty sentence on top of the test cases.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Introduced to variables `wordCount` and `charCount` and used those variables with a ternary operator to append a string with the actual value if the value was not equal to the expected value.

Below is the current error message output, that "only" states what value was expected.

<img width="328" alt="current_errormessage" src="https://user-images.githubusercontent.com/26281193/208099946-e7c1e7ac-cc46-4286-98bb-386222c4e53a.png">

In this PR, the string value now also displays the actual value for further information about what the `countWords(...)` function actually returns.

<img width="427" alt="improved_errormessage" src="https://user-images.githubusercontent.com/26281193/208099864-014f1b11-d7b5-438d-a3f8-4aa621d1f11d.png">

Also an edge test case was added, that test if the `countWords(...)` function correctly returns the expected values if the provided sentence is empty.

<img width="242" alt="empty_sentence" src="https://user-images.githubusercontent.com/26281193/208100504-5cd0e076-7f58-478c-a04c-06cd93bfef8e.png">




## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: macOS Monterey 12.6.1
