### PR TITLE
Do not crash on empty window_state.yml

### DIFF
--- a/source/app/service-providers/windows/index.ts
+++ b/source/app/service-providers/windows/index.ts
@@ -252,7 +252,7 @@ export default class WindowProvider extends ProviderContract {
     this._logger.verbose('Window manager booting up ...')
 
     // Immediately begin loading the data
-    if (!await this._stateContainer.isInitialized()) {
+    if (!await this._stateContainer.isInitialized() || (await this._stateContainer.get()) === null) {
       await this._stateContainer.init(Object.fromEntries(this._windowState))
     }
     const tmpObject = await this._stateContainer.get()

--- a/source/app/service-providers/windows/index.ts
+++ b/source/app/service-providers/windows/index.ts
@@ -252,7 +252,7 @@ export default class WindowProvider extends ProviderContract {
     this._logger.verbose('Window manager booting up ...')
 
     // Immediately begin loading the data
-    if (!await this._stateContainer.isInitialized() || (await this._stateContainer.get()) === null) {
+    if (!await this._stateContainer.isInitialized()) {
       await this._stateContainer.init(Object.fromEntries(this._windowState))
     }
     const tmpObject = await this._stateContainer.get()

--- a/source/common/modules/persistent-data-container/index.ts
+++ b/source/common/modules/persistent-data-container/index.ts
@@ -94,7 +94,7 @@ export default class PersistentDataContainer {
   public async isInitialized (): Promise<boolean> {
     try {
       await fs.access(this._filePath, FSConstants.R_OK | FSConstants.W_OK)
-      return (await this.get()) !== null
+      return (await fs.readFile(this._filePath, { encoding: 'utf-8' })).trim() !== ''
     } catch (err: any) {
       return false
     }

--- a/source/common/modules/persistent-data-container/index.ts
+++ b/source/common/modules/persistent-data-container/index.ts
@@ -94,7 +94,8 @@ export default class PersistentDataContainer {
   public async isInitialized (): Promise<boolean> {
     try {
       await fs.access(this._filePath, FSConstants.R_OK | FSConstants.W_OK)
-      return (await fs.readFile(this._filePath, { encoding: 'utf-8' })).trim() !== ''
+      const contents = await fs.readFile(this._filePath, 'utf-8')
+      return contents.trim() !== ''
     } catch (err: any) {
       return false
     }

--- a/source/common/modules/persistent-data-container/index.ts
+++ b/source/common/modules/persistent-data-container/index.ts
@@ -94,7 +94,7 @@ export default class PersistentDataContainer {
   public async isInitialized (): Promise<boolean> {
     try {
       await fs.access(this._filePath, FSConstants.R_OK | FSConstants.W_OK)
-      return true
+      return (await this.get()) !== null
     } catch (err: any) {
       return false
     }


### PR DESCRIPTION
## Description
Fixes #4099 

## Changes
Zettlr Crashes at start if `window_state.yml` exists but is empty. This happens because the stateContainer is initialized (because the file can be read) but when interpreting the file (`stateContainer.get()`), no content is available, so it returns null which cannot be handled by `Object.entries`.

## Additional information
The real error behind this is: Why is an empty `window_state.yml` written generally. But as the error seems to occur just at my PC, this might be too much to investigate. So, I guess this might be an acceptable workaround.

If you don't think so, or you have a better idea to fix this, feel free to close this PR.

Tested on: Ubuntu 22.04
