### PR TITLE
feat: Add transform to strip duplicate spaces

### DIFF
--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -21,6 +21,7 @@ import { type SyntaxNode } from '@lezer/common'
 import { forEachDiagnostic, type Diagnostic, forceLinting, setDiagnostics } from '@codemirror/lint'
 import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList } from '../commands/markdown'
 import { cut, copyAsPlain, copyAsHTML, paste, pasteAsPlain } from '../util/copy-paste-cut'
+import { stripDuplicateSpaces } from '../util/transform-selected-text'
 
 const ipcRenderer = window.ipc
 const suggestionCache = new Map<string, string[]>()
@@ -250,6 +251,23 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       id: 'selectAll',
       type: 'normal',
       enabled: true
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: trans('Transform'),
+      id: 'submenuTransform',
+      type: 'submenu',
+      enabled: true,
+      submenu: [
+        {
+          label: trans('Strip duplicate spaces'),
+          id: 'stripDuplicateSpaces',
+          type: 'normal',
+          enabled: true
+        }
+      ]
     }
   ]
 
@@ -285,6 +303,8 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       paste(view)
     } else if (clickedID === 'pasteAsPlain') {
       pasteAsPlain(view)
+    } else if (clickedID === 'stripDuplicateSpaces') {
+      stripDuplicateSpaces(view)
     } else if (clickedID === 'selectAll') {
       view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } })
     } else if (clickedID === 'no-suggestion') {

--- a/source/common/modules/markdown-editor/util/transform-selected-text.ts
+++ b/source/common/modules/markdown-editor/util/transform-selected-text.ts
@@ -1,0 +1,86 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        transformSelectedText function
+ * CVM-Role:        Utility function
+ * Maintainers:     Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     A higher-order Command for transforming selected text.
+ *
+ * END HEADER
+ */
+
+import { ChangeSet, type StateCommand } from '@codemirror/state'
+
+/**
+ * Transform the supplied `text`.
+ *
+ * * strip duplicate spaces
+ * * trim leading and trailing whitespace
+ * * change the casing
+ * * etc.
+ *
+ * @param   {string}  text  The text to be transformed.
+ *
+ * @return  {string}        The transformed text.
+ */
+export type TransformText = (text: string) => string
+
+/**
+ * Utility to transform selected text.
+ */
+export function transformSelectedText (transform: TransformText): StateCommand {
+  return ({ state, dispatch }) => {
+    if (state.selection.ranges.length === 0) {
+      // when nothing is selected there's nothing to do
+      return false
+    }
+
+    const changes = state.selection.ranges.reduce((change, { from, to }) => {
+      const text = state.sliceDoc(from, to)
+
+      const transformedText = transform(text)
+
+      if (transformedText === text) {
+        // when there's no change just return the existing change (if any)
+        return change
+      }
+
+      const nextChange = ChangeSet.of(
+        { from, to, insert: transformedText },
+        state.doc.length
+      )
+
+      return change.compose(nextChange)
+    }, ChangeSet.empty(state.doc.length))
+
+    if (changes.empty) {
+      // when there are no changes there's nothing to do
+      return false
+    }
+
+    dispatch(state.update({ changes }))
+    return true
+  }
+}
+
+const SEPARATOR_WORD = ' '
+
+/**
+ * Strip duplicate spaces from selected text.
+ *
+ * Sequences of two or more spaces will be collapsed to a single space.
+ *
+ * Note that sequences of interleaved whitespace such as `\t \t \t ` will _not_
+ * lead to any collapsing: _only_ sequences of two or more _spaces_ will be
+ * collapsed to a single space.
+ *
+ * @param   {string}  text
+ *
+ * @return  {string}        The text with all duplicate spaces stripped.
+ */
+export const stripDuplicateSpaces = transformSelectedText((text) => {
+  return text.replaceAll(/ {2,}/g, SEPARATOR_WORD)
+})

--- a/test/transform-selected-text/strip-duplicate-spaces.spec.ts
+++ b/test/transform-selected-text/strip-duplicate-spaces.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Tests for the stripDuplicateSpaces function
+ * CVM-Role:        TESTING
+ * Maintainers:     Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     This file tests the stripDuplicateSpaces function.
+ *
+ * END HEADER
+ */
+
+import { stripDuplicateSpaces } from '@common/modules/markdown-editor/util/transform-selected-text'
+import { fail, deepEqual, strictEqual } from 'assert'
+import { EditorSelection, EditorState, Transaction } from '@codemirror/state'
+import { selectAll } from './support'
+
+describe('MarkdownEditor#stripDuplicateSpaces()', function () {
+  it('given text with two duplicate spaces' +
+     ' and all the text is selected' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then a transaction is dispatched to strip them', function () {
+
+    const text = 'Duplicate (  ) spaces'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    let wasDispatched = false
+
+    const dispatch = (tx: Transaction) => {
+      wasDispatched = true
+
+       // minus the 1 stripped space
+      const expectedLengthAfterStripping = text.length - 1
+
+      deepEqual(tx.changes, {
+        inserted: [
+          {
+            length: expectedLengthAfterStripping,
+            text: ['Duplicate ( ) spaces']
+          }
+        ],
+        sections: [
+          text.length,
+          expectedLengthAfterStripping
+        ]
+      })
+    }
+
+    stripDuplicateSpaces({ state, dispatch })
+
+    strictEqual(wasDispatched, true, "A transaction must have been dispatched")
+  })
+
+  it('given text with multiple occurrences of duplicate spaces' +
+     ' and all the text is selected' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then a transaction is dispatched to strip all occurrences', function () {
+
+    const text = 'Duplicate (  ) spaces and again (     ) and again (  ) '
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    let wasDispatched = false
+
+    const dispatch = (tx: Transaction) => {
+     wasDispatched = true
+
+     // minus all the stripped extra spaces
+      const expectedLengthAfterStripping = text.length - 6
+
+      deepEqual(tx.changes, {
+        inserted: [
+          {
+            length: expectedLengthAfterStripping,
+            text: ['Duplicate ( ) spaces and again ( ) and again ( ) ']
+          }
+        ],
+        sections: [
+          text.length,
+          expectedLengthAfterStripping
+        ]
+      })
+   }
+
+   stripDuplicateSpaces({ state, dispatch })
+
+   strictEqual(wasDispatched, true, "A transaction must have been dispatched")
+ })
+
+  it('given text with no duplicate spaces' +
+     ' and no selected text' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then no transaction is dispatched' +
+     ' because nothing is selected', function () {
+
+      const state = EditorState.create({
+        doc: 'There are no duplicate spaces in this text'
+      })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    stripDuplicateSpaces({ state, dispatch })
+  })
+
+  it('given text with no duplicate spaces' +
+     ' and all the text is selected' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then no transaction is dispatched' +
+     ' because there are no spaces to be stripped', function () {
+
+    const text = 'There are no duplicate spaces in this text'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    stripDuplicateSpaces({ state, dispatch })
+  })
+
+  it('given text with two duplicate spaces' +
+     ' but those dupes are not in the selected text' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then no transaction is dispatched', function () {
+
+    const text = 'Duplicate (  ) spaces'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: EditorSelection.create([
+        // select just the first word which *doesn't* include the dupes
+        EditorSelection.range(0, 8),
+      ]),
+    })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    stripDuplicateSpaces({ state, dispatch })
+  })
+
+  it('given text with no duplicate spaces' +
+     ' but there\'s a sequence of duplicated *tabs*' +
+     ' and all the text is selected' +
+     ' when stripDuplicateSpaces is applied' +
+     ' then no transaction is dispatched' +
+     ' because there are no duplicate spaces to be stripped', function () {
+
+    const text = 'No duplicate spaces but \t \t\t there are duplicate tabs'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    stripDuplicateSpaces({ state, dispatch })
+  })
+})

