### PR TITLE
fix: "Dancing" list items by normalizing line indentation

### DIFF
--- a/source/app/service-providers/documents/util/change-file-indentation.ts
+++ b/source/app/service-providers/documents/util/change-file-indentation.ts
@@ -35,7 +35,7 @@ export function changeFileIndentation (text: string, newIndent: '\t'|' ', newSiz
   for (let i = 0; i < lines.length; i++) {
     // Take the current indent in multiples of current indentation size in its
     // entirety (leaving out any trailing spaces)...
-    lines[i] = lines[i].replace(new RegExp(`^${currentIndent}{${currentSize}}*`), (match) => {
+    lines[i] = lines[i].replace(new RegExp(`^(?:${currentIndent}{${currentSize}})*`), (match) => {
       // And replace them with the same amount of newIndents times newSize.
       return newIndent.repeat(newSize * Math.floor(match.length / currentSize))
     })

--- a/source/app/service-providers/documents/util/change-file-indentation.ts
+++ b/source/app/service-providers/documents/util/change-file-indentation.ts
@@ -1,0 +1,45 @@
+import { detectFileIndentation } from "../../fsal/util/detect-file-indentation"
+import { extractLinefeed } from "../../fsal/util/extract-linefeed"
+import { normalizeLineEndings } from "../../fsal/util/normalize-line-endings"
+
+/**
+ * This function takes in a file and normalizes the file's line indentation to
+ * whichever is desired. NOTE: This function will implicitly also normalize the
+ * line endings of the text you provide, as it must split the file content into
+ * lines for the indentation changer. It uses the same utility functions as the
+ * various file loaders across the app for this.
+ *
+ * @param   {string}    text           The text in question
+ * @param   {'\t'|' '}  newIndent      The new indent character
+ * @param   {number}    newSize        The new indent size. Will be set to 1 for
+ *                                     tabs.
+ * @param   {'\t'|' '}  currentIndent  (Optional) Current indent. Detected
+ *                                     automatically if not provided.
+ * @param   {number}    currentSize    (Optional) The current indent size.
+ *                                     Detected automatically if not provided.
+ *
+ * @return  {string}                   The text with the line indents normalized
+ */
+export function changeFileIndentation (text: string, newIndent: '\t'|' ', newSize: number, currentIndent?: '\t'|' ', currentSize?: number): string {
+  const linefeed = extractLinefeed(text)
+
+  const lines = normalizeLineEndings(text).split('\n')
+  if (currentIndent === undefined || currentSize === undefined) {
+    [ currentIndent, currentSize ] = detectFileIndentation(lines)
+  }
+
+  if (newIndent === '\t' && newSize !== 1) {
+    newSize = 1 // Enforce single tabs
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    // Take the current indent in multiples of current indentation size in its
+    // entirety (leaving out any trailing spaces)...
+    lines[i] = lines[i].replace(new RegExp(`^${currentIndent}{${currentSize}}*`), (match) => {
+      // And replace them with the same amount of newIndents times newSize.
+      return newIndent.repeat(newSize * Math.floor(match.length / currentSize))
+    })
+  }
+
+  return lines.join(linefeed)
+}

--- a/source/app/service-providers/fsal/fsal-file.ts
+++ b/source/app/service-providers/fsal/fsal-file.ts
@@ -21,6 +21,7 @@ import type { MDFileDescriptor } from '@dts/common/fsal'
 import type FSALCache from './fsal-cache'
 import type { SearchTerm } from '@dts/common/search'
 import { getFilesystemMetadata } from './util/get-fs-metadata'
+import { normalizeLineEndings } from './util/normalize-line-endings'
 
 /**
  * Applies a cached file, saving time where the file is not being parsed.
@@ -85,6 +86,8 @@ export async function parse (
     tags: [], // All tags that are to be found inside the file's contents.
     links: [], // Any outlinks
     bom: '', // Default: No BOM
+    indentChar: ' ', // Default: spaces
+    indentSize: 4, // Default: 4 spaces
     type: 'file',
     wordCount: 0,
     charCount: 0,
@@ -159,14 +162,8 @@ export async function search (fileObject: MDFileDescriptor, terms: SearchTerm[])
 export async function load (fileObject: MDFileDescriptor): Promise<string> {
   // Loads the content of a file from disk
   const content = await fs.readFile(fileObject.path, { encoding: 'utf8' })
-  return content
-    // Account for an optional BOM, if present
-    .substring(fileObject.bom.length)
-    // Always split with a regular expression to ensure that mixed linefeeds
-    // don't break reading in a file. Then, on save, the linefeeds will be
-    // standardized to whatever the linefeed extractor detected.
-    .split(/\r\n|\n\r|\n|\r/g)
-    .join('\n')
+  // Account for an optional BOM, if present
+  return normalizeLineEndings(content.substring(fileObject.bom.length))
 }
 
 /**

--- a/source/app/service-providers/fsal/index.ts
+++ b/source/app/service-providers/fsal/index.ts
@@ -446,10 +446,9 @@ export default class FSAL extends ProviderContract {
   }
 
   /**
-   * This is a convenience function to retrieve the file contents (as a string)
-   * of any file that is supported by Zettlr, meaning you can use this function
-   * to load the contents of any Markdown file, any JSON or YAML file, or any
-   * TeX file (+ maybe others in the future).
+   * Retrieves the file contents (as a string) of any text file that is
+   * supported by Zettlr. NOTE: This function will normalize the line endings of
+   * the file, so it cannot be used to perform linefeed detection!
    *
    * @throws When the path was a directory or an unsupported file (unsupported
    *         includes attachments)

--- a/source/app/service-providers/fsal/util/detect-file-indentation.ts
+++ b/source/app/service-providers/fsal/util/detect-file-indentation.ts
@@ -1,0 +1,83 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        detectFileIndentation
+ * CVM-Role:        Utility Function
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This module detects the most prevalent line indentation
+ *                  mechanism of a text file. It can account for tabs or spaces
+ *                  of variable length.
+ *
+ * END HEADER
+ */
+
+/**
+ * Returns the amount of uninterrupted space characters at the beginning of the
+ * line.
+ *
+ * @param   {string}  line  The line's text contents
+ *
+ * @return  {number}        The number of leading spaces
+ */
+function getLeadingSpacesCount (line: string): number {
+  let count = 0
+  for (const char of line) {
+    if (char !== ' ') {
+      return count
+    }
+    count++
+  }
+
+  return count
+}
+
+/**
+ * Utility function that takes a list of lines (i.e., already split on newlines)
+ * and returns a pair of elements. The first element is either a tab or a space,
+ * reflecting which character is being used to indent in the file, and the
+ * second element contains the amount of repeated characters used for
+ * indentation, which is defined as 1 in the case of tabs, or any higher number
+ * in the case of spaces.
+ *
+ * @param   {string[]}          lines  The lines of the file
+ *
+ * @return  {[string, number]}         An element tuple of `['\t'|' ', number]`
+ */
+export function detectFileIndentation (lines: string[]): [ '\t'|' ', number ] {
+  // NOTE: This function is taken from Heather Arthur and adapted for our case.
+  // Source: https://gist.github.com/harthur/c6c939a938db52064a7a
+  // cf. original article: https://heathermoor.medium.com/detecting-code-indentation-eff3ed0fb56b
+  const indents: Record<string, number> = {}
+  let lastIndentSize = 0
+
+  // First round, count the occurrences of any type of indentation differences
+  for (const line of lines) {
+    if (line.startsWith('\t')) {
+      indents['\t'] = (indents['\t'] || 0) + 1
+    } else {
+      const spacesCount = getLeadingSpacesCount(line)
+      const difference = Math.abs(spacesCount - lastIndentSize)
+      const currentIndentation = ' '.repeat(difference)
+      if (difference > 1) {
+        indents[currentIndentation] = (indents[currentIndentation] || 0) + 1
+      }
+      lastIndentSize = spacesCount
+    }
+  }
+
+  // Second round: Determine which indent diff is most prevalent in the file
+  let detectedIndentation = '    ' // By default, assume 4 spaces indentation
+  let max = 0
+  for (const [ indent, count ] of Object.entries(indents)) {
+    if (count > max) {
+      max = count
+      detectedIndentation = indent
+    }
+  }
+
+  // Return the detected indentation
+  return [ detectedIndentation.slice(0, 1) as '\t'|' ', detectedIndentation.length ]
+}

--- a/source/app/service-providers/fsal/util/extract-linefeed.ts
+++ b/source/app/service-providers/fsal/util/extract-linefeed.ts
@@ -14,6 +14,14 @@
 
 type Linefeed = '\n'|'\r'|'\r\n'|'\n\r'
 
+/**
+ * Utility function that detects and returns the first detected linefeed of a
+ * file. It checks for linefeeds one after another in decreasing prevalence.
+ *
+ * @param   {string}    text  The text in question
+ *
+ * @return  {Linefeed}        The detected linefeed
+ */
 export function extractLinefeed (text: string): Linefeed {
   const CR = text.includes('\r')
   const LF = text.includes('\n')

--- a/source/app/service-providers/fsal/util/file-parser.ts
+++ b/source/app/service-providers/fsal/util/file-parser.ts
@@ -29,6 +29,8 @@ import type {
   ZettelkastenTag
 } from '@common/modules/markdown-utils/markdown-ast'
 import { extractLinefeed } from './extract-linefeed'
+import { detectFileIndentation } from './detect-file-indentation'
+import { normalizeLineEndings } from './normalize-line-endings'
 
 // Here are all supported variables for Pandoc:
 // https://pandoc.org/MANUAL.html#variables
@@ -65,6 +67,8 @@ export default function getMarkdownFileParser (
     file.bom = extractBOM(content)
     file.linefeed = extractLinefeed(content)
     file.id = extractFileId(file.name, content, idREPattern)
+    const normalizedContent = normalizeLineEndings(content)
+    ;[ file.indentChar, file.indentSize ] = detectFileIndentation(normalizedContent.split('\n'))
 
     // Parse the file into our AST
     const ast = md2ast(content)

--- a/source/app/service-providers/fsal/util/normalize-line-endings.ts
+++ b/source/app/service-providers/fsal/util/normalize-line-endings.ts
@@ -1,0 +1,31 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        normalizeLineEndings
+ * CVM-Role:        Utility Function
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     A utility function to normalize line endings.
+ *
+ * END HEADER
+ */
+
+/**
+ * Utility function that takes in a file's contents, splits it according to any
+ * available line ending, ordered by prevalence (CRLF, LFCR, LF, CR), and then
+ * joins the lines with a simple linefeed (LF, `\n`).
+ *
+ * @param   {string}  text  The unsanitized text
+ *
+ * @return  {string}        The text with all linefeeds normalized to LF.
+ */
+export function normalizeLineEndings (text: string): string {
+  return text
+    // Always split with a regular expression to ensure that mixed linefeeds
+    // don't break reading in a file. Then, on save, the linefeeds will be
+    // standardized to whatever the linefeed extractor detected.
+    .split(/\r\n|\n\r|\n|\r/g)
+    .join('\n')
+}

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -195,7 +195,7 @@ function getCoreExtensions (options: CoreExtensionOptions): Extension[] {
     search({ top: true }), // Add a search
     // TAB SIZES/INDENTATION -> Depend on the configuration field
     EditorState.tabSize.from(configField, (val) => val.indentUnit),
-    indentUnit.from(configField, (val) => val.indentWithTabs ? '\t' : ' '.repeat(val.indentUnit)),
+    indentUnit.from(configField, (val) => ' '.repeat(val.indentUnit)),
     EditorView.lineWrapping, // Enable line wrapping,
     autoCloseBracketsConfig,
 

--- a/source/types/common/fsal.ts
+++ b/source/types/common/fsal.ts
@@ -84,6 +84,8 @@ export interface MDFileDescriptor extends FSMetaInfo {
   tags: string[]
   links: string[] // Any outlinks declared in the file
   bom: string // An optional BOM
+  indentChar: '\t'|' ' // Detected indentation char, either a tab or a space
+  indentSize: number // Number of char repetitions, always 1 for tabs.
   wordCount: number
   charCount: number
   firstHeading: string|null
@@ -100,6 +102,8 @@ export interface CodeFileDescriptor extends FSMetaInfo {
   ext: string
   type: 'code'
   bom: string // An optional BOM
+  indentChar: '\t'|' ' // Detected indentation char, either a tab or a space
+  indentSize: number // Number of char repetitions, always 1 for tabs.
   linefeed: string
   modified: boolean
 }

--- a/test/change-file-indentation.spec.ts
+++ b/test/change-file-indentation.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-disable no-undef */
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        File Indentation change tester
+ * CVM-Role:        TESTING
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This file tests a component of Zettlr.
+ *
+ * END HEADER
+ */
+
+import { strictEqual } from 'assert'
+import { changeFileIndentation } from 'source/app/service-providers/documents/util/change-file-indentation'
+
+interface Test {
+  newIndent: '\t'|' '
+  newSize: number
+  input: string
+  output: string
+}
+
+const testers: Test[] = [
+  {
+    newIndent: '\t',
+    newSize: 3, // Intentional wrong number
+    input: `# This is a Markdown document
+
+It has an indentation of four spaces.
+
+- One
+    - Sub one
+    - Sub two
+- Two
+
+Here is an odd indentation that should be kept:
+
+ Hello.
+
+Another thing it should not do is tamper with trailing spaces as here    
+
+Or in this other line:        `,
+    output: `# This is a Markdown document
+
+It has an indentation of four spaces.
+
+- One
+	- Sub one
+	- Sub two
+- Two
+
+Here is an odd indentation that should be kept:
+
+ Hello.
+
+Another thing it should not do is tamper with trailing spaces as here    
+
+Or in this other line:        `
+  },
+  {
+    newIndent: ' ',
+    newSize: 7,
+    input: `# This is a Markdown document
+
+It has an indentation of four spaces.
+
+- One
+	- Sub one
+	- Sub two
+- Two
+
+Here is an odd indentation that should be kept:
+
+ Hello.
+
+Another thing it should not do is tamper with trailing spaces as here    
+
+Or in this other line:        `,
+    output: `# This is a Markdown document
+
+It has an indentation of four spaces.
+
+- One
+       - Sub one
+       - Sub two
+- Two
+
+Here is an odd indentation that should be kept:
+
+ Hello.
+
+Another thing it should not do is tamper with trailing spaces as here    
+
+Or in this other line:        `
+  }
+]
+
+describe('Utility#changeFileIndentation()', function () {
+  for (const test of testers) {
+    it(`should propely adapt the indentation to "${test.newIndent}" (width: ${test.newSize})`, function () {
+      strictEqual(changeFileIndentation(test.input, test.newIndent, test.newSize), test.output)
+    })
+  }
+})


### PR DESCRIPTION
## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->

This PR's aim is to finally solve the various bug reports complaining about "dancing" list items with users who use tabs instead of spaces for their Markdown indentation.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

The fix is basically to remove any tabs upon file loading and only re-add them upon saving the file. It sounds stupid, but I hope that it works, in which case it ain't stupid.

## Side Effects

There is a side effect that this PR will introduce, namely that indentation will automatically be normalized upon reading and writing any supported file with Zettlr, like line endings.

This means: If you have a mixed indentation in any file (i.e., two spaces and four spaces), the more prevalent indentation pattern will overwrite the lesser used pattern. This means that this PR has the ability to change your files simply by opening and saving them. **IN THEORY**, this should have no impact on people, but I wanted to mention it here.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

For months now people have been complaining that their lists were expressing "dancing" behavior. The cause is simple to explain: Zettlr wraps long lines, and without any special treatment, indented lines would look like this:

```
- List item
    - An indented list item, which we will assume to
be wrapped at this point.
```

But we want it to look like this:

```
- List item
    - An indented list item, which we will assume to
      be wrapped at this point.
```

In order to do so, we have to continuously play around with the text-indent and first-line indent to match up the characters on the list item's lines. Since this also must work with variable-width fonts (since not all use one of the monospaced themes), we have to actually measure pixel-precise where these lines are at.

The issue with tab characters now is the way tab characters are supposed to work. Using tabulators assumes that you can take a page and split it up into invisible vertical columns. Inserting a tab character means that any text after it should always be moved to the beginning of the next available vertical column. This means, if you insert or delete some text from before the tab character, this will not change the position of the text following the tab character.

So, in our case: When we measure the positions of the two wrapped lines, the tabs will cause the lines to be at one of these vertical lines. If we now apply our calculations to the line and change the text-indent and first-line indent accordingly, the browser will immediately recalculate where the text should be according to the tab characters in the document. This will move the text, rendering our calculations wrong.

Since we re-calculate these indents on every single keystroke, the lines will move every time. If you observe this behavior, you will notice that it starts to cycle between a few positions back and forth as you type.

As I cannot influence how the browser's layouting algorithm recalculates tab sizes (again, tab characters are NOT a fixed width, they only have a fixed MINIMUM width and are thus variable in width), this PR circumvents this issue entirely by just removing all tab characters before displaying the document.

This is how tabs are now treated:

```
1. Load in a file that uses tab indentation
2. Zettlr replaces them with a space-based indentation
3. You modify the document, indenting and unindenting lines
4. You tell Zettlr to save your file
5. Zettlr replaces the space-based indentation with tabs
6. Write the file to disk.
```

## Things we definitely have to test

Since my time is limited, I decided to provide the basic implementation, but I'll have to leave testing to others:

- [ ] How does navigation work? Right now we probably can navigate the various spaces. Should we not do this and instead make the cursor movement "jump" across indentation units (i.e., four spaces at a time)?
- [ ] Does this thing even work in preserving tabs on disk but not displaying them?
- [ ] One thing I couldn't test is whether this now influences the way equality is being calculated to determine if we need to save a document (newlines are probably already accounted for …? Please check.)
- [ ] Also we definitely have to check what influence the tab size setting now has on the documents. I am considering if we should always use a fixed tab size in the editors of four spaces, and only apply the tab setting to the file saving process…? Comments requested.

<!-- Please provide any testing system -->
Tested on: macOS Sequoia 15.0

Fixes (or should fix) the following issues:

- Fixes #4602
