### PR TITLE
Fix regression error from #4379

### DIFF
--- a/source/common/util/replace-tags.ts
+++ b/source/common/util/replace-tags.ts
@@ -70,7 +70,7 @@ export default function replaceTags (markdown: string, oldTag: string, newTag: s
   // of the tags in the new document remain valid, even after replacing the tags
   const newTagHasSpaces = /\s/.test(newTag)
   for (const tagNode of tagNodes.reverse()) {
-    if (tagNode.value.substring(1) !== oldTag) {
+    if (tagNode.value !== oldTag) {
       continue
     }
 


### PR DESCRIPTION
See [#4379 (comment)](https://github.com/Zettlr/Zettlr/pull/4379#issuecomment-1566229531)

The slice from the tag value has to be mirrored in the replacing tag functionality.