### PR TITLE
Insert DisplayName instead of FileName after an zkn-link

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/files.ts
+++ b/source/common/modules/markdown-editor/autocomplete/files.ts
@@ -34,7 +34,7 @@ export const filesUpdateField = StateField.define<Completion[]>({
           return {
             label: entry.displayName,
             detail: entry.id !== '' ? entry.id : undefined,
-            apply: apply(entry.filename, entry.id)
+            apply: apply(entry.filename, entry.id, entry.displayName)
           }
         })
       }
@@ -49,7 +49,7 @@ export const filesUpdateField = StateField.define<Completion[]>({
  *
  * @param   {string}      infoString  The infostring to use
  */
-const apply = (filename: string, fileId: string) => function (view: EditorView, completion: Completion, from: number, to: number) {
+const apply = (filename: string, fileId: string, displayName: string) => function (view: EditorView, completion: Completion, from: number, to: number) {
   // Applies a filename insertion
   const { linkFilenameOnly, linkPreference } = view.state.field(configField)
 
@@ -63,7 +63,7 @@ const apply = (filename: string, fileId: string) => function (view: EditorView, 
   } else {
     const textToInsert = fileId === '' ? filename: fileId
     if (linkPreference === 'always' || (linkPreference === 'withID' && textToInsert === fileId)) {
-      insert = `${textToInsert}]] ${filename}` // NOTE: No postLink, but linkEnd
+      insert = `${textToInsert}]] ${displayName}` // NOTE: No postLink, but linkEnd
       if (linkEndAfterCursor) {
         to += 2 // Overwrite the linkEnd following the completion
       }

--- a/source/win-preferences/schema/zettelkasten.ts
+++ b/source/win-preferences/schema/zettelkasten.ts
@@ -44,7 +44,7 @@ export default function (): any {
         },
         {
           type: 'radio',
-          label: trans('When linking files, add the filename …'),
+          label: trans('When linking files, add the display name …'),
           model: 'zkn.linkWithFilename',
           options: {
             'always': trans('always'),


### PR DESCRIPTION
## Description / Changes

Inserts the DisplayName, which is shown in the autocompletion of a ZknLink, instead of the filename after the ID when inserting a ZknLink with autocompletion.

By using the displayName from the autocompletion, it depends upon the config about how files are shown. So if someone just wants to see the filename, the filename is still inserted. But if someone wants to see the title, the title is inserted.

## Additional information
Resolves #4134 

Tested on: Ubuntu 2022.04

(Feel free to close this PR if it is buggy, or you would like to fix #4134 in another way, but I needed to insert 100 links today, so writing this was easier than writing all the titles by myself.)