### PR TITLE
Search when clicking on frontmatter tags and keywords

### DIFF
--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -83,7 +83,7 @@ import { addNewFootnote } from './commands/footnotes'
 import { copyAsHTML, pasteAsPlain } from './util/copy-paste-cut'
 import openMarkdownLink from './util/open-markdown-link'
 import { highlightRangesEffect } from './plugins/highlight-ranges'
-import { isAnyLiteralNodeContainingATag } from './util/yaml-tag-detection'
+import { isThisNodeAnyLiteralNodeInAYamlKeywordsOrTagsPair } from './util/yaml-tag-detection'
 
 import safeAssign from '@common/util/safe-assign'
 import { countAll } from '@common/util/counter'
@@ -387,7 +387,7 @@ export default class MarkdownEditor extends EventEmitter {
 
             const innerNodeAt = syntaxTree(view.state).resolveInner(pos, 0)
 
-            if (isAnyLiteralNodeContainingATag(innerNodeAt, view.state)) {
+            if (isThisNodeAnyLiteralNodeInAYamlKeywordsOrTagsPair(innerNodeAt, view.state)) {
               let tag = view.state.sliceDoc(innerNodeAt.from, innerNodeAt.to)
               if (innerNodeAt.type.name === 'QuotedLiteral') {
                 tag = tag.substring(1, tag.length-1)

--- a/source/common/modules/markdown-editor/util/yaml-tag-detection.ts
+++ b/source/common/modules/markdown-editor/util/yaml-tag-detection.ts
@@ -1,9 +1,31 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        isThisNodeAnyLiteralNodeInAYamlKeywordsOrTagsPair function
+ * CVM-Role:        Utility function
+ * Maintainers:     Oskar Pfeifer-Bley
+ * License:         GNU GPL v3
+ *
+ * Description:     This function detects whether a given node is a literal node in a YAML keywords or tags pair.
+ *                  It detects single tags and multiple tags in both notions, array and list.
+ *
+ * END HEADER
+ */
+
 import type { SyntaxNode } from '@lezer/common'
 import type { EditorState } from '@codemirror/state'
 
+/**
+ * Recursively finds an ancestor node that matches a sequence of expected node types.
+ *
+ * @param {SyntaxNode|null} node        The starting node to check and traverse its parent chain.
+ * @param {...string} expectedNodeTypes The sequence of expected node type names to match in order.
+ * @return {SyntaxNode|null}            The matched ancestor node if the sequence matches; otherwise, null.
+ */
 function findNodeFollowingParentsTypes (node: SyntaxNode|null, ...expectedNodeTypes: string[]): SyntaxNode|null  {
   node = node?.parent ?? null
-  if (! node || expectedNodeTypes[0] !== node.type.name) {
+  if (node === null || expectedNodeTypes[0] !== node.type.name) {
     return null
   }
   if (expectedNodeTypes.length < 2) {
@@ -12,19 +34,75 @@ function findNodeFollowingParentsTypes (node: SyntaxNode|null, ...expectedNodeTy
   return findNodeFollowingParentsTypes(node, ...expectedNodeTypes.slice(1))
 }
 
-export function isAnyLiteralNodeContainingATag (node: SyntaxNode, state: EditorState): boolean {
-  if (node.type.name === 'Literal' || node.type.name === 'QuotedLiteral') {
-    return true
+/**
+ * This function detects whether a given node is a literal node in a YAML keywords or tags pair.
+ *
+ * Examples of literal nodes that would be matched together with their AST representation:
+ *
+ *  tags: "matched"
+ *
+ *  Document
+ *  └─ BlockMapping
+ *     └─ Pair
+ *        ├─ Key
+ *        │  └─ Literal (tags)
+ *        └─ QuotedLiteral ("matched")
+ *
+ *
+ *  keywords: [matched, "also matched"]
+ *
+ *  Document
+ *  └─ BlockMapping
+ *     └─ Pair
+ *        ├─ Key
+ *        │  └─ Literal (keywords)
+ *        └─ FlowSequence
+ *           ├─ Item
+ *           │  └─ Literal (matched)
+ *           └─ Item
+ *              └─ QuotedLiteral ("also matched")
+ *
+ *
+ *  tags:
+ *   - matched
+ *   - "also matched"
+ *
+ *  Document
+ *  └─ BlockMapping
+ *     └─ Pair
+ *        ├─ Key
+ *        │  └─ Literal (tags)
+ *        └─ BlockSequence
+ *           ├─ Item
+ *           │  └─ Literal (matched)
+ *           └─ Item
+ *              └─ QuotedLiteral ("also matched")
+ *
+ * @param {SyntaxNode} node   The node to check
+ * @param {EditorState} state The state of the editor containing the node
+ *
+ * @return {boolean}          True if the node is a literal node in a YAML keywords or tags pair
+ */
+export function isThisNodeAnyLiteralNodeInAYamlKeywordsOrTagsPair (node: SyntaxNode, state: EditorState): boolean {
+  if (! [ 'Literal', 'QuotedLiteral' ].includes(node.type.name)) {
+    return false
   }
 
   const dashListTags = findNodeFollowingParentsTypes(node, 'Item', 'BlockSequence', 'Pair')
   const arrayListTags = findNodeFollowingParentsTypes(node, 'Item', 'FlowSequence', 'Pair')
   const noListTags = findNodeFollowingParentsTypes(node, 'Pair')
-  const possibleTagNameNode = (dashListTags ?? arrayListTags ?? noListTags)?.childAfter(0)?.childAfter(0)
-  if (! possibleTagNameNode) {
+
+  const tagsNode = (dashListTags ?? arrayListTags ?? noListTags)
+  const tagsNodeIsDirectChildOfRoot = tagsNode?.parent?.parent?.type.name === 'Document'
+  if (!tagsNodeIsDirectChildOfRoot) {
     return false
   }
-  const possibleTagKey = state.sliceDoc(possibleTagNameNode.from, possibleTagNameNode.to)
+
+  const possibleTagNameLiteralNode = tagsNode?.childAfter(0)?.childAfter(0)
+  if (! possibleTagNameLiteralNode) {
+    return false
+  }
+  const possibleTagKey = state.sliceDoc(possibleTagNameLiteralNode.from, possibleTagNameLiteralNode.to)
 
   return [ 'tags', 'keywords' ].includes(possibleTagKey)
 }


### PR DESCRIPTION
## Description

Triggers a change when a keyword or a tag in YAML Frontmatter is clicked.

## Changes

I could not get it working with simple using the information from the frontmatter-parser because the nodes were neither accessible nor hierarchical. I looked at the implementation of version 2.3 and stole the idea to use the YAML parser. It works so far, but it won't help for implementing the autocompletion for tags and keywords, where the same problem will occur.

## Additional information
Resolves #4498 

Tested on: Ubuntu 22.04
