### PR TITLE
fix: Prevent onerous popups & cursor jumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
     name: Windows (x86_64)
     env:
       npm_config_arch: x64
-    needs: [preflight, verify_version, i18n]
+    needs: [preflight, verify_version]
     runs-on: windows-latest
     steps:
       - name: Checkout branch ${{ github.ref_name }}
@@ -163,7 +163,7 @@ jobs:
   #   env:
   #     npm_config_arch: arm64
   #     TARGET_ARCH: arm64 # Seen at https://github.com/hydraulic-software/github-desktop/blob/conveyorize/.github/workflows/ci.yml
-  #   needs: [preflight, verify_version, i18n]
+  #   needs: [preflight, verify_version]
   #   runs-on: windows-latest
   #   steps:
   #     - name: Checkout branch ${{ github.ref_name }}
@@ -237,7 +237,7 @@ jobs:
     name: macOS (x86_64)
     env:
       npm_config_arch: x64
-    needs: [preflight, verify_version, i18n]
+    needs: [preflight, verify_version]
     runs-on: macos-latest
     steps:
       # Check out master for a regular release, or develop branch for a nightly
@@ -283,7 +283,7 @@ jobs:
     name: macOS (arm64)
     env:
       npm_config_arch: arm64
-    needs: [preflight, verify_version, i18n]
+    needs: [preflight, verify_version]
     runs-on: macos-latest
     steps:
       - name: Checkout branch ${{ github.ref_name }}
@@ -333,7 +333,7 @@ jobs:
     name: Linux (x86_64)
     env:
       npm_config_arch: x64
-    needs: [preflight, verify_version, i18n]
+    needs: [preflight, verify_version]
     runs-on: ubuntu-20.04
     steps:
       # Check out master for a regular release, or develop branch for a nightly
@@ -372,7 +372,7 @@ jobs:
     name: Linux (arm64)
     env:
       npm_config_arch: arm64
-    needs: [preflight, verify_version, i18n]
+    needs: [preflight, verify_version]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ but the possibility of having to adapt the Custom CSS may arise for some of you.
   system accent color on macOS and Windows, and Zettlr's brand green on Linux;
   themes do not provide an accent color anymore
 - Restored syntax highlighting for inline math code
+- Fixes an issue that would frequently may make the cursor appear to jump or a
+  dialog appearing warning of external changes (#4729; #4732)
 
 ## Under the Hood
 

--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -92,6 +92,12 @@ interface Document {
    */
   lastSavedVersion: number
   /**
+   * This is a duplicate of whatever has been last written to disk. It is used
+   * to double check whether a change event actually changed the content of a
+   * file or if the file remains the same on disk as in buffer.
+   */
+  lastSavedContent: string
+  /**
    * Holds all updates between minimumVersion and currentVersion in a granular
    * form.
    */
@@ -593,6 +599,7 @@ export default class DocumentManager extends ProviderContract {
       currentVersion: 0,
       minimumVersion: 0,
       lastSavedVersion: 0,
+      lastSavedContent: content,
       updates: [],
       document: Text.of(content.split(descriptor.linefeed)),
       lastSavedCharCount: descriptor.type === 'file' ? descriptor.charCount : 0,
@@ -902,6 +909,15 @@ export default class DocumentManager extends ProviderContract {
     // (e.g. OneDrive and Box) from having text appear to "jump" from time to time.
     if (modtime <= ourModtime) {
       return // Nothing to do
+    }
+
+    // ... however, some cloud services may still emit additional change events
+    // that merely change attributes, but not the content. We handle this case
+    // next
+    const diskContents = await this._app.fsal.loadAnySupportedFile(doc.descriptor.path)
+
+    if (diskContents === doc.lastSavedContent) {
+      return
     }
 
     const isModified = doc.lastSavedVersion !== doc.currentVersion
@@ -1358,6 +1374,7 @@ export default class DocumentManager extends ProviderContract {
     // 4. The save finishes and undos the modifications
     const content = doc.document.toString()
     doc.lastSavedVersion = doc.currentVersion
+    doc.lastSavedContent = content
 
     if (doc.descriptor.type === 'file') {
       // In case of an MD File increase the word or char count


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

This PR adds a (hopefully working as intended) minimal-invasive fix to issues #4729 and #4732. It adds an explicit check that *really* makes sure that a file is changed on disk before pestering the user. In other words: If the disk contents do not differ from whatever content has last been written to disk, Zettlr ignores that change entirely, i.e. no popups (if auto-load changes is set to off) and no cursor jumping (if auto-load changes is set to on).

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

* Store a copy of a file's last saved disk contents in the Document descriptor within the documents provider.
* Compare that on every change event that is neither ignored nor has an appropriate modtime to the actual disk contents at that point to see if a document has actually changed.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Since I do not experience this bug, it would be amazing if some folks could test it out who were experencing these issues.

<!-- Please provide any testing system -->
Tested on: not tested b/c I do not have a system that experiences this bug.

* Fixes #4729
* Fixes #4732