### PR TITLE
fix: Cursor position after link autocomplete

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/files.ts
+++ b/source/common/modules/markdown-editor/autocomplete/files.ts
@@ -62,7 +62,7 @@ const apply = (filename: string, fileId: string, displayName: string) => functio
   } else {
     const textToInsert = fileId === '' ? filename: fileId
     if (linkPreference === 'always' || (linkPreference === 'withID' && textToInsert === fileId)) {
-      insert = `${textToInsert}]] ${displayName}` // NOTE: No postLink, but linkEnd
+      insert = `${textToInsert}]] ${displayName}`
     } else {
       insert = `${textToInsert}]]`
     }

--- a/source/common/modules/markdown-editor/autocomplete/files.ts
+++ b/source/common/modules/markdown-editor/autocomplete/files.ts
@@ -54,22 +54,22 @@ const apply = (filename: string, fileId: string, displayName: string) => functio
   const { linkFilenameOnly, linkPreference } = view.state.field(configField)
 
   const linkEndAfterCursor = view.state.sliceDoc(to, to + 2) === ']]'
-  const postLink = (linkEndAfterCursor) ? '' : ']]'
 
   let insert = ''
   if (linkFilenameOnly) {
     // Just dump the filename in there
-    insert = `${filename}${postLink}`
+    insert = `${filename}]]`
   } else {
     const textToInsert = fileId === '' ? filename: fileId
     if (linkPreference === 'always' || (linkPreference === 'withID' && textToInsert === fileId)) {
       insert = `${textToInsert}]] ${displayName}` // NOTE: No postLink, but linkEnd
-      if (linkEndAfterCursor) {
-        to += 2 // Overwrite the linkEnd following the completion
-      }
     } else {
-      insert = `${textToInsert}${postLink}`
+      insert = `${textToInsert}]]`
     }
+  }
+
+  if (linkEndAfterCursor) {
+    to += 2 // Overwrite the linkEnd following the completion
   }
 
   view.dispatch({


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Closes #4550

I have tested the new logic with the various Zettelkasten link options, and it seems to work without issues now.


## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Manjaro Linux
