### PR TITLE
fix: downgrade Ubuntu for Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
     env:
       npm_config_arch: x64
     needs: [preflight, verify_version]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       # Check out master for a regular release, or develop branch for a nightly
       - name: Checkout branch ${{ github.ref_name }}
@@ -304,7 +304,7 @@ jobs:
       CC: zig cc -target aarch64-linux-gnu
       CXX: zig c++ -target aarch64-linux-gnu
     needs: [preflight, verify_version]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Under the Hood
 
-(Nothing here)
+- Downgrade Ubuntu builds to 20.04 (#5137)
 
 # 3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Under the Hood
 
-- Downgrade Ubuntu builds to 20.04 (#5137)
+- Downgrade Linux builds to use Ubuntu 20.04 (#5137)
 
 # 3.1.1
 


### PR DESCRIPTION
## Description
Downgrade Linux builds to use Ubuntu 20.04 (fixes https://github.com/Zettlr/Zettlr/issues/5137)

## Changes
Changed the `build` Github Action (partially reverting https://github.com/Zettlr/Zettlr/commit/9e2178ac723db9e7d1930e808f359096987d7fda). I say partially because I only downgraded the build jobs. The other ones (`verify_version` and `prepare_release` are still using Ubuntu 22.04).

## Additional information
I did a [test release](https://github.com/IgnacioHeredia/Zettlr/releases/tag/v3.1.1) and Zettlr seems to work fine with the changes.
