### PR TITLE
Run the check workflow on pull-requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: Unit Tests / Lint
 
-# On every push, and whenever another workflow calls this one
-on: [push, workflow_call]
+# On every push, for every pull-request and whenever another workflow calls this one
+on: [push, pull_request, workflow_call]
 
 permissions:
   contents: read


### PR DESCRIPTION
Following [the documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), adding `pull_request` should run the checks for every PR.