### PR TITLE
Issue 4921 reopen : Show the Title instead of the file name in the popup file preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming
 
+* fix: The file preview tooltip now respects the filename display settings
+
 ## Changes to file filtering logic
 
 Previously when searching for files and workspaces in the filter field in

--- a/source/app/service-providers/commands/file-find-and-return-meta-data.ts
+++ b/source/app/service-providers/commands/file-find-and-return-meta-data.ts
@@ -21,8 +21,8 @@ const MAX_FILE_PREVIEW_LENGTH = 300
 const MAX_FILE_PREVIEW_LINES = 10
 
 function previewTitleGenerator (userConfig: string, descriptor: MDFileDescriptor): string {
-  if (userConfig.includes('heading') && descriptor.firstHeading !== null) return descriptor.firstHeading
-  else if (userConfig.includes('title')&& descriptor.yamlTitle !== undefined) return descriptor.yamlTitle
+  if (userConfig.includes('title')&& descriptor.yamlTitle !== undefined) return descriptor.yamlTitle
+  else if (userConfig.includes('heading') && descriptor.firstHeading !== null) return descriptor.firstHeading
   return descriptor.name
 }
 

--- a/source/app/service-providers/commands/file-find-and-return-meta-data.ts
+++ b/source/app/service-providers/commands/file-find-and-return-meta-data.ts
@@ -20,6 +20,12 @@ import type { MDFileDescriptor } from '@dts/common/fsal'
 const MAX_FILE_PREVIEW_LENGTH = 300
 const MAX_FILE_PREVIEW_LINES = 10
 
+function previewTitleGenerator (userConfig: string, descriptor: MDFileDescriptor): string {
+  if (userConfig.includes('heading') && descriptor.firstHeading !== null) return descriptor.firstHeading
+  else if (userConfig.includes('title')&& descriptor.yamlTitle !== undefined) return descriptor.yamlTitle
+  return descriptor.name
+}
+
 export default class FilePathFindMetaData extends ZettlrCommand {
   constructor (app: any) {
     super(app, [ 'find-exact', 'file-find-and-return-meta-data' ])
@@ -64,7 +70,7 @@ export default class FilePathFindMetaData extends ZettlrCommand {
     }
 
     return [
-      descriptor.name,
+      previewTitleGenerator(this._app.config.get().fileNameDisplay, descriptor),
       preview,
       descriptor.wordCount,
       descriptor.modtime


### PR DESCRIPTION

## Description
This is me reopening this pervious PR as I messed up the merge history. The code is still the same and follows the suggestions provided.

Previous PR can be visited here -> https://github.com/Zettlr/Zettlr/pull/5128

## Changes
The file-find-and-return-meta data query now returns previewTitle depending on user filename display settings
Tested on: MacOs 14.3.1
