### PR TITLE
Update readme to reflect deprecation of --frozen-lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ Then, simply clone the repository and install the dependencies on your local com
 ```bash
 $ git clone https://github.com/Zettlr/Zettlr.git
 $ cd Zettlr
-$ yarn install --frozen-lockfile
+$ yarn install --immutable
 ```
 
-The `--frozen-lockfile` flag ensures that yarn will stick to the versions as listed in the `yarn.lock` and not attempt to update them.
+The `--immutable` flag ensures that yarn will stick to the versions as listed in the `yarn.lock` and not attempt to update them.
 
 During development, hot module reloading (HMR) is active so that you can edit the renderer's code easily and hit `F5` after the changes have been compiled by `electron-forge`. You can keep the developer tools open to see when HMR has finished loading your changes.
 


### PR DESCRIPTION
...which is replaced with --immutable.

<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Update readme to reflect changes within yarn to replace --frozen-lockfile with --immutable. This is helpful for reducing output bloat when setting up the repo in a new workspace.

See https://classic.yarnpkg.com/lang/en/docs/cli/install/ and https://yarnpkg.com/cli/install for old and new flags respectively.

## Changes
Simply replace --frozen-lockfile flag in the setup instructions with --immutable.


## Additional information
There is also a new --immutable-cache flag;  I'm not sure if this is relevant or not for Zettlr.

<!-- Please provide any testing system -->
Tested on: Windows 10 build 19045.2965
