### PR TITLE
Added ability to specify target directory when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ links as well.
   actual mouse position if the window's GUI was scaled absolutely (as per the
   preferences); now the context menu should always appear exactly where it
   should be
+- Added the ability to specify the target directory when exporting. This allows you to place the output file wherever you please independently of the current working directory. When exporting a single file the target directory can be specified in the YAML frontmatter as zettlr:pandoc_target_filename (similar to how the existing zettlr:pandoc_target_dir is implemented). When exporting a project the target directory can be specified in the .zsh_directory project json as targetDir.
 
 ## Under the Hood
 

--- a/source/app/service-providers/commands/dir-project-export.ts
+++ b/source/app/service-providers/commands/dir-project-export.ts
@@ -112,11 +112,17 @@ export default class DirProjectExport extends ZettlrCommand {
         template = config.templates.tex
       }
 
+      // Set target directory so that it is not always cwd. We check if the project .ztl_directory file has a 'targetDir' set and set targetDirectory to that value (or set targetDirectory = dir.cwd if it is not set)
+      let targetDir = dir.path
+      if (config.targetDir !== '') {
+        targetDir = config.targetDir
+      }
+
       try {
         const opt: ExporterOptions = {
           profile,
           sourceFiles: files,
-          targetDirectory: dir.path,
+          targetDirectory: targetDir,
           cwd: dir.path,
           defaultsOverride: {
             title: config.title,

--- a/source/app/service-providers/commands/export.ts
+++ b/source/app/service-providers/commands/export.ts
@@ -109,6 +109,16 @@ export default class Export extends ZettlrCommand {
         exporterOptions.cwd = fileDescriptor.frontmatter.zettlr.pandoc_working_dir
       }
 
+      // A user can override this default by providing in a frontmatter the
+      // key zettlr.pandoc_target_dir: /path/to/directory. This sets the destination for the
+      // output file.
+      let frontmatterTarget = ''
+      if (fileDescriptor.type === 'file' &&
+      typeof fileDescriptor.frontmatter?.zettlr?.pandoc_target_dir === 'string' &&
+      await this._app.fsal.isDir(fileDescriptor.frontmatter.zettlr.pandoc_target_dir)) {
+        frontmatterTarget = fileDescriptor.frontmatter.zettlr.pandoc_target_dir
+      }
+
       switch (exportTo) {
         case 'ask': {
           const folderSelection = await this._app.windows.askDir(trans('Choose export destination'), null, trans('Save'))
@@ -126,6 +136,10 @@ export default class Export extends ZettlrCommand {
         default:
           exporterOptions.targetDirectory = fileDescriptor.dir
           break
+      }
+
+      if (frontmatterTarget !== '') {
+        exporterOptions.targetDirectory = frontmatterTarget
       }
     }
 

--- a/source/app/service-providers/fsal/fsal-directory.ts
+++ b/source/app/service-providers/fsal/fsal-directory.ts
@@ -58,7 +58,8 @@ const PROJECT_TEMPLATE: ProjectSettings = {
   templates: {
     tex: '', // An optional tex template
     html: '' // An optional HTML template
-  }
+  },
+  targetDir: ''
 }
 
 /**

--- a/source/types/common/fsal.ts
+++ b/source/types/common/fsal.ts
@@ -9,6 +9,7 @@ export interface ProjectSettings {
     tex: string
     html: string
   }
+  targetDir: string
 }
 
 /**


### PR DESCRIPTION
Hi,

Scratching an itch, I found that I wanted to export to latex to a specific folder containing my latex template assets. I didn't want to use the CWD which is what is set in the code as I wanted my markdown and output/template to be in a different folder. I made the attached changes and I'm submitting them back in case they are helpful.

Hope this is useful. I've started using Zettlr instead of Joplin and it's much better for academic writing - Thanks so much.

-James
  

## Description
With this change you can place the output file wherever you please independently of the current working directory. When exporting a single file the target directory can be specified in the YAML frontmatter as zettlr:pandoc_target_filename (similar to how the existing zettlr:pandoc_target_dir is implemented). When exporting a project the target directory can be specified in the .ztr_directory project json as targetDir.

## Changes
Changed Exporter.tx and Dir-Exporter.ts to incorporate target dir for exporter. Small change to FSAL to add target directory field.

## Additional information
TODO: Add a field to the project_settings:Files tab to specify the target directory. Currently I manually add 'targetDir' to the .ztr_directory json.

Tested on: MacOS
