### PR TITLE
Fix keymap conflicts that caused issues #5636 and #5637

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming
 
+- Fix issues #5636 and #5637 where conflicting keymaps would cause pressing
+  'Enter' to jump to a new line instead of applying autocomplete suggestions. 
+
 ## GUI and Functionality
 
 - **Breaking Change**: Switched Windows Code Signing Certificate to the Azure

--- a/source/common/modules/markdown-editor/autocomplete/index.ts
+++ b/source/common/modules/markdown-editor/autocomplete/index.ts
@@ -19,11 +19,7 @@ import {
   type CompletionSource,
   type CompletionResult,
   autocompletion,
-  type CompletionContext,
-  startCompletion,
-  acceptCompletion,
-  closeCompletion,
-  moveCompletionSelection
+  type CompletionContext
 } from '@codemirror/autocomplete'
 import { type StateField } from '@codemirror/state'
 import { codeBlocks } from './code-blocks'
@@ -32,7 +28,6 @@ import { snippets } from './snippets'
 import { files } from './files'
 import { tags } from './tags'
 import { headings } from './headings'
-import { keymap } from '@codemirror/view'
 
 export interface AutocompletePlugin {
   /**

--- a/source/common/modules/markdown-editor/autocomplete/index.ts
+++ b/source/common/modules/markdown-editor/autocomplete/index.ts
@@ -122,17 +122,6 @@ export const autocomplete = [
     // produce backticks. (See issue #5517)
     defaultKeymap: false
   }),
-  keymap.of([
-    // TODO: We probably want to move this into the keymaps section at some
-    // point.
-    { key: 'Ctrl-Space', run: startCompletion },
-    { key: 'Escape', run: closeCompletion },
-    { key: 'ArrowDown', run: moveCompletionSelection(true) },
-    { key: 'ArrowUp', run: moveCompletionSelection(false) },
-    { key: 'PageDown', run: moveCompletionSelection(true, 'page') },
-    { key: 'PageUp', run: moveCompletionSelection(false, 'page') },
-    { key: 'Enter', run: acceptCompletion }
-  ]),
   // Make sure any configuration fields will be inserted into the state so that
   // the plugins can look them up and function correctly. These fields are not
   // required by the main class (MarkdownEditor), hence we do not have to re-

--- a/source/common/modules/markdown-editor/keymaps/markdown.ts
+++ b/source/common/modules/markdown-editor/keymaps/markdown.ts
@@ -1,5 +1,6 @@
 import {
-  acceptCompletion, closeCompletion, deleteBracketPair, moveCompletionSelection
+  acceptCompletion, closeCompletion, deleteBracketPair, moveCompletionSelection,
+  startCompletion
 } from '@codemirror/autocomplete'
 import {
   insertNewlineAndIndent, copyLineUp, copyLineDown
@@ -29,6 +30,7 @@ import { sharedKeymap } from './shared'
 export function markdownKeymap (): Extension {
   return keymap.of([
     // completionKeymap
+    { key: 'Ctrl-Space', run: startCompletion },
     { key: 'Escape', run: closeCompletion },
     { key: 'ArrowDown', run: moveCompletionSelection(true) },
     { key: 'ArrowUp', run: moveCompletionSelection(false) },

--- a/source/common/modules/markdown-editor/keymaps/markdown.ts
+++ b/source/common/modules/markdown-editor/keymaps/markdown.ts
@@ -4,7 +4,9 @@ import {
 import {
   insertNewlineAndIndent, copyLineUp, copyLineDown
 } from '@codemirror/commands'
-import { insertNewlineContinueMarkup } from '@codemirror/lang-markdown'
+import { 
+  insertNewlineContinueMarkup, deleteMarkupBackward
+} from '@codemirror/lang-markdown'
 import type { Extension } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
 import { nextSnippet, abortSnippet } from '../autocomplete/snippets'
@@ -58,6 +60,7 @@ export function markdownKeymap (): Extension {
     { key: 'Enter', run: insertNewlineAndIndent },
 
     // Overload Backspace
+    { key: 'Backspace', run: deleteMarkupBackward },
     { key: 'Backspace', run: deleteBracketPair },
     { key: 'Backspace', run: handleBackspace },
 

--- a/source/common/modules/markdown-editor/parser/markdown-parser.ts
+++ b/source/common/modules/markdown-editor/parser/markdown-parser.ts
@@ -174,6 +174,7 @@ export default function markdownParser (config?: MarkdownParserConfig): Language
 
       return null
     },
+    addKeymap: false,
     extensions: {
       // yamlCodeParse is a wrapper that scans the document for the existence of
       // a YAML frontmatter and then parses its contents. NOTE: Since a single


### PR DESCRIPTION
## Description
Fix issues #5636 and #5637 where conflicting keymaps would cause pressing 'Enter' to jump to a new line instead of applying autocomplete suggestions.

## Changes
The fix involved configuring the @codemirror/lang-markdown package to NOT install its Markdown keymap because this keymap took precedence over Zettlr's custom keymaps causing undesired behavior.

Tested on: macOS Sequoia 15.3.1, Apple Silicon