### PR TITLE
Update PopoverTags.vue

### DIFF
--- a/source/win-main/PopoverTags.vue
+++ b/source/win-main/PopoverTags.vue
@@ -52,7 +52,7 @@ import PopoverWrapper from './PopoverWrapper.vue'
 import TextControl from '@common/vue/form/elements/TextControl.vue'
 import TabBar, { type TabbarControl } from '@common/vue/TabBar.vue'
 import { trans } from '@common/i18n-renderer'
-import { ref, computed, onBeforeMount } from 'vue'
+import { ref, computed, onBeforeMount, onMounted } from 'vue'
 import { useConfigStore, useTagsStore } from 'source/pinia'
 
 const props = defineProps<{
@@ -107,7 +107,7 @@ const filteredTags = computed(() => {
   })
 })
 
-onBeforeMount(() => {
+onMounted(() => {
   filter.value?.focus()
 })
 


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Fixes issue #5138 where the tag filter didn't get focused after clicking once, It had to be clicked twice to register the typed text. This issue was observed on Linux platform.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The code changes line 110 in file https://github.com/Zettlr/Zetttlr/blob/develop/source/win-main/PopoverTags.vue by replacing the onBeforeMount hook with onMounted hook.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
None

<!-- Please provide any testing system -->
Tested on: macOS