### PR TITLE
run Linux builds on Ubuntu 20.04 machines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
   # havoc because we don't push unstable code to master, BUT it looks bad.
   verify_version:
     name: 'Preflight: Verify version tag'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository (master branch)
         uses: actions/checkout@v3
@@ -329,7 +329,7 @@ jobs:
     env:
       npm_config_arch: x64
     needs: [preflight, verify_version]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Check out master for a regular release, or develop branch for a nightly
       - name: Checkout branch ${{ github.ref_name }}
@@ -366,7 +366,7 @@ jobs:
     env:
       npm_config_arch: arm64
     needs: [preflight, verify_version]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v3
@@ -416,7 +416,7 @@ jobs:
       - build_macos_arm64
       - build_linux_x64
       - build_linux_arm64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v3


### PR DESCRIPTION
Builds made against Ubuntu 22.04's glibc won't work on environments with an older glibc, like Debian or Ubuntu 20.04's installations.

This patch changes the builder workflows to make GNU/Linux builds be created in an Ubuntu 20.04 environment, producing builds that work on both older and more recent environments.

Closes: #4049

I have  *not* added an entry to the CHANGELOG.md, as this introduces no change from the previous Zettlr version.
Tested on: Ubuntu 20.04