### PR TITLE
Fix display of title for files

### DIFF
--- a/source/common/util/safe-assign.ts
+++ b/source/common/util/safe-assign.ts
@@ -20,13 +20,12 @@
 /**
  * Overwrites properties on the referenceObject, if they also occur in obj.
  * @param {any} obj The new object to be safe assigned
- * @param {any} referenceObject The reference to use the props from (without props with undefined as value)
- * @param {any} keyReferenceObject The original reference to check whether a key occurs
+ * @param {any} referenceObject The reference to use the props from
  */
-function safeAssign (obj: any, referenceObject: any, keyReferenceObject: any): void {
+function safeAssign (obj: any, referenceObject: any): void {
   // Overwrite all given attributes (and leave the not given in place)
   // This will ensure sane defaults.
-  for (const prop in keyReferenceObject) {
+  for (const prop in referenceObject) {
     if (prop in obj) {
       // safeAssign updates even nested objects, which we'll
       // do here. The "else" is for primitives. "Why do you
@@ -37,7 +36,7 @@ function safeAssign (obj: any, referenceObject: any, keyReferenceObject: any): v
         !Array.isArray(referenceObject[prop]) &&
         referenceObject[prop] !== null) {
         // Update the sub-object
-        safeAssign(obj[prop], referenceObject[prop], keyReferenceObject[prop])
+        safeAssign(obj[prop], referenceObject[prop])
       } else {
         // Assign the primitive
         referenceObject[prop] = obj[prop]
@@ -58,8 +57,8 @@ function safeAssign (obj: any, referenceObject: any, keyReferenceObject: any): v
 export default function <A, B> (obj: A, reference: B): B {
   // Make sure to clone the reference object, so that users
   // do not have to worry about doing this themselves.
-  const clone = JSON.parse(JSON.stringify(reference))
+  const clone = structuredClone(reference)
   // After cloning, safely assign the object to the reference
-  safeAssign(obj, clone, reference)
+  safeAssign(obj, clone)
   return clone
 }

--- a/source/common/util/safe-assign.ts
+++ b/source/common/util/safe-assign.ts
@@ -20,12 +20,13 @@
 /**
  * Overwrites properties on the referenceObject, if they also occur in obj.
  * @param {any} obj The new object to be safe assigned
- * @param {any} referenceObject The reference to use the props from
+ * @param {any} referenceObject The reference to use the props from (without props with undefined as value)
+ * @param {any} keyReferenceObject The original reference to check whether a key occurs
  */
-function safeAssign (obj: any, referenceObject: any): void {
+function safeAssign (obj: any, referenceObject: any, keyReferenceObject: any): void {
   // Overwrite all given attributes (and leave the not given in place)
   // This will ensure sane defaults.
-  for (const prop in referenceObject) {
+  for (const prop in keyReferenceObject) {
     if (prop in obj) {
       // safeAssign updates even nested objects, which we'll
       // do here. The "else" is for primitives. "Why do you
@@ -36,7 +37,7 @@ function safeAssign (obj: any, referenceObject: any): void {
         !Array.isArray(referenceObject[prop]) &&
         referenceObject[prop] !== null) {
         // Update the sub-object
-        safeAssign(obj[prop], referenceObject[prop])
+        safeAssign(obj[prop], referenceObject[prop], keyReferenceObject[prop])
       } else {
         // Assign the primitive
         referenceObject[prop] = obj[prop]
@@ -59,6 +60,6 @@ export default function <A, B> (obj: A, reference: B): B {
   // do not have to worry about doing this themselves.
   const clone = JSON.parse(JSON.stringify(reference))
   // After cloning, safely assign the object to the reference
-  safeAssign(obj, clone)
+  safeAssign(obj, clone, reference)
   return clone
 }

--- a/test/safe-assign.spec.ts
+++ b/test/safe-assign.spec.ts
@@ -44,6 +44,10 @@ const inputs = [
   // Based on a true story, as safeAssign apparently doesn't overwrite values
   {
     'fullScreen': true
+  },
+  // A safeAssign will use values even if the reference has an undefined value
+  {
+    a: 'foo'
   }
 ]
 const referenceObjects = [
@@ -74,6 +78,9 @@ const referenceObjects = [
   {
     'fullScreen': false,
     someOtherVar: 'Hello World'
+  },
+  {
+    a: undefined
   }
 ]
 const expectedOutputs = [
@@ -105,6 +112,10 @@ const expectedOutputs = [
   {
     'fullScreen': true,
     someOtherVar: 'Hello World'
+  },
+  // Expected output file
+  {
+    a: 'foo'
   }
 ]
 


### PR DESCRIPTION
Resolves #4363

The current implementation of `safeAssign` [strips properties with `undefined`](https://github.com/Zettlr/Zettlr/blob/develop/source/common/util/safe-assign.ts#L60) as value from the reference. Hence, the properties from the `obj` are not passed.

As the [`yamlTitle` is initialized with `undefined`](https://github.com/Zettlr/Zettlr/blob/e920dee0741641c82707e04a30d9002ecb74d00a/source/app/service-providers/fsal/fsal-file.ts#L94) it is not copied from the cache.
