### PR TITLE
[#5571] Changed shortcut to switch tab

### DIFF
--- a/source/app/service-providers/menu/menu.darwin.ts
+++ b/source/app/service-providers/menu/menu.darwin.ts
@@ -598,7 +598,7 @@ export default function getMenu (
         {
           id: 'menu.tab_previous',
           label: trans('Previous Tab'),
-          accelerator: 'Ctrl+Shift+Tab',
+          accelerator: 'Ctrl+PageDown',
           click: function (_menuitem, focusedWindow) {
             (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'previous-tab')
           }
@@ -606,7 +606,7 @@ export default function getMenu (
         {
           id: 'menu.tab_next',
           label: trans('Next Tab'),
-          accelerator: 'Ctrl+Tab',
+          accelerator: 'Ctrl+PageUp',
           click: function (_menuitem, focusedWindow) {
             (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'next-tab')
           }

--- a/source/app/service-providers/menu/menu.win32.ts
+++ b/source/app/service-providers/menu/menu.win32.ts
@@ -572,7 +572,7 @@ export default function getMenu (
         {
           id: 'menu.tab_previous',
           label: trans('Previous Tab'),
-          accelerator: 'Ctrl+Shift+Tab',
+          accelerator: 'Ctrl+PageDown',
           click: function (_menuitem, focusedWindow) {
             (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'previous-tab')
           }
@@ -580,7 +580,7 @@ export default function getMenu (
         {
           id: 'menu.tab_next',
           label: trans('Next Tab'),
-          accelerator: 'Ctrl+Tab',
+          accelerator: 'Ctrl+PageUp',
           click: function (_menuitem, focusedWindow) {
             (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'next-tab')
           }


### PR DESCRIPTION
Description

Fix issue https://github.com/Zettlr/Zettlr/issues/5571 . Users can now open the next and previous active tab via Ctrl+PageUp and Ctrl+PageDown like in Visual Studio Code.

Changes

Shortcut to open the next and previous active tab is changed to CTRL+PageUp/Down as in Visual Studio Code.

Test

1. Open 3 documents
2. Press the shortcut Ctrl+PageUp
3. See that the next open document is shown
4. Press Ctrl+PageDown
5. See that the previous open document is shown


Expected behavior: the next/previous tab is shown.

Tested on: Ubuntu 22.04 LTS