### PR TITLE
feat: Project Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,9 @@ take the appropriate action (especially if it was an accidental deletion).
 - Improved how focusing the various open editors works (#4889)
 - Fixed an issue where some borders in between split views wouldn't be drawn in
   more complex layouts
+- Fixed an issue that would not add a newly created file outside the loaded
+  workspaces to the list of standalone files, leading to various minor
+  annoyances around other parts of the app
 
 ## Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,55 @@ follow these links again.
 Note that we have not yet implemented the functionality of auto-renaming files
 or showing tooltips on these links.
 
+## Project Overhaul: Full Control Over Your Files
+
+Projects are at the heart of Zettlr. As a writing toolbox primarily targeted at
+academics, journalists, and writers, it must cater not just to simple note-
+taking workflows, but also to serious writing. Because of this, Zettlr ships
+with a project feature since the very beginning (since version `0.18.0`,
+released on Jul 20, 2018, to be precise).
+
+However, for a long time the feature attempted to piggyback on the way your
+files were displayed. This meant that (a) the order in which your files were
+weaved together into the project file depended on the sorting of the directory,
+and (b) there was no clear way to exclude files that naturally amass during the
+lifetime of a project, such as notes, backup files, and miscellaneous.
+
+Zettlr 3.1.0 fixes this issue by introducing a rather small, but powerful change
+to the way projects work. We have removed the difficult to understand glob-
+patterns that were introduced in a less-than-ideal attempt to fix some of the
+complexity-issues that were introduced later (such as displaying file titles
+instead of filenames, and others). Instead, you can now explicitly select which
+files will be included in your bound export files – and in which order.
+
+The new file list, which you can find in the project properties dialog, aims to
+be dead-simple to understand, yet give you back the certainty which files will
+end up where in your export – without a doubt.
+
+This also means a change to your projects: After this update, the glob patterns
+will be removed from your `.ztr-directory` files and replaced with an (initially
+empty) array of files to be included in your project. That means that you will
+have to select the files you want to include in a project once after the update.
+
+Managing this list in the project properties is simple: The "Files" tab includes
+a list of all files available within the project's folder structure. To select a
+file for export, click the "+"-button to move it up and include it in the
+export. Next, you can use the "Up"- and "Down"-buttons to change the order of
+the files within your export. The "-"-button removes a file again and moves it
+back down to the list of ignored files. Changes are immediately applied and
+persisted to your disk.
+
+When you now export the project, Zettlr will use only the files you have
+selected, and put them in the appropriate order.
+
+Should you have deleted a file that you originally included in the list of
+files, Zettlr will show you a warning message as soon as you export it so that
+you can have a second look to not send off a file that's missing a crucial part
+of your work. Such missing files are shown atop of the available files and
+feature a "-"-button which allows you to remove them from the list. We opted for
+this approach, since it makes it transparent which files are missing so you can
+take the appropriate action (especially if it was an accidental deletion).
+
 ## GUI and Functionality
 
 - **Feature**: Zettlr now supports titles in internal (wiki) links; the default
@@ -77,6 +126,8 @@ or showing tooltips on these links.
   option on the Pandoc Markdown reader (`wikilinks_title_after_pipe` or
   `wikilinks_title_before_pipe`, respectively) if you wish to export files with
   this option
+- **Feature**: Project Overhaul. Now you can properly manage which files will be
+  exported in projects, and in which order
 - **Feature**: Zettlr can now suggest you emojis during autocompletion. Emojis
   use the same trigger character as the snippets autocomplete, a colon (`:`);
   and Emojis will always be sorted below your snippets -- you can turn this off

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "luxon": "^3.4.4",
     "md5": "^2.3.0",
     "mermaid": "^10.9.0",
-    "minimatch": "^9.0.4",
     "nodehun": "^3.0.2",
     "pinia": "^2.1.7",
     "rehype-parse": "^9.0.0",

--- a/source/app/service-providers/commands/dir-project-export.ts
+++ b/source/app/service-providers/commands/dir-project-export.ts
@@ -15,13 +15,14 @@
 import ZettlrCommand from './zettlr-command'
 import objectToArray from '@common/util/object-to-array'
 import { makeExport } from './exporter'
-import { minimatch } from 'minimatch'
 import { shell, dialog } from 'electron'
 import type { ExporterOptions } from './exporter/types'
 import type LogProvider from '@providers/log'
 import { trans } from '@common/i18n-main'
 import { runShellCommand } from './exporter/run-shell-command'
 import { showNativeNotification } from '@common/util/show-notification'
+import type { AnyDescriptor } from 'source/types/common/fsal'
+import path from 'path'
 
 export default class DirProjectExport extends ZettlrCommand {
   constructor (app: any) {
@@ -49,32 +50,31 @@ export default class DirProjectExport extends ZettlrCommand {
       return false
     }
 
-    // Receive a two dimensional array of all directory contents and remove all
-    // directories as well as any non-code/MD file
-    let files = objectToArray(dir, 'children').filter(e => e.type !== 'directory' && e.type !== 'other')
+    // Now, we have to retrieve the files. We have a directory descriptor that
+    // contains a list of existing files on disk, and we have a project config
+    // that specifies files and a sorting for export. We need to check that all
+    // files specified in the config still exist. If a file is missing, display
+    // a warning but export anyway.
+    const availableFiles = objectToArray<AnyDescriptor>(dir, 'children').filter(e => e.type !== 'directory' && e.type !== 'other').map(e => e.path)
 
-    if (files.length === 0) {
-      return false // Cannot export, but this should be obvious to the user
-    }
+    // Since the config.files array already includes relative paths, we
+    // basically just have to make them absolute relative to the directory and
+    // ensure those paths exist in availableFiles.
+    const existingFilesWithSorting = config.files.map(file => path.join(dir.path, file)).filter(file => availableFiles.includes(file))
 
-    // Use minimatch to filter against the project's filter patterns
-    for (const pattern of config.filters) {
-      this._app.log.info(`[Project] Filtering fileset: Matching against "${pattern}"`)
-      // NOTE: We cannot use the `array.filter(minimatch.filter()) pattern because
-      // we have an array of objects, not strings!
-      const filter = minimatch.filter(pattern, { matchBase: true })
-      files = files.filter(fileDescriptor => filter(fileDescriptor.name))
-    }
-
-    if (files.length === 0) {
-      this._app.log.warning('[Project] Aborting export: No files remained after filtering.')
-      // Cannot export, but this time we must inform the user that their patterns
-      // have filtered out every file.
+    if (existingFilesWithSorting.length === 0) {
+      this._app.log.warning('[Project] Aborting project export: No files to export')
       dialog.showErrorBox(
         trans('Cannot export project'),
-        trans('After applying your glob-filters, no files remained to export. Please adjust them in the project settings.')
+        trans('There are no files selected for export. Please select files to be included in the project settings.')
       )
-      return false
+      return false // Cannot export
+    } else if (existingFilesWithSorting.length !== config.files.length) {
+      await dialog.showMessageBox({
+        title: trans('Project File Mismatch'),
+        message: trans('One or more files specified in the project settings have not been found. They may have moved or been deleted. Please verify that all files that you would like to export are included.'),
+        buttons: [trans('Ok')]
+      }) // Don't return, because we still can export
     }
 
     const allDefaults = await this._app.assets.listDefaults()
@@ -112,10 +112,14 @@ export default class DirProjectExport extends ZettlrCommand {
         template = config.templates.tex
       }
 
+      const sourceFiles = existingFilesWithSorting.map(file => {
+        return { path: file, name: path.basename(file), ext: path.extname(file) }
+      })
+
       try {
         const opt: ExporterOptions = {
           profile,
-          sourceFiles: files,
+          sourceFiles,
           targetDirectory: dir.path,
           cwd: dir.path,
           defaultsOverride: {
@@ -134,11 +138,11 @@ export default class DirProjectExport extends ZettlrCommand {
         }
         this._app.log.info(`[Project] Exported ${dir.name} as ${result.targetFile}`)
       } catch (err: any) {
-        this._app.log.error(err.message, err)
+        this._app.log.error(String(err.message), err)
         this._app.windows.showErrorMessage(
-          ('title' in err) ? err.title : err.message,
-          err.message,
-          ('additionalInfo' in err) ? err.additionalInfo : ''
+          ('title' in err) ? String(err.title) : String(err.message),
+          String(err.message),
+          ('additionalInfo' in err) ? String(err.additionalInfo) : ''
         )
       }
     }

--- a/source/app/service-providers/commands/file-new.ts
+++ b/source/app/service-providers/commands/file-new.ts
@@ -141,6 +141,14 @@ export default class FileNew extends ZettlrCommand {
 
       // And directly thereafter, open the file
       await this._app.documents.openFile(windowId, leafId, absPath, true)
+      // Final check: If the file has been created outside of any loaded
+      // workspace, we must add it as root so that some other functions of
+      // Zettlr work fine (even though the editing should work flawlessly.).
+      // Since at this point the events that add the file to the tree likely
+      // haven't fired yet, we can check whether the parent directory exists.
+      if (this._app.workspaces.findDir(path.dirname(absPath)) === undefined) {
+        this._app.config.addPath(absPath)
+      }
     } catch (err: any) {
       this._app.log.error(`Could not create file: ${err.message as string}`)
       this._app.windows.prompt({

--- a/source/app/service-providers/fsal/fsal-directory.ts
+++ b/source/app/service-providers/fsal/fsal-directory.ts
@@ -53,7 +53,7 @@ const PROJECT_TEMPLATE: ProjectSettings = {
   // General values that not only pertain to the PDF generation
   title: 'Untitled', // Default project title is the directory's name
   profiles: [], // NOTE: Must correspond to the defaults in ProjectProperties.vue
-  filters: [], // A list of filters (glob patterns) to exclude certain files
+  files: [], // A list of absolute paths to the files to be included, sorted (!)
   cslStyle: '', // A path to an optional CSL style file.
   templates: {
     tex: '', // An optional tex template

--- a/source/app/service-providers/workspaces/index.ts
+++ b/source/app/service-providers/workspaces/index.ts
@@ -314,7 +314,7 @@ export default class WorkspaceProvider extends ProviderContract {
    * @return  {Array<AnyFileDescriptor>}  An array of every file
    */
   public getAllFiles (): Array<MDFileDescriptor|CodeFileDescriptor|OtherFileDescriptor> {
-    return objectToArray(this.roots.map(root => root.rootDescriptor), 'children')
+    return objectToArray<any>(this.roots.map(root => root.rootDescriptor), 'children')
       .filter(descriptor => descriptor.type !== 'directory')
   }
 
@@ -346,7 +346,7 @@ export default class WorkspaceProvider extends ProviderContract {
    * @param  {string}  query  What to search for
    */
   public findExact (query: string): MDFileDescriptor|undefined {
-    const idREPattern = this._config.get('zkn.idRE')
+    const idREPattern = this._config.get().zkn.idRE
     const idRE = getIDRE(idREPattern, true)
     const extensions = mdFileExtensions(true)
     const allWorkspaces = this.roots.map(root => root.rootDescriptor)

--- a/source/common/vue/ZtrAdmonition.vue
+++ b/source/common/vue/ZtrAdmonition.vue
@@ -1,0 +1,83 @@
+<template>
+  <div
+    v-bind:class="{
+      admonition: true,
+      [props.type ?? 'warning']: true
+    }"
+  >
+    <cds-icon v-bind:shape="icon"></cds-icon>
+    <span>
+      <slot></slot>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ type?: 'warning'|'error'|'info' }>()
+
+const icon = computed(() => {
+  switch (props.type) {
+    case 'error':
+      return 'error-standard'
+    case 'info':
+      return 'info-standard'
+    case 'warning':
+      // falls through
+    default:
+      return 'warning-standard'
+  }
+})
+</script>
+
+<style lang="less">
+.admonition {
+  display: flex;
+  align-items: center;
+  border: 1px solid #dfdfdf;
+  border-radius: 5px;
+  padding: 5px 10px;
+  font-size: 80%;
+
+  // More spacing between the icon and the text
+  cds-icon { margin-right: 10px; }
+
+  &.warning {
+    color: #333333;
+    background-color: #ffffa7;
+  }
+
+  &.error {
+    color: #333333;
+    background-color: #ffa7a7;
+    border-color: #333333;
+  }
+
+  &.info {
+    color: #3333aa;
+    background-color: #bad1ff;
+    border-color: #3333aa;
+  }
+}
+
+body.dark .admonition {
+  &.warning {
+    background-color: #515100;
+    color: #ffffaa;
+    border-color: #8c9200;
+  }
+
+  &.error {
+    background-color: #510000;
+    color: #ffaaaa;
+    border-color: #333333;
+  }
+
+  &.info {
+    background-color: #333352;
+    color: #aaaaff;
+    border-color: #333333;
+  }
+}
+</style>

--- a/source/common/vue/form/elements/CheckboxControl.vue
+++ b/source/common/vue/form/elements/CheckboxControl.vue
@@ -98,6 +98,17 @@ body {
     }
 
     .cb-group-label { grid-area: label; }
+
+    label {
+      &.disabled {
+        color: grey;
+      }
+    }
+
+    div.info {
+      color: grey;
+      font-size: 80%;
+    }
   }
 
   label.checkbox {
@@ -152,17 +163,6 @@ body {
         border-color: rgb(90, 90, 90);
       }
     }
-  }
-
-  label {
-    &.disabled {
-      color: grey;
-    }
-  }
-
-  div.info {
-    color: grey;
-    font-size: 80%;
   }
 }
 

--- a/source/common/vue/form/elements/FileControl.vue
+++ b/source/common/vue/form/elements/FileControl.vue
@@ -113,15 +113,14 @@ function requestDir (): void {
 <style lang="less">
 body {
   .form-control .input-button-group {
-    display: flex;
+    display: grid;
     column-gap: 10px;
+    grid-template-columns: auto 100px;
     margin: 10px 0;
 
     input, button { white-space: nowrap; }
 
-    input { flex-grow: 4; }
     button {
-      flex-grow: 1;
       overflow: hidden;
       text-overflow: ellipsis;
     }

--- a/source/common/vue/window/assets/generic.less
+++ b/source/common/vue/window/assets/generic.less
@@ -115,7 +115,6 @@ body.linux {
   input, select, textarea, button {
     border-radius: 4px;
     padding: 4px;
-    min-width: 50px;
     border: 1px solid rgb(180, 180, 180);
   }
 

--- a/source/types/common/fsal.ts
+++ b/source/types/common/fsal.ts
@@ -1,10 +1,30 @@
 // FSAL types available in both main process and renderer process
 
 export interface ProjectSettings {
+  /**
+   * The title of the project, will be used, e.g., as title and filename for
+   * projects.
+   */
   title: string
+  /**
+   * A list of project filenames (found in the defaults folder in the app data)
+   * to use for export.
+   */
   profiles: string[]
-  filters: string[]
+  /**
+   * A sorted (!) list of absolute paths to the files that should be included in
+   * the export of this project, including the ordering in which they should be
+   * included.
+   */
+  files: string[]
+  /**
+   * An optional, deviating CSL Style to use for citations within this project.
+   */
   cslStyle: string
+  /**
+   * Template files for various export profiles that override any templates
+   * provided by the templates themselves.
+   */
   templates: {
     tex: string
     html: string

--- a/source/win-assets/DefaultsTab.vue
+++ b/source/win-assets/DefaultsTab.vue
@@ -40,16 +40,13 @@
           v-on:click="openDefaultsDirectory"
         ></ButtonControl>
 
-        <span v-if="visibleItems.length > 0 && visibleItems[currentItem].isProtected === true" class="protected-info">
-          &#128274; {{ protectedProfileWarning }}
-        </span>
+        <ZtrAdmonition v-if="visibleItems.length > 0 && visibleItems[currentItem].isProtected === true" type="info">
+          {{ protectedProfileWarning }}
+        </ZtrAdmonition>
 
-        <p v-if="visibleItems[currentItem]?.isInvalid" class="warning">
-          <cds-icon shape="warning-standard"></cds-icon>
-          <span> <!-- NOTE: Wrapping in a span due to the flex -->
-            {{ invalidProfileWarning }}
-          </span>
-        </p>
+        <ZtrAdmonition v-if="visibleItems[currentItem]?.isInvalid">
+          {{ invalidProfileWarning }}
+        </ZtrAdmonition>
 
         <CodeEditor
           ref="code-editor"
@@ -93,6 +90,7 @@ import SelectableList, { type SelectableListItem } from '@common/vue/form/elemen
 import TextControl from '@common/vue/form/elements/TextControl.vue'
 import ButtonControl from '@common/vue/form/elements/ButtonControl.vue'
 import CodeEditor from '@common/vue/CodeEditor.vue'
+import ZtrAdmonition from '@common/vue/ZtrAdmonition.vue'
 import { trans } from '@common/i18n-renderer'
 import { ref, computed, toRef, watch, onUnmounted } from 'vue'
 import { type PandocProfileMetadata } from '@providers/assets'
@@ -336,20 +334,6 @@ function openDefaultsDirectory (): void {
 
   .CodeMirror {
     flex-grow: 1;
-  }
-
-  p.warning {
-    display: flex;
-    align-items: center;
-    color: rgb(135, 135, 0);
-    background-color: rgb(255, 255, 0);
-    border: 1px solid rgb(135, 135, 0);
-    border-radius: 5px;
-    padding: 5px;
-    margin: 5px;
-
-    // More spacing between the icon and the text
-    span { padding-left: 5px; }
   }
 
   span.protected-info {

--- a/source/win-main/file-manager/TreeItem.vue
+++ b/source/win-main/file-manager/TreeItem.vue
@@ -164,7 +164,7 @@ import PopoverDirProps from './util/PopoverDirProps.vue'
 import PopoverFileProps from './util/PopoverFileProps.vue'
 
 import RingProgress from '@common/vue/window/toolbar-controls/RingProgress.vue'
-import { nextTick, ref, computed, watch, onMounted } from 'vue'
+import { nextTick, ref, computed, watch, onMounted, toRef } from 'vue'
 import { type DirDescriptor, type MaybeRootDescriptor } from '@dts/common/fsal'
 import { useConfigStore, useWindowStateStore } from 'source/pinia'
 import { pathBasename } from '@common/util/renderer-path-polyfill'
@@ -205,7 +205,8 @@ const {
   finishNameEditing,
   isDirectory,
   selectedFile,
-  selectedDir
+  selectedDir,
+  updateObject
 } = useItemComposable(props.obj, displayText, props.windowId, nameEditingInput)
 
 function sel (event: MouseEvent): void {
@@ -381,6 +382,12 @@ watch(operationType, (newVal) => {
     })
       .catch(err => console.error(err))
   }
+})
+
+// I have no idea why passing this as a Ref to the composable doesn't work, but
+// this way it does.
+watch(toRef(props, 'obj'), function (value) {
+  updateObject(value)
 })
 
 onMounted(uncollapseIfApplicable)

--- a/source/win-main/file-manager/util/dir-item-context.ts
+++ b/source/win-main/file-manager/util/dir-item-context.ts
@@ -19,7 +19,7 @@ import type { AnyMenuItem } from '@dts/renderer/context'
 
 const ipcRenderer = window.ipc
 
-export default function displayFileContext (event: MouseEvent, dirObject: DirDescriptor, el: HTMLElement, callback: (clickedID: string) => void): void {
+export function displayDirContext (event: MouseEvent, dirObject: DirDescriptor, el: HTMLElement, callback: (clickedID: string) => void): void {
   const isMac = process.platform === 'darwin'
   const isWin = process.platform === 'win32'
 

--- a/source/win-main/file-manager/util/dir-item-context.ts
+++ b/source/win-main/file-manager/util/dir-item-context.ts
@@ -102,8 +102,8 @@ export default function displayFileContext (event: MouseEvent, dirObject: DirDes
       id: 'menu.project_build',
       type: 'normal',
       label: trans('Export Project'),
-      // Only enable if there are formats to export to
-      enabled: dirObject.settings.project.profiles.length > 0
+      // Only enable if there are files and formats to export to
+      enabled: dirObject.settings.project.profiles.length > 0 && dirObject.settings.project.files.length > 0
     })
   }
 

--- a/source/win-main/file-manager/util/file-item-context.ts
+++ b/source/win-main/file-manager/util/file-item-context.ts
@@ -19,7 +19,7 @@ import type { AnyMenuItem } from '@dts/renderer/context'
 
 const ipcRenderer = window.ipc
 
-export default function displayFileContext (event: MouseEvent, fileObject: MDFileDescriptor|CodeFileDescriptor, el: HTMLElement, callback: (clickedID: string) => void): void {
+export function displayFileContext (event: MouseEvent, fileObject: MDFileDescriptor|CodeFileDescriptor, el: HTMLElement, callback: (clickedID: string) => void): void {
   const isMac = process.platform === 'darwin'
   const isWin = process.platform === 'win32'
 

--- a/source/win-main/file-manager/util/item-composable.ts
+++ b/source/win-main/file-manager/util/item-composable.ts
@@ -14,8 +14,8 @@
  * END HEADER
  */
 
-import fileContextMenu from './file-item-context'
-import dirContextMenu from './dir-item-context'
+import { displayFileContext } from './file-item-context'
+import { displayDirContext } from './dir-item-context'
 import { useConfigStore, useDocumentTreeStore, useWindowStateStore } from 'source/pinia'
 import type { MaybeRootDescriptor } from 'source/types/common/fsal'
 import { ref, computed, type Ref, watch, nextTick } from 'vue'
@@ -121,7 +121,7 @@ export function useItemComposable (
     }
 
     if (obj.value.type === 'directory') {
-      dirContextMenu(event, obj.value, rootElement.value, clickedID => {
+      displayDirContext(event, obj.value, rootElement.value, clickedID => {
         if (clickedID === 'menu.rename_dir') {
           nameEditing.value = true
         } else if (clickedID === 'menu.new_file') {
@@ -152,7 +152,7 @@ export function useItemComposable (
         }
       })
     } else {
-      fileContextMenu(event, obj.value, rootElement.value, clickedID => {
+      displayFileContext(event, obj.value, rootElement.value, clickedID => {
         if (clickedID === 'new-tab') {
           // Request the clicked file, explicitly in a new tab
           ipcRenderer.invoke('documents-provider', {

--- a/source/win-project-properties/App.vue
+++ b/source/win-project-properties/App.vue
@@ -197,6 +197,18 @@ const configStore = useConfigStore()
 const useH1 = computed(() => configStore.config.fileNameDisplay.includes('heading'))
 const useTitle = computed(() => configStore.config.fileNameDisplay.includes('title'))
 
+/**
+ * Helper function that converts any path fragment -- especially when it comes
+ * from Windows -- into a Unix path by replacing \ with /.
+ *
+ * @param   {string}  pathFragment  The path (fragment)
+ *
+ * @return  {string}                The path as a Unix path
+ */
+function pathToUnix (pathFragment: string): string {
+  return pathFragment.replace(/\\/g, '/')
+}
+
 const tabs: WindowTab[] = [
   {
     id: 'formats-control',
@@ -246,7 +258,8 @@ const exportFileList = computed(() => {
       }
     }
 
-    const relativePath = file.path.slice(dirPath.length + 1)
+    // The app always defaults to the Unix path conventions (/ instead of \\)
+    const relativePath = pathToUnix(file.path.slice(dirPath.length + 1))
     files.push({
       // NOTE: We must map the files to the relative paths from the directory!
       relativePath,
@@ -279,7 +292,7 @@ const exportFileList = computed(() => {
 // present in the project directory.
 const missingFiles = computed(() => {
   const missing: string[] = []
-  const availablePaths = availableFiles.value.map(x => x.path.slice(dirPath.length + 1))
+  const availablePaths = availableFiles.value.map(x => pathToUnix(x.path.slice(dirPath.length + 1)))
 
   for (const file of projectSettings.value.files) {
     if (!availablePaths.includes(file)) {

--- a/source/win-project-properties/App.vue
+++ b/source/win-project-properties/App.vue
@@ -20,10 +20,10 @@
         v-bind:label="projectTitleLabel"
       ></TextControl>
 
-      <p v-if="projectSettings.profiles.length === 0" class="warning">
-        <cds-icon shape="warning-standard"></cds-icon>
-        <span>{{ projectBuildWarning }}</span>
-      </p>
+      <ZtrAdmonition v-if="projectSettings.profiles.length === 0" style="margin: 10px 0">
+        {{ projectBuildWarning }}
+      </ZtrAdmonition>
+
       <ListControl
         v-bind:label="exportFormatLabel"
         v-bind:value-type="'record'"
@@ -40,16 +40,81 @@
       id="files-panel"
       role="tabpanel"
     >
-      <!-- First the glob patterns -->
-      <ListControl
-        v-model="projectSettings.filters"
-        v-bind:value-type="'simpleArray'"
-        v-bind:label="exportPatternLabel"
-        v-bind:column-labels="[exportPatternNameLabel]"
-        v-bind:editable="[0]"
-        v-bind:addable="true"
-        v-bind:deletable="true"
-      ></ListControl>
+      <!-- First, the files to be included in the export -->
+      <p>{{ exportFilesLabel }}</p>
+
+      <div v-if="missingFiles.length > 0" class="export-file-list">
+        <ZtrAdmonition>{{ missingFilesMessage }}</ZtrAdmonition>
+        <div v-for="file in missingFiles" v-bind:key="file" class="export-file-item">
+          <button
+            class="remove-button"
+            v-bind:aria-label="removeButtonTitle"
+            v-bind:title="removeButtonTitle"
+            v-on:click="removeFileFromExportList(file)"
+          >
+            &nbsp;&ndash;&nbsp;
+          </button>
+          <span>
+            {{ file }}
+          </span>
+        </div>
+      </div>
+
+      <ZtrAdmonition v-if="projectSettings.files.length === 0" style="margin: 10px 0">
+        {{ noFilesSelectedMessage }}
+      </ZtrAdmonition>
+
+      <div class="export-file-list">
+        <div v-for="(file, i) in exportFileList" v-bind:key="file.displayName" v-bind:class="{ 'export-file-item': true, active: file.included }">
+          <div class="actions">
+            <template v-if="file.included">
+              <button
+                class="remove-button"
+                v-bind:aria-label="removeButtonTitle"
+                v-bind:title="removeButtonTitle"
+                v-on:click="removeFileFromExportList(file.relativePath)"
+              >
+                &nbsp;&ndash;&nbsp;
+              </button>
+              <button
+                v-if="i > 0"
+                class="up-button"
+                v-bind:aria-label="upButtonTitle"
+                v-bind:title="upButtonTitle"
+                v-on:click="moveFileUpInExportList(file.relativePath)"
+              >
+                &nbsp;&uarr;&nbsp;
+              </button>
+              <button
+                v-if="i < projectSettings.files.length - 1"
+                class="down-button"
+                v-bind:aria-label="downButtonTitle"
+                v-bind:title="downButtonTitle"
+                v-on:click="moveFileDownInExportList(file.relativePath)"
+              >
+                &nbsp;&darr;&nbsp;
+              </button>
+            </template>
+            <button
+              v-else
+              class="add-button"
+              v-bind:aria-label="addButtonTitle"
+              v-bind:title="addButtonTitle"
+              v-on:click="addFileToExportList(file.relativePath)"
+            >
+              &nbsp;+&nbsp;
+            </button>
+          </div>
+          <div class="display-name">
+            <span>
+              {{ file.displayName }}
+            </span>
+            <span class="relative-dirname">
+              {{ file.relativePath }}
+            </span>
+          </div>
+        </div>
+      </div>
 
       <!-- Then the CSL file -->
       <FileControl
@@ -95,13 +160,16 @@ import WindowChrome from '@common/vue/window/WindowChrome.vue'
 import ListControl from '@common/vue/form/elements/ListControl.vue'
 import FileControl from '@common/vue/form/elements/FileControl.vue'
 import TextControl from '@common/vue/form/elements/TextControl.vue'
+import ZtrAdmonition from '@common/vue/ZtrAdmonition.vue'
 import { ref, computed, watch } from 'vue'
-import { type ProjectSettings, type DirDescriptor } from '@dts/common/fsal'
+import type { ProjectSettings, DirDescriptor, AnyDescriptor, MDFileDescriptor, CodeFileDescriptor } from '@dts/common/fsal'
 import { type PandocProfileMetadata } from '@providers/assets'
 import { PANDOC_READERS, PANDOC_WRITERS, SUPPORTED_READERS } from '@common/util/pandoc-maps'
 import getPlainPandocReaderWriter from '@common/util/plain-pandoc-reader-writer'
 import { type WindowTab } from '@common/vue/window/WindowTabbar.vue'
 import { useConfigStore } from 'source/pinia'
+import objectToArray from 'source/common/util/object-to-array'
+import { pathBasename } from 'source/common/util/renderer-path-polyfill'
 
 const ipcRenderer = window.ipc
 
@@ -112,15 +180,22 @@ const exportFormatLabel = trans('Export project to:')
 const exportFormatUseLabel = trans('Use')
 const exportFormatNameLabel = trans('Format')
 const conversionLabel = trans('Conversion')
-const exportPatternLabel = trans('Add Glob patterns to include only specific files')
-const exportPatternNameLabel = trans('Glob Pattern')
+const exportFilesLabel = trans('Files to be included in the export')
 const projectBuildWarning = trans('Please select at least one profile to build this project.')
 const projectTitleLabel = trans('Project Title')
 const cslStyleLabel = trans('CSL Stylesheet')
 const texTemplateLabel = trans('LaTeX Template')
 const htmlTemplateLabel = trans('HTML Template')
+const removeButtonTitle = trans('Remove file from export')
+const addButtonTitle = trans('Add file to export')
+const upButtonTitle = trans('Move file up')
+const downButtonTitle = trans('Move file down')
+const noFilesSelectedMessage = trans('You have not selected any files for export.')
+const missingFilesMessage = trans('Some files are selected for export but no longer exist in the directory.')
 
 const configStore = useConfigStore()
+const useH1 = computed(() => configStore.config.fileNameDisplay.includes('heading'))
+const useTitle = computed(() => configStore.config.fileNameDisplay.includes('title'))
 
 const tabs: WindowTab[] = [
   {
@@ -147,9 +222,72 @@ const customCommands = configStore.config.export.customCommands
 const projectSettings = ref<ProjectSettings>({
   title: '',
   profiles: [],
-  filters: [],
+  files: [],
   cslStyle: '',
   templates: { tex: '', html: '' }
+})
+
+// Holds all available files inside the directory
+const availableFiles = ref<Array<MDFileDescriptor|CodeFileDescriptor>>([])
+
+// Returns a list of all files, prepared for enabling the user to add/remove
+// files from the export list
+const exportFileList = computed(() => {
+  const files: Array<{ displayName: string, included: boolean, relativePath: string }> = []
+  const projectFiles = projectSettings.value.files
+
+  for (const file of availableFiles.value) {
+    let basename = pathBasename(file.path)
+    if (file.type === 'file') {
+      if (useTitle.value && file.yamlTitle !== undefined) {
+        basename = file.yamlTitle
+      } else if (useH1.value && file.firstHeading !== null) {
+        basename = file.firstHeading
+      }
+    }
+
+    const relativePath = file.path.slice(dirPath.length + 1)
+    files.push({
+      // NOTE: We must map the files to the relative paths from the directory!
+      relativePath,
+      displayName: basename,
+      included: projectFiles.includes(relativePath)
+    })
+  }
+
+  files.sort((a, b) => {
+    // Negative if a < b
+    const aIdx = projectFiles.indexOf(a.relativePath)
+    const bIdx = projectFiles.indexOf(b.relativePath)
+
+    if (aIdx === bIdx) {
+      return 0 // Both are -1
+    } else if (aIdx < 0 && bIdx > -1) {
+      return 1
+    } else if (bIdx < 0 && aIdx > -1) {
+      return -1
+    } else {
+      // Calculate from the indices
+      return aIdx - bIdx
+    }
+  })
+
+  return files
+})
+
+// Holds a list of files that are selected for export, but seem to be no longer
+// present in the project directory.
+const missingFiles = computed(() => {
+  const missing: string[] = []
+  const availablePaths = availableFiles.value.map(x => x.path.slice(dirPath.length + 1))
+
+  for (const file of projectSettings.value.files) {
+    if (!availablePaths.includes(file)) {
+      // This will be passed into "remove" so it needs to be the same as in the original array
+      missing.push(file)
+    }
+  }
+  return missing
 })
 
 const currentTab = ref(0)
@@ -259,6 +397,7 @@ function fetchProperties (): void {
       // Save the actually used formats.
       if (descriptor.settings.project !== null) {
         projectSettings.value = descriptor.settings.project
+        availableFiles.value = objectToArray<AnyDescriptor>(descriptor, 'children').filter(e => [ 'code', 'file' ].includes(e.type)) as Array<CodeFileDescriptor|MDFileDescriptor>
       } else {
         // Apparently the user kept the window open and removed the project
         // state on this project. So let's close this window silently.
@@ -268,6 +407,75 @@ function fetchProperties (): void {
       // handlers can overwrite them.
     })
     .catch(err => console.error(err))
+}
+
+/**
+ * Adds the provided file to the list of to-be-exported files in this project.
+ *
+ * @param   {string}  relativeFilePath  The file path to add
+ */
+function addFileToExportList (relativeFilePath: string): void {
+  if (projectSettings.value.files.includes(relativeFilePath)) {
+    return
+  }
+
+  // Will automagically update
+  projectSettings.value.files.push(relativeFilePath)
+}
+
+/**
+ * Removes the provided file from the list of to-be-exported files in this
+ * project.
+ *
+ * @param   {string}  relativeFilePath  The file path to remove
+ */
+function removeFileFromExportList (relativeFilePath: string): void {
+  if (!projectSettings.value.files.includes(relativeFilePath)) {
+    return
+  }
+
+  const idx = projectSettings.value.files.indexOf(relativeFilePath)
+  projectSettings.value.files.splice(idx, 1)
+}
+
+/**
+ * Moves the provided file down in the list of to-be-exported files in this
+ * project.
+ *
+ * @param   {string}  relativeFilePath  The file path to move
+ */
+function moveFileDownInExportList (relativeFilePath: string): void {
+  if (!projectSettings.value.files.includes(relativeFilePath)) {
+    return
+  }
+
+  const idx = projectSettings.value.files.indexOf(relativeFilePath)
+  if (idx === projectSettings.value.files.length - 1) {
+    return
+  }
+
+  projectSettings.value.files.splice(idx, 1)
+  projectSettings.value.files.splice(idx + 1, 0, relativeFilePath)
+}
+
+/**
+ * Moves the provided file up in the list of to-be-exported files in this
+ * project.
+ *
+ * @param   {string}  relativeFilePath  The file path to move
+ */
+function moveFileUpInExportList (relativeFilePath: string): void {
+  if (!projectSettings.value.files.includes(relativeFilePath)) {
+    return
+  }
+
+  const idx = projectSettings.value.files.indexOf(relativeFilePath)
+  if (idx === 0) {
+    return
+  }
+
+  projectSettings.value.files.splice(idx, 1)
+  projectSettings.value.files.splice(idx - 1, 0, relativeFilePath)
 }
 </script>
 
@@ -289,5 +497,69 @@ div[role="tabpanel"] {
   overflow: auto; // Enable scrolling, if necessary
   padding: 10px;
   width: 100%;
+}
+
+.export-file-list {
+  margin: 20px 0 40px 0;
+
+  .export-file-item {
+    padding: 5px;
+    display: grid;
+    grid-template-areas: "actions display-name";
+    grid-template-columns: 50px auto;
+    column-gap: 20px;
+
+    .display-name {
+      grid-area: display-name;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      .relative-dirname {
+        font-size: 80%;
+        color: #ccc;
+      }
+    }
+
+    .actions {
+      grid-area: actions;
+      display: grid;
+      grid-template-areas: "add-or-remove up-button"
+      "add-or-remove down-button";
+      grid-template-columns: 50% 50%;
+      column-gap: 10px;
+      align-items: center;
+      justify-content: center;
+
+      .up-button { grid-area: up-button; }
+      .down-button { grid-area: down-button; }
+      .add-button { grid-area: add-or-remove; }
+      .remove-button { grid-area: add-or-remove; }
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid #ccc;
+    }
+
+    &:not(.active) {
+      color: #ccc;
+    }
+  }
+}
+
+body.dark .export-file-list {
+  .export-file-item {
+    .display-name .relative-dirname {
+      color: #999;
+    }
+
+    &:not(.active) {
+      color: #999;
+    }
+
+    &:not(:last-child) {
+      border-bottom-color: #666;
+    }
+  }
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9954,15 +9954,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
-  version: 9.0.4
-  resolution: "minimatch@npm:9.0.4"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
-  languageName: node
-  linkType: hard
-
 "minimist@npm:^1.2.0, minimist@npm:^1.2.6":
   version: 1.2.7
   resolution: "minimist@npm:1.2.7"
@@ -14728,7 +14719,6 @@ __metadata:
     luxon: ^3.4.4
     md5: ^2.3.0
     mermaid: ^10.9.0
-    minimatch: ^9.0.4
     mocha: ^10.4.0
     node-loader: ^2.0.0
     nodehun: ^3.0.2


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description

The project feature is one of the oldest in Zettlr, stemming from `v0.18.0` from July 2018. However, for basically the entire past six years, the project feature has attempted to piggyback on the way the files in your project directory were displayed in the file manager. The initial assumptions were (a) all files need to be exported and (b) the visible sorting (by name or time) is a sufficient amount of control over the project build step.

However, I was wrong. Over time, many important features have made it into the app, such as displaying YAML titles or H1 headings instead of the filenames. Now that Zettlr is such a powerful tool, you likely don't just have the actual project files in a project directory, but likely notes, minutes, and miscellaneous files as well.

The previous change to add glob patterns that allow for subsetting of the files and excluding files was a little improvement. However, it was (a) extremely difficult to understand (even for me, see below) and (b) it still did not solve the issue with the export order.

This PR introduces a technically extremely simple change that has a ton of potential for wielding actual control over your projects.

## Changes

### At a glance

* Removed the `filters` array of Zettlr projects (within the `.ztr-directory`-files)
* Added a `files` array there, that hold paths (relative to the directory) of all files that should be exported, manually sorted
* Modified the logic in the exporter to take that array instead of some filters, and pass it as-is to the exporter
* Added appropriate GUI elements to the project properties dialog that allow the modification of that list with easy to understand controls

### In Detail

When you open a directory's project properties, the Files-tab has now changed. See the image below for a description of the various elements:

![image](https://github.com/Zettlr/Zettlr/assets/17251683/086e0305-2dd9-4eaf-81c4-d7b57a1aead4)

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

### Migration

User migration is simple: After the upgrade, the glob patterns will be gone, and instead an empty file array will be shown. **This feature is backwards-compatible.** Should the user downgrade (which is not recommended, but, you know…) the file list will simply be replaced with an empty glob pattern list again.

### Timeline

This PR should be once confirmed with @sensologica. In addition, someone with a **Windows PC and Linux or Mac** should test this out, because I'm a bit afraid of what will happen with cross-platform compatibility given the different path separators on Win and \*nix. It should work, but you never know.

<!-- Please provide any testing system -->
Tested on: macOS Sonoma 14.2.1

***

EDIT: Fixes #4966 