### PR TITLE
feat: Cache ESLint to improve speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,9 @@ test-config.yml
 yarn-error.log
 yarn.log
 
-# Don't commit ESLint error reports
+# Don't commit ESLint stuff
 eslint_report.htm
+.eslintcache
 
 # Taken from https://www.gitignore.io/api/visualstudiocode
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "update:citation": "node scripts/update-citation.mjs",
     "test": "mocha",
     "test-gui": "cross-env NODE_ENV=develop node scripts/test-gui/index.mjs",
-    "lint:code": "eslint",
+    "lint:code": "eslint --cache",
     "lint:types": "vue-tsc --noEmit",
     "lint:po": "node scripts/lint-po.mjs",
     "lint": "yarn lint:code && yarn lint:types",


### PR DESCRIPTION
## Description

Running ESLint on the command line is slow.

This change enables ESLint caching which speeds up subsequent runs of the tool on the command line.

* [Caching](https://eslint.org/docs/latest/use/command-line-interface#caching)

Current timings with no caching.

```
real    1m32.620s
```

After change, with caching.

```
real    0m7.296s
```

I am using the ESLint VSCode extension for in-the-moment linting of files I'm working on. Still, I lilke to run the `yarn lint` and `yarn test` scripts before pushing just to ensure that I haven't b0rk3d anything.

Waiting near two minutes for the linting to complete is punishing. The caching is not a great solution -- waiting near 10 seconds is still pretty slow -- but it's a marked improvement on the performance without it.

Note that this doesn't have any impact on the GitHub Actions builds; they are still taking near two minutes to lint the codebase.

* [Recent build](https://github.com/Zettlr/Zettlr/actions/runs/14171139998/job/39695001535)

Addressing the GitHub Actions build times is a separate issue I think; this fix is all about improving (one small aspect of) the Developer Experience (DX) of working on the Zettlr codebase.

## Additional information

Tested on: Windows 11 Home.

> Note that I have not updated the CHANGELOG per the PR template guideline 'cos I don't know when this'll be merged, if ever 🤷