### PR TITLE
Fixes the tag-extraction from files and searching by tags

### DIFF
--- a/source/app/service-providers/fsal/util/file-parser.ts
+++ b/source/app/service-providers/fsal/util/file-parser.ts
@@ -71,7 +71,7 @@ export default function getMarkdownFileParser (
     const ast = md2ast(content)
 
     const tags = extractASTNodes(ast, 'ZettelkastenTag') as ZettelkastenTag[]
-    file.tags = tags.map(tag => tag.value)
+    file.tags = tags.map(tag => tag.value.substring(1))
 
     const links = extractASTNodes(ast, 'ZettelkastenLink') as ZettelkastenLink[]
     file.links = links.map(link => link.value)
@@ -113,6 +113,21 @@ export default function getMarkdownFileParser (
         const title = frontmatter.title.trim()
         if (title !== '') {
           file.yamlTitle = title
+        }
+      }
+
+      const tagsFromFrontmatter = []
+      if (file.frontmatter.tags) {
+        tagsFromFrontmatter.push(...file.frontmatter.tags)
+      }
+      if (file.frontmatter.keywords) {
+        tagsFromFrontmatter.push(...file.frontmatter.keywords)
+      }
+      if (tagsFromFrontmatter.length > 0) {
+        for (let i = 0; i < tagsFromFrontmatter.length; i++) {
+          if (!file.tags.includes(tagsFromFrontmatter[i])) {
+            file.tags.push(tagsFromFrontmatter[i])
+          }
         }
       }
     } catch (err: any) {

--- a/source/app/service-providers/fsal/util/file-parser.ts
+++ b/source/app/service-providers/fsal/util/file-parser.ts
@@ -138,7 +138,6 @@ export default function getMarkdownFileParser (
           // the YAML parser will obviously cast those to numbers, but we don't want
           // this, so forcefully cast everything to string (see issue #1433).
           const sanitizedKeywords: string[] = frontmatter[prop].map((tag: any) => String(tag).toString().toLowerCase())
-          console.log(sanitizedKeywords)
           file.tags.push(...sanitizedKeywords.filter((each) => !file.tags.includes(each)))
         }
       }

--- a/source/app/service-providers/fsal/util/search-file.ts
+++ b/source/app/service-providers/fsal/util/search-file.ts
@@ -72,7 +72,7 @@ export default function searchFile (fileObject: MDFileDescriptor|CodeFileDescrip
           // Break because only one match necessary
           break
         }
-      } else if (wd[0] === '#' && fileObject.type === 'file' && fileObject.tags.includes(wd.toLowerCase().substring(1))) {
+      } else if (wd[0] === '#' && fileObject.type === 'file' && fileObject.tags.map((each) => each.toLowerCase()).includes(wd.toLowerCase().substring(1))) {
         // Account for a potential # in front of the tag
         matchedWords.add(wd)
         if (t.operator === 'OR') {

--- a/source/app/service-providers/fsal/util/search-file.ts
+++ b/source/app/service-providers/fsal/util/search-file.ts
@@ -72,7 +72,7 @@ export default function searchFile (fileObject: MDFileDescriptor|CodeFileDescrip
           // Break because only one match necessary
           break
         }
-      } else if (wd[0] === '#' && fileObject.type === 'file' && fileObject.tags.map((each) => each.toLowerCase()).includes(wd.toLowerCase().substring(1))) {
+      } else if (wd[0] === '#' && fileObject.type === 'file' && fileObject.tags.includes(wd.toLowerCase().substring(1))) {
         // Account for a potential # in front of the tag
         matchedWords.add(wd)
         if (t.operator === 'OR') {

--- a/source/common/modules/markdown-utils/markdown-ast.ts
+++ b/source/common/modules/markdown-utils/markdown-ast.ts
@@ -863,7 +863,7 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         name: 'ZknTag',
         from: node.from,
         to: node.to,
-        value: markdown.substring(node.from, node.to).slice(1)
+        value: markdown.substring(node.from + 1, node.to)
       }
       return astNode
     }

--- a/source/common/modules/markdown-utils/markdown-ast.ts
+++ b/source/common/modules/markdown-utils/markdown-ast.ts
@@ -863,7 +863,7 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         name: 'ZknTag',
         from: node.from,
         to: node.to,
-        value: markdown.substring(node.from, node.to)
+        value: markdown.substring(node.from, node.to).slice(1)
       }
       return astNode
     }


### PR DESCRIPTION
Resolves #4366 

This pr resolves some errors regarding tags:

- Tags from within the yaml-body (`This is #a_tag`) were used along with their `#`. Hence, they were shown in the tag cloud with `#`.
- The properties `keywords` and `tags` were parsed in the fsal, but not assigned to tags and therefore ignored.
- The search for tags did not work. It assumed that the tags are already transformed to lower case, even if this was not the case.