### PR TITLE
Fix "unsaved change" dialog action translations in fr-FR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ multiple queries.
 
 - **Change**: When searching for files in the filter field, only files and
   workspaces that match all queries entered will be displayed
+- Fixed the French translation of unsaved-changes dialog actions. (#5177)
 
 ## Under the Hood
 

--- a/static/lang/fr-FR.po
+++ b/static/lang/fr-FR.po
@@ -852,12 +852,12 @@ msgstr "Le fichier de la bibliographie a été modifié. Rechargement…"
 #: source/app/service-providers/documents/index.ts:343
 #, fuzzy
 msgid "Save changes"
-msgstr "Modifications non enregistrées"
+msgstr "Enregistrer les modifications"
 
 #: source/app/service-providers/documents/index.ts:344
 #, fuzzy
 msgid "Discard changes"
-msgstr "Modifications non enregistrées"
+msgstr "Abandonner les modifications"
 
 #. If the user cancels, do not omit (the default) but actually cancel
 #: source/app/service-providers/documents/index.ts:347


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Fixed the French translation of unsaved-changes dialog actions. (#5177)

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Two tranlastions entries were added.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on:
Windows 11.

Warning in yarn lint and error in yarn test are the same as in the current head of the develop branch.
