### PR TITLE
Forcing custom menus of rendered elements instead of the default menus

### DIFF
--- a/source/common/modules/markdown-editor/renderers/render-citations.ts
+++ b/source/common/modules/markdown-editor/renderers/render-citations.ts
@@ -57,7 +57,7 @@ class CitationWidget extends WidgetType {
   }
 
   ignoreEvent (event: Event): boolean {
-    return false // By default ignore all events
+    return event instanceof MouseEvent
   }
 }
 

--- a/source/common/modules/markdown-editor/renderers/render-headings.ts
+++ b/source/common/modules/markdown-editor/renderers/render-headings.ts
@@ -120,7 +120,7 @@ class HeadingTagWidget extends WidgetType {
   }
 
   ignoreEvent (event: Event): boolean {
-    return false // By default ignore all events
+    return event instanceof MouseEvent
   }
 }
 

--- a/source/common/modules/markdown-editor/renderers/render-tasks.ts
+++ b/source/common/modules/markdown-editor/renderers/render-tasks.ts
@@ -42,7 +42,7 @@ class TaskWidget extends WidgetType {
   }
 
   ignoreEvent (event: Event): boolean {
-    return false // By default ignore all events
+    return event instanceof MouseEvent && event.type === 'mousedown'// Allows clicking on the checkbox without checklist toggling
   }
 }
 


### PR DESCRIPTION
There are three positions where the events are not correctly prevented: Citations, the little icon in front of rendered Headings and the checkbox of Tasks.

In theory, the mermaid renderer doesn't ignore any event also, but as it has no affected renderer, I saw no reason to change it.

Fixes #4499

