### PR TITLE
feat: Improve Vim mode navigation and restore default shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@
   project files to reside in the top folder; included project files in
   subfolders will not be affected
 - The formatting toolbar can now be toggled on or off in the preferences (#5207)
-- Mapped Vim's write and quit commands to saving and closing actions (#4720,
-  #5463):
-  - `w`: Executes a save command for the current file
-  - `q`: Executes a close-file command for the current file
-  - `wq`: Attempts to save the current file and then close it
-  - Note that the `!` argument for supressing the "Omit unsaved changes" dialog
-    will not work, as the editor does not have the authority to tell main to
-    simply omit work (this is a security feature)
+- Vim mode improvements:
+  - Mapped Vim's write and quit commands to saving and closing actions (#4720,
+    #5463):
+    - `w`: Executes a save command for the current file
+    - `q`: Executes a close-file command for the current file
+    - `wq`: Attempts to save the current file and then close it
+    - Note that the `!` argument for supressing the "Omit unsaved changes" dialog
+      will not work, as the editor does not have the authority to tell main to
+      simply omit work (this is a security feature)
+  - Movement keys (`j`/`k`) now account for line wrapping for a smoother
+    navigation experience
+  - Default Shortcuts Restored: Unmapped `C-f`, `C-t`, and `C-c` in specific modes to re-enable default editor behaviors like search and task item shortcuts
 - Columns in the preferences window are now properly aligned (#5410)
 - Prevent initial startup update-check if the setting is unchecked (context:
   https://github.com/Zettlr/Zettlr/commit/812899#r148519528)

--- a/source/common/modules/markdown-editor/plugins/vim-mode.ts
+++ b/source/common/modules/markdown-editor/plugins/vim-mode.ts
@@ -109,6 +109,15 @@ Vim.defineEx('wq', 'wq', (cm: CodeMirror, params: VimParams) => {
   })
 })
 
+// Remap movement keys
+Vim.map('j', 'gj') // Account for line wraps when moving down
+Vim.map('k', 'gk') // Account for line wraps when moving up
+
+// Unmap bindings to restore default editor behavior
+Vim.unmap('<C-f>') // Allow invoking Ctrl+F search from all modes
+Vim.unmap('<C-t>', 'insert') // Allow task item shortcut in Insert mode
+Vim.unmap('<C-c>', 'insert') // Allow using Ctrl+C without exiting Insert mode
+
 // Why do we do this, even though it seems somewhat pointless? Well, first to
 // ensure that we have a central place where we modify the Vim extension, and
 // two, in case we can actually provide extensions inside the state here, we


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
After seeing the recent changes to the Vim mode (https://github.com/Zettlr/Zettlr/commit/284b549b7de5b1011831777b17d3b19d402c61c3), I thought this would a good chance to also introduce some additional quality of life improvements when using Vim mode in Zettlr specifically (see Changes below).


## Changes
- Remapped movement keys (`j`/`k`) to `gj`/`gk` to account for line wraps
- Unmapped the following Vim key bindings to prefer the default Zettlr behavior:
  - `Ctrl + F`: Invoke the search bar (all modes)
  - `Ctrl + T`: Task item shortcut (insert mode)
  - `Ctrl + C`: Copy (insert mode; if this binding was _not_ unmapped, it would simply exit Insert mode)

## Additional information
I have been using these bindings extensively for quite some time in my custom setup, and had no issues with them so far.

<!-- Please provide any testing system -->
Tested on: Ubuntu, Windows 11
