### PR TITLE
fix: search in folder autofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ multiple queries.
 
 - **Change**: When searching for files in the filter field, only files and
   workspaces that match all queries entered will be displayed
+- **Fix**: Focus input field when search in folder (global search) is
+  triggered
 
 ## Under the Hood
 

--- a/source/common/vue/form/elements/AutocompleteText.vue
+++ b/source/common/vue/form/elements/AutocompleteText.vue
@@ -4,7 +4,7 @@
     <!-- AutocompleteText is being implemented as a search for easy emptying of the field -->
     <input
       v-bind:id="fieldId"
-      ref="input-field"
+      ref="inputField"
       v-model="thisValue"
       type="search"
       v-bind:class="{ inline: inline === true }"


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
This MR fixes a bug when autofocus for the "search in folder" (aka. global search) panel stopped working

| before | after |
| -- | -- |
|  ![zettlr-focus-before](https://github.com/Zettlr/Zettlr/assets/1079718/9b9ebe31-c308-4d55-9db9-92e86554a5a2) | ![zettlr-focus-after](https://github.com/Zettlr/Zettlr/assets/1079718/435a9ed1-9d7f-41c6-abd2-bf9ccdbca3e4) |

I tested it locally

## Changes
The ref of the input component was incorrect.

## Additional information

The issue was introduced in https://github.com/Zettlr/Zettlr/commit/3ecba4659f0d8193f76cbd22f8aa1f3b0b5706ec

`yarn test` fails for me locally (immediately without running any tests)

```
Exception during run: TypeError: Cannot set property navigator of #<Object> which has only a getter
```

<!-- Please provide any testing system -->
Tested on:  latest MacOS 14.5 (23F79)