### PR TITLE
fix: Make sure active tab is synced to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fixed link previews for short notes
 - Updated the notification and menubar (Windows/Linux) icons to the new logo
 - Fixed a bug that would prevent changing the directory sorting order (#4654)
+- Fixed a bug that would sometimes cause the last active tab(s) to not be
+  remembered correctly on launch
 
 ## Under the Hood
 

--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -743,6 +743,7 @@ export default class DocumentManager extends ProviderContract {
       // leaf.tabMan.activeFile = filePath
       leaf.tabMan.openFile(filePath)
       this.broadcastEvent(DP_EVENTS.ACTIVE_FILE, { windowId, leafId, filePath })
+      this.syncToConfig()
       return true
     }
 


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
I noticed that sometimes the last active tab was not opened on re-launch of Zettlr. After digging a bit I found that we may have a missing `syncToConfig()` for active tabs. This PR addresses that.



## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Linux Manjaro
