### PR TITLE
Added new protected nodes + comment for '---' autocorrect ignore

### DIFF
--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -39,18 +39,16 @@ function posInProtectedNode (state: EditorState, pos: number): boolean {
   // Having the cursor at the end of the HorizontalRule '---' is not considered inside the HorizontalRule node
   // So we check the previous position to see if it is in a HorizontalRule node
   const checkHorizontalRuleNode = syntaxTree(state).resolve(pos - 1, 0)
-  const checkHorizontalRule = [ 'HorizontalRule', 'YAMLFrontmatterStart' ].includes(checkHorizontalRuleNode.type.name)
+  const checkHorizontalRule = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd' ].includes(checkHorizontalRuleNode.type.name)
   if (checkHorizontalRule) {
     return checkHorizontalRule
   }
-
   return [
     'InlineCode', // `code`
     'Comment', 'CommentBlock', // <!-- comment -->
     'FencedCode', // Code block
     'CodeText', // Code block
-    'HorizontalRule', // ---
-    'YAMLFrontmatterStart'
+    'HorizontalRule' // ---
   ].includes(node.type.name)
 }
 

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -38,10 +38,10 @@ function posInProtectedNode (state: EditorState, pos: number): boolean {
 
   // Having the cursor at the end of the HorizontalRule '---' is not considered inside the HorizontalRule node
   // So we check the previous position to see if it is in a HorizontalRule node
-  const checkHorizontalRuleNode = syntaxTree(state).resolve(pos - 1, 0)
-  const checkHorizontalRule = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd' ].includes(checkHorizontalRuleNode.type.name)
-  if (checkHorizontalRule) {
-    return checkHorizontalRule
+  const checkYAMLFrontmatterNode = syntaxTree(state).resolve(pos - 1, 0)
+  const checkYAMLFrontmatter = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd' ].includes(checkYAMLFrontmatterNode.type.name)
+  if (checkYAMLFrontmatter) {
+    return checkYAMLFrontmatter
   }
   return [
     'InlineCode', // `code`

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -34,21 +34,15 @@ const startChars = ' ([{-–—\n\r\t\v\f'
  * @return  {boolean}             True if the position touches a protected node.
  */
 function posInProtectedNode (state: EditorState, pos: number): boolean {
-  const node = syntaxTree(state).resolve(pos, 0)
-
-  // Having the cursor at the end of the HorizontalRule '---' is not considered inside the HorizontalRule node
-  // So we check the previous position to see if it is in a HorizontalRule node
-  const checkYAMLFrontmatterNode = syntaxTree(state).resolve(pos - 1, 0)
-  const checkYAMLFrontmatter = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd', 'HorizontalRule' ].includes(checkYAMLFrontmatterNode.type.name)
-  if (checkYAMLFrontmatter) {
-    return checkYAMLFrontmatter
-  }
+  const node = syntaxTree(state).resolve(pos, -1)
   return [
     'InlineCode', // `code`
     'Comment', 'CommentBlock', // <!-- comment -->
     'FencedCode', // Code block
     'CodeText', // Code block
-    'HorizontalRule' // ---
+    'HorizontalRule', // --- and ***
+    'YAMLFrontmatterStart',
+    'YAMLFrontmatterEnd'
   ].includes(node.type.name)
 }
 

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -39,7 +39,7 @@ function posInProtectedNode (state: EditorState, pos: number): boolean {
   // Having the cursor at the end of the HorizontalRule '---' is not considered inside the HorizontalRule node
   // So we check the previous position to see if it is in a HorizontalRule node
   const checkYAMLFrontmatterNode = syntaxTree(state).resolve(pos - 1, 0)
-  const checkYAMLFrontmatter = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd' ].includes(checkYAMLFrontmatterNode.type.name)
+  const checkYAMLFrontmatter = [ 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd', 'HorizontalRule' ].includes(checkYAMLFrontmatterNode.type.name)
   if (checkYAMLFrontmatter) {
     return checkYAMLFrontmatter
   }

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -39,7 +39,7 @@ function posInProtectedNode (state: EditorState, pos: number): boolean {
   // Having the cursor at the end of the HorizontalRule '---' is not considered inside the HorizontalRule node
   // So we check the previous position to see if it is in a HorizontalRule node
   const checkHorizontalRuleNode = syntaxTree(state).resolve(pos - 1, 0)
-  const checkHorizontalRule = ['HorizontalRule', 'YAMLFrontmatterStart'].includes(checkHorizontalRuleNode.type.name)
+  const checkHorizontalRule = [ 'HorizontalRule', 'YAMLFrontmatterStart' ].includes(checkHorizontalRuleNode.type.name)
   if (checkHorizontalRule) {
     return checkHorizontalRule
   }

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -79,6 +79,14 @@ export function handleReplacement (view: EditorView): boolean {
       continue
     }
 
+    // Leave --- and ... lines (YAML frontmatter as well as horizontal rules)
+    // We have investigated finding these as protected nodes however '---' in the first line is not parsed as any type
+    // Therefore, this is still required until this parsing from Lezer changes.
+    const line = view.state.doc.lineAt(range.from)
+    if ([ '---', '...' ].includes(line.text)) {
+      continue
+    }
+
     const from = Math.max(range.from - maxKeyLength, 0)
     const slice = view.state.sliceDoc(from, range.from)
     for (const { key, value } of replacements) {

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -16,7 +16,6 @@ import { type BlockParser } from '@lezer/markdown'
 import { StreamLanguage } from '@codemirror/language'
 import { yaml } from '@codemirror/legacy-modes/mode/yaml'
 import { partialParse } from './partial-parse'
-// import { log } from 'console'
 
 const yamlLang = StreamLanguage.define(yaml)
 

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -16,6 +16,7 @@ import { type BlockParser } from '@lezer/markdown'
 import { StreamLanguage } from '@codemirror/language'
 import { yaml } from '@codemirror/legacy-modes/mode/yaml'
 import { partialParse } from './partial-parse'
+// import { log } from 'console'
 
 const yamlLang = StreamLanguage.define(yaml)
 
@@ -31,6 +32,9 @@ export const frontmatterParser: BlockParser = {
     // This parser is inspired by the BlockParsers defined in
     // @lezer/markdown/src/markdown.ts
     if (line.text !== '---' || ctx.lineStart !== 0) {
+      console.log('Before HorizontalRule')
+      console.log(line.text)
+      console.log(ctx.lineStart)
       return false
     }
 

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -49,6 +49,9 @@ export const frontmatterParser: BlockParser = {
       // The parser has collected the full rest of the document. This means
       // the frontmatter never stopped. In order to maintain readability, we
       // simply abort parsing.
+      const node = ctx.elt('YAMLFrontmatterStart', 0, 3)
+      ctx.nextLine()
+      ctx.addElement(node)
       return false
     }
 

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -32,9 +32,6 @@ export const frontmatterParser: BlockParser = {
     // This parser is inspired by the BlockParsers defined in
     // @lezer/markdown/src/markdown.ts
     if (line.text !== '---' || ctx.lineStart !== 0) {
-      console.log('Before HorizontalRule')
-      console.log(line.text)
-      console.log(ctx.lineStart)
       return false
     }
 

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -50,9 +50,6 @@ export const frontmatterParser: BlockParser = {
       // The parser has collected the full rest of the document. This means
       // the frontmatter never stopped. In order to maintain readability, we
       // simply abort parsing.
-      const node = ctx.elt('YAMLFrontmatterStart', 0, 3)
-      ctx.nextLine()
-      ctx.addElement(node)
       return false
     }
 


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This is a replacement for pull request #4389 which has cleaned up the commits and has fixed the diff of the file which showed the whole file is changed

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
There are some additional checks for protected nodes and an additional comment regarding why we have kept the manual check for '---' and '...'

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Windows 11
