### PR TITLE
fix: Tweak citation selection to be less greedy

### DIFF
--- a/source/common/modules/markdown-editor/renderers/click-and-select.ts
+++ b/source/common/modules/markdown-editor/renderers/click-and-select.ts
@@ -31,9 +31,34 @@ export default function clickAndSelect (view: EditorView): (event: MouseEvent) =
       return
     }
 
-    const { top, left, bottom, right } = target.getBoundingClientRect()
-    const fromPos = view.posAtCoords({ x: left, y: top })
-    const toPos = view.posAtCoords({ x: right, y: bottom })
+    // The thing we're clicking on may span multiple lines in the editor; for
+    // example, clicking on a citation that has a (soft) line-wrap in the middle
+    // of the rendered text.
+    //
+    // Grabbing the `getBoundingClientRect` is too coarse in such cases because
+    // the selection will span the *entirety* of both lines rather than just the
+    // text of the rendered citation (in this example).
+    //
+    // So, we need to find the *smallest* rectangle that applies in the list of
+    // all possible rectangles for the target; continuing with the citation
+    // example, clicking on a citation that has a (soft) line-wrap in the middle
+    // of the rendered text *must* only select (highlight) the rectangle of the
+    // citation text itself.
+    const rects = target.getClientRects()
+    let fromPos = null
+    let toPos = null
+
+    for (const rect of rects) {
+      const startPos = view.posAtCoords({ x: rect.left, y: rect.top })
+      const endPos = view.posAtCoords({ x: rect.right, y: rect.bottom })
+
+      if (startPos !== null && (fromPos === null || startPos < fromPos)) {
+        fromPos = startPos
+      }
+      if (endPos !== null && (toPos === null || endPos > toPos)) {
+        toPos = endPos
+      }
+    }
 
     if (fromPos === null || toPos === null) {
       return


### PR DESCRIPTION
Fixes #5192

## Description

When clicking on a thing -- such as a citation -- that has a (soft) line-wrap in the middle of the rendered text the current (unwanted) behaviour is that the entirety of all lines that the clicked-on thing spans are selected.

This fixes the behaviour so that *only* the clicked-on thing is selected, even when the clicked-on thing spans multiple lines due to a (soft) line-wrap.

## Before

Notice how text outside the citation is highlighted.

https://github.com/user-attachments/assets/6d77d04e-3601-4854-af6b-7da34a2f51ab

## After

Notice how only the text of the citation is highlighted.

https://github.com/user-attachments/assets/7104a5cb-373b-4008-a795-16c0db57c77f

## Additional information

The fix absolutely 100% belongs to @pradnyaakumbhar: I've just picked up their work from #5470 because it's been languishing in PR limbo. Solely in the interest of getting this over the line -- because it's been mildly annoying me when using Zettlr for my own work -- I've addressed the linting issues and tested it locally. Hopefully this is enought to get it over the line, all hail Pradnya 🙇‍♂️

> I'm not trying to jump Pradnya's train. I'm looking to contribute more to Zettlr and this was a `good first issue` that looked to be stalled.

Tested on: Windows 11 Home
