### PR TITLE
Have more verbose (and useful) error messages

### DIFF
--- a/source/app/service-providers/windows/index.ts
+++ b/source/app/service-providers/windows/index.ts
@@ -256,6 +256,7 @@ export default class WindowProvider extends ProviderContract {
       await this._stateContainer.init(Object.fromEntries(this._windowState))
     }
     const tmpObject = await this._stateContainer.get()
+    if (tmpObject === null) this._logger.error('[Window Manager] tmpObject is null');
     this._windowState = new Map(Object.entries(tmpObject))
     this._logger.info('[Window Manager] Window Manager started.')
   }

--- a/source/common/modules/persistent-data-container/index.ts
+++ b/source/common/modules/persistent-data-container/index.ts
@@ -139,6 +139,7 @@ export default class PersistentDataContainer {
     try {
       const content = await fs.readFile(this._filePath, { encoding: 'utf-8' })
 
+      if (content.trim().length === 0) throw new Error("Container at " + this._filePath + " was empty (content is null).");
       if (this._dataType === 'json') {
         this._data = JSON.parse(content)
       } else {


### PR DESCRIPTION
If a data container file is empty, we'll now have a more useful error message showing to the user.