### PR TITLE
Change replacement of '--' to regex, to ignore autocorrect for <!--

### DIFF
--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -195,7 +195,7 @@ export default function getConfigTemplate (): ConfigOptions {
           { key: '(r)', value: '®' },
           // Interpunctation
           { key: '...', value: '…' },
-          { key: '--', value: '–' },
+          { key: '/(?<!<!)--/', value: '–' },
           { key: '---', value: '—' }
         ]
       } // END autoCorrect options


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This changes the '--' replacement to a regex expression which does not allow '--' to autocorrect if the characters '<!' are in front of them. This should stop any problems with the term \<!-- autocorrecting to stop the inline comments from generating. 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Changed the replacement string for '--' to a regex expression '/(?<!<!)--/'.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
This is in regards to the issue #4340. Most changes recommended have been committed by @nathanlesage however I believe that this problem still persists. 
It is worth noting that the regex is potentially more confusing in the autocorrect tab of the preferences.

Additional contributors:
@josh-133 
@mr-verb

<!-- Please provide any testing system -->
Tested on: Windows 11
