### PR TITLE
Update nodejs used in CI runs off of EOL version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ defaults:
 
 # Global environment variables
 env:
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
 
 # Ensure only a single build workflow runs at any one time
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
   # havoc because we don't push unstable code to master, BUT it looks bad.
   verify_version:
     name: 'Preflight: Verify version tag'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository (master branch)
         uses: actions/checkout@v3
@@ -329,7 +329,7 @@ jobs:
     env:
       npm_config_arch: x64
     needs: [preflight, verify_version]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Check out master for a regular release, or develop branch for a nightly
       - name: Checkout branch ${{ github.ref_name }}
@@ -370,7 +370,7 @@ jobs:
       CC: zig cc -target aarch64-linux-gnu
       CXX: zig c++ -target aarch64-linux-gnu
     needs: [preflight, verify_version]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v3
@@ -424,7 +424,7 @@ jobs:
       - build_macos_arm64
       - build_linux_x64
       - build_linux_arm64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v3


### PR DESCRIPTION
Electron got updated in v3.0.5, but the nodejs used in CI is still EOL and something we're trying to deprecate and get rid of. In building Arch Linux packages I was able to build it with Iron, so I don't think Hydrogen is a requirement any more.