--- a/test/transform-selected-text/support.ts
+++ b/test/transform-selected-text/support.ts
@@ -1,0 +1,21 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Supporting code for the text transform tests
+ * CVM-Role:        TESTING
+ * Maintainers:     Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     This file has supporting code for the text transform tests.
+ *
+ * END HEADER
+ */
+
+import { EditorSelection } from '@codemirror/state'
+
+export function selectAll(text: string): EditorSelection {
+  return EditorSelection.create([
+    EditorSelection.range(0, text.length)
+  ])
+}


### PR DESCRIPTION
Closes #5679

This adds one of the text transforms -- strip duplicate spaces -- from issue #5659.

I'm using this PR to both flush out the approach and learn any things about contributing to this codebase. If all goes well I'll implement the other text transforms secure in the knowledge that the approach has been signed-off by Hendrik (and others) and any "dumb" first-time contributor stuff is sorted.

## Description

This adds a new _Transforms_ submenu to the editor which has exactly one transform in it (for now): strip duplicate spaces.

In the video I am:

* adding some spaces between words
* selecting text that I want to strip duplicate spaces from
* clicking the command from the aforementioned submenu

After running the command the duplicate spaces are stripped: that is, collapsed to a single space.



https://github.com/user-attachments/assets/c90fa712-40c6-4235-ae2e-3b911aedf2bc


## Additional information

Tested on: Windows 11 Home.

> Note that I have not updated the CHANGELOG per the PR template guideline 'cos I don't know when this'll be merged, if ever 🤷
