### PR TITLE
Fix link preview for short notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   extensions
 - The generic text input context menu shows proper labels (#4655)
 - Improved the French translation
+- Fixed link previews for short notes
 
 ## Under the Hood
 

--- a/source/app/service-providers/commands/file-find-and-return-meta-data.ts
+++ b/source/app/service-providers/commands/file-find-and-return-meta-data.ts
@@ -17,6 +17,7 @@ import ZettlrCommand from './zettlr-command'
 import type { MDFileDescriptor } from '@dts/common/fsal'
 
 const MAX_FILE_PREVIEW_LENGTH = 300
+const MAX_FILE_PREVIEW_LINES = 10
 
 export default class FilePathFindMetaData extends ZettlrCommand {
   constructor (app: any) {
@@ -49,7 +50,8 @@ export default class FilePathFindMetaData extends ZettlrCommand {
 
     let preview = ''
     let i = 0
-    while (preview.length <= MAX_FILE_PREVIEW_LENGTH && i < 10) {
+    const maxPreviewLines = Math.min(lines.length, MAX_FILE_PREVIEW_LINES)
+    while (preview.length <= MAX_FILE_PREVIEW_LENGTH && i < maxPreviewLines) {
       const remainingChars = MAX_FILE_PREVIEW_LENGTH - preview.length
       if (lines[i].length <= remainingChars) {
         preview += lines[i] + '\n'


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Fixes #4650: Link previews do not work for short notes.

## Changes
* Limit the number of lines retrieved based on the actual number of lines in the note.
* Create a named constant for the maximum number of lines.

## Additional information
I was not sure if this belongs in the changelog; please let me know if I should add an entry.

Tested on: Linux (Debian Testing)
