### PR TITLE
fix: Spawn shell when starting test GUI on Windows

### DIFF
--- a/scripts/test-gui/index.mjs
+++ b/scripts/test-gui/index.mjs
@@ -122,6 +122,7 @@ function startApp (argv = []) {
   const forgeArgs = [ 'start', '--', `--data-dir="${CONF_DIRECTORY}"`, ...argv ]
   // Spawn's options: Use the root as CWD and pipe the process's stdio to the parent process.
   const spawnOptions = {
+    shell: process.platform === "win32",
     cwd: path.join(__dirname, '../../'),
     stdio: [ process.stdin, process.stdout, process.stderr ]
   }


### PR DESCRIPTION
## Description

When running the test GUI in Windows I encounter the following error:

```shell
$ yarn start
Starting app with old test environment ...
Starting Zettlr with custom configuration ...
node:internal/child_process:420
    throw new ErrnoException(err, 'spawn');
          ^

Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:420:11)
    at spawn (node:child_process:762:9)
    at startApp (file:///C:/Users/44750/projects/zettlr/scripts/test-gui/index.mjs:142:16)
    at file:///C:/Users/44750/projects/zettlr/scripts/test-gui/index.mjs:53:3
    at ModuleJob.run (node:internal/modules/esm/module_job:263:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:540:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
}

Node.js v20.19.0
```

> Note that this error happens whether the test environment is new or old.

## Changes

If I change the `spawn` call so that it uses a shell -- [options](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) -- when running on Windows then the test GUI runs just fine with no error. (Or at least, not that error.)

There are other places in the codebase that also explicitly request a shell when spawning: they _always_ request a shell rather than just when running on Windows. `{ shell: true }`

Thoughts? I need this fix in place to be able to run the test GUI on Windows. I can, of course, use WSL but hey, I thought I'd raise this speculatively and see what rolls out.

Tested on: Windows 11 Home, running Git-Bash.

> Note that I have not updated the CHANGELOG per the PR template guideline 'cos I don't know when this'll be merged, if ever 🤷