### PR TITLE
feat: Add Custom Shortcuts

### DIFF
--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -16,6 +16,7 @@ import { app } from 'electron'
 import * as bcp47 from 'bcp-47'
 import { v4 as uuid4 } from 'uuid'
 import getLanguageFile from '@common/util/get-language-file'
+import { getPlatformSpecificDefaultKeybinding, type EditorKeyboardCommand } from '@common/modules/markdown-editor/keymaps/default-map'
 
 export type MarkdownTheme = 'berlin'|'frankfurt'|'bielefeld'|'karl-marx-stadt'|'bordeaux'
 
@@ -120,6 +121,7 @@ export interface ConfigOptions {
       replacements: Array<{ key: string, value: string }>
       matchWholeWords: boolean
     }
+    keyboardShortcuts: Record<EditorKeyboardCommand, string>
   }
   display: {
     theme: MarkdownTheme
@@ -364,7 +366,11 @@ export function getConfigTemplate (): ConfigOptions {
           { key: '---', value: '—' }
         ],
         matchWholeWords: false // Whether to only autocorrect entire words, not parts
-      } // END autoCorrect options
+      }, // END autoCorrect options
+      keyboardShortcuts: {
+        insertImage: getPlatformSpecificDefaultKeybinding('insertImage'),
+        addFootnote: getPlatformSpecificDefaultKeybinding('addFootnote')
+      }
     },
     display: {
       theme: 'berlin', // The theme, can be berlin|frankfurt|bielefeld|karl-marx-stadt|bordeaux

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -16,7 +16,7 @@ import { app } from 'electron'
 import * as bcp47 from 'bcp-47'
 import { v4 as uuid4 } from 'uuid'
 import getLanguageFile from '@common/util/get-language-file'
-import { getPlatformSpecificDefaultKeybinding, type EditorKeyboardCommand } from '@common/modules/markdown-editor/keymaps/default-map'
+import { getPlatformSpecificDefaultKeybinding, type EditorKeyboardCommand } from '@common/modules/markdown-editor/keymaps/custom-map'
 
 export type MarkdownTheme = 'berlin'|'frankfurt'|'bielefeld'|'karl-marx-stadt'|'bordeaux'
 

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -71,9 +71,9 @@ import { mainOverride } from './theme/main-override'
 import { highlightWhitespace } from './plugins/highlight-whitespace'
 import { tagClasses } from './plugins/tag-classes'
 import { autocompleteTriggerCharacter } from './autocomplete/snippets'
-import { defaultKeymap } from './keymaps/default'
 import { vimPlugin } from './plugins/vim-mode'
 import { projectInfoField } from './plugins/project-info-field'
+import { defaultKeymap } from './keymaps'
 
 /**
  * This interface describes the required properties which the extension sets

--- a/source/common/modules/markdown-editor/keymaps/custom-map.ts
+++ b/source/common/modules/markdown-editor/keymaps/custom-map.ts
@@ -47,6 +47,11 @@ const defaultMap: EditorCommandMap = {
 export type EditorKeyboardCommand = keyof EditorCommandMap
 
 /**
+ * A simple type to pass custom shortcut configurations around the editor.
+ */
+export type CustomShortcutConfiguration = Partial<Record<EditorKeyboardCommand, string>>
+
+/**
  * Returns the platform-specific shortcut defined for the provided command,
  * based on the runtime-determined platform (via `process.platform`). Returns
  * undefined if the command has no keyboard binding for this platform defined.

--- a/source/common/modules/markdown-editor/keymaps/default-map.ts
+++ b/source/common/modules/markdown-editor/keymaps/default-map.ts
@@ -1,0 +1,75 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        CodeMirror default key bindings
+ * CVM-Role:        Utility
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This file contains the default key bindings for the editor,
+ *                  alongside a few utilities that help accessing this.
+ *
+ * END HEADER
+ */
+
+/**
+ * A ShortcutBinding conforms essentially to the same API as the CodeMirror
+ * keybindings, sans the actual `run` properties.
+ */
+interface ShortcutBinding {
+  key?: string
+  mac?: string
+  linux?: string
+  win?: string
+}
+
+/**
+ * These are the editor commands that can be remapped
+ */
+interface EditorCommandMap {
+  insertImage: ShortcutBinding
+  addFootnote: ShortcutBinding
+}
+
+/**
+ * These are the default key bindings (which were previously stored in the
+ * actual key map)
+ */
+const defaultMap: EditorCommandMap = {
+  insertImage: { key: 'Mod-Alt-i', mac: 'Mod-Shift-i' },
+  addFootnote: { key: 'Mod-Alt-f', mac: 'Mod-Alt-r' }
+} as const
+
+/**
+ * Allows typing correlated types with the proper available commands.
+ */
+export type EditorKeyboardCommand = keyof EditorCommandMap
+
+/**
+ * Returns the platform-specific shortcut defined for the provided command,
+ * based on the runtime-determined platform (via `process.platform`). Returns
+ * undefined if the command has no keyboard binding for this platform defined.
+ *
+ * @param   {keyof typeof defaultMap}  command  The command to return the keybinding for
+ *
+ * @return  {string}                            The keybinding.
+ *
+ * @throws When a keyboard shortcut does not define a generic `key` property or
+ * the platform does not have a specific keybinding.
+ */
+export function getPlatformSpecificDefaultKeybinding (command: EditorKeyboardCommand): string {
+  const cmd = defaultMap[command]
+  
+  if (process.platform === 'darwin' && cmd.mac !== undefined) {
+    return cmd.mac
+  } else if (process.platform === 'win32' && cmd.win !== undefined) {
+    return cmd.win
+  } else if (process.platform === 'linux' && cmd.linux !== undefined) {
+    return cmd.linux
+  } else if (cmd.key !== undefined) {
+    return cmd.key
+  } else {
+    throw new Error(`Missing keyboard shortcut for command ${command} on platform ${process.platform}`)
+  }
+}

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -61,14 +61,14 @@ import {
   insertLink, insertImage, applyBold, applyItalic, applyComment, applyTaskList
 } from '../commands/markdown'
 import { pasteAsPlain, copyAsHTML } from '../util/copy-paste-cut'
-import { getPlatformSpecificDefaultKeybinding, type EditorKeyboardCommand } from './default-map'
+import { type CustomShortcutConfiguration, getPlatformSpecificDefaultKeybinding } from './custom-map'
 
 // Includes:
 // * defaultKeymap
 // * historyKeymap
 // * closeBracketsKeymap
 // * searchKeymap
-export function defaultKeymap (customKeymap?: Record<EditorKeyboardCommand, string>): Extension {
+export function generateDefaultKeymap (customKeymap?: CustomShortcutConfiguration): Extension {
   return keymap.of([
     // completionKeymap
     { key: 'Ctrl-Space', run: startCompletion },

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -61,13 +61,14 @@ import {
   insertLink, insertImage, applyBold, applyItalic, applyComment, applyTaskList
 } from '../commands/markdown'
 import { pasteAsPlain, copyAsHTML } from '../util/copy-paste-cut'
+import { getPlatformSpecificDefaultKeybinding, type EditorKeyboardCommand } from './default-map'
 
 // Includes:
 // * defaultKeymap
 // * historyKeymap
 // * closeBracketsKeymap
 // * searchKeymap
-export function defaultKeymap (): Extension {
+export function defaultKeymap (customKeymap?: Record<EditorKeyboardCommand, string>): Extension {
   return keymap.of([
     // completionKeymap
     { key: 'Ctrl-Space', run: startCompletion },
@@ -86,9 +87,9 @@ export function defaultKeymap (): Extension {
     { key: 'Mod-k', run: insertLink },
     // NOTE: We have to do it like this, because the Mod-Shift-i is occupied on
     // Windows/Linux by the DevTools shortcut, and Mod-Alt-i is the same for Mac.
-    { key: 'Mod-Alt-i', mac: 'Mod-Shift-i', run: insertImage },
+    { key: customKeymap?.insertImage ?? getPlatformSpecificDefaultKeybinding('insertImage'), run: insertImage },
     { key: 'Mod-C', run: applyComment },
-    { key: 'Mod-Alt-f', mac: 'Mod-Alt-r', run: addNewFootnote },
+    { key: customKeymap?.addFootnote ?? getPlatformSpecificDefaultKeybinding('addFootnote'), run: addNewFootnote },
 
     // Overload Tab, depending on context (priority high->low)
     { key: 'Tab', run: acceptCompletion },

--- a/source/common/modules/markdown-editor/keymaps/index.ts
+++ b/source/common/modules/markdown-editor/keymaps/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        defaultKeymap
+ * CVM-Role:        CodeMirror Extension
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This file contains extensions and configuration to enable
+ *                  the use of custom keyboard shortcuts for CodeMirror. It
+ *                  contains a transaction extender that checks every
+ *                  transaction for a shortcutUpdateEffect and regenerates the
+ *                  default keymap based off this. Whenever the user changes the
+ *                  keyboard bindings, this will update the keymap so that the
+ *                  new shortcuts apply.
+ *
+ * END HEADER
+ */
+
+import { Compartment, EditorState, type Extension, StateEffect } from '@codemirror/state'
+import { type CustomShortcutConfiguration } from './custom-map'
+import { generateDefaultKeymap } from './default'
+
+/**
+ * State effect used to override the custom keyboard command map. Provide this
+ * with a (partial) map of editor keyboard commands to keyboard shortcuts.
+ */
+export const shortcutUpdateEffect = StateEffect.define<CustomShortcutConfiguration>()
+
+const keymapCompartment = new Compartment
+
+const shortcutReconfiguration = EditorState.transactionExtender.of(tr => {
+  const newEffects = []
+  for (const effect of tr.effects) {
+    if (effect.is(shortcutUpdateEffect)) {
+      newEffects.push(
+        keymapCompartment.reconfigure(generateDefaultKeymap(effect.value))
+      )
+    }
+  }
+  return { effects: newEffects }
+})
+
+export function defaultKeymap (customKeymap?: CustomShortcutConfiguration): Extension {
+  return [
+    shortcutReconfiguration,
+    keymapCompartment.of(generateDefaultKeymap(customKeymap))
+  ]
+}

--- a/source/common/vue/CodeEditor.vue
+++ b/source/common/vue/CodeEditor.vue
@@ -42,7 +42,7 @@ import { plainLinkHighlighter } from '@common/modules/markdown-utils/plain-link-
 import { useConfigStore } from 'source/pinia'
 import { darkMode, darkModeEffect } from '../modules/markdown-editor/theme/dark-mode'
 import { highlightWhitespace, highlightWhitespaceEffect } from '../modules/markdown-editor/plugins/highlight-whitespace'
-import { defaultKeymap } from '../modules/markdown-editor/keymaps/default'
+import { defaultKeymap, shortcutUpdateEffect } from '../modules/markdown-editor/keymaps'
 
 const configStore = useConfigStore()
 
@@ -62,7 +62,7 @@ const cleanFlag = ref<boolean>(true)
 
 function getExtensions (mode: 'css'|'yaml'|'markdown-snippets'): Extension[] {
   const extensions = [
-    defaultKeymap(),
+    defaultKeymap(configStore.customShortcuts),
     search({ top: true }),
     codeFolding(),
     foldGutter(),
@@ -141,12 +141,13 @@ const props = defineProps<Props>()
 
 const emit = defineEmits<(e: 'update:modelValue', newContents: string) => void>()
 
-// Switch the darkMode variable in the editor based on the config
+// Switch compartments via effects whenever the config updates
 configStore.$subscribe((_mutation, state) => {
   cmInstance.dispatch({
     effects: [
       darkModeEffect.of({ darkMode: state.config.darkMode }),
-      highlightWhitespaceEffect.of(state.config.editor.showWhitespace)
+      highlightWhitespaceEffect.of(state.config.editor.showWhitespace),
+      shortcutUpdateEffect.of(state.config.editor.keyboardShortcuts)
     ]
   })
 })

--- a/source/common/vue/form/FormBuilder.vue
+++ b/source/common/vue/form/FormBuilder.vue
@@ -221,6 +221,14 @@ interface SliderField extends BasicInfo {
   max?: number
 }
 
+interface ShortcutField extends BasicInfo {
+  type: 'shortcut'
+  placeholder?: string
+  reset?: string|boolean
+  info?: string
+  disabled?: boolean
+}
+
 interface ThemeField extends BasicInfo {
   type: 'theme'
   options: Record<string, ThemeDescriptor>
@@ -231,7 +239,7 @@ interface ThemeField extends BasicInfo {
  */
 export type FormField = Separator|FormText|FormButton|TextField|NumberField|
 TimeField|ColorField|FileField|CheckboxField|RadioField|SelectField|ListField|
-TokenField|SliderField|ThemeField
+TokenField|SliderField|ShortcutField|ThemeField
 
 /**
  * Fields that can only occur within the title area of a fieldset
@@ -328,6 +336,7 @@ function getModelValue (model: string): any {
         font-weight: bolder;
         font-size: 15px;
         margin-top: 2px;
+        margin-bottom: 4px;
         padding: 0;
       }
 

--- a/source/common/vue/form/FormField.vue
+++ b/source/common/vue/form/FormField.vue
@@ -142,6 +142,18 @@
     v-bind:name="props.field.model"
     v-on:update:model-value="emit('update:modelValue', $event)"
   ></SliderInput>
+  <ShortcutCaptureControl
+    v-else-if="props.field.type === 'shortcut'"
+    v-bind:disabled="props.field.disabled"
+    v-bind:placeholder="props.field.placeholder"
+    v-bind:label="props.field.label"
+    v-bind:name="props.field.model"
+    v-bind:reset="props.field.reset"
+    v-bind:info="props.field.info"
+    v-bind:inline="props.field.inline"
+    v-bind:model-value="model"
+    v-on:update:model-value="emit('update:modelValue', $event)"
+  ></ShortcutCaptureControl>
   <ThemeInput
     v-else-if="props.field.type === 'theme'"
     v-bind:model-value="model"
@@ -168,6 +180,7 @@ import SliderInput from './elements/SliderControl.vue'
 import ListControl from './elements/ListControl.vue'
 import TokenInput from './elements/TokenList.vue'
 import ThemeInput from './elements/ThemeSelector.vue'
+import ShortcutCaptureControl from './elements/ShortcutCaptureControl.vue'
 
 /**
  * @ignore

--- a/source/common/vue/form/elements/ShortcutCaptureControl.vue
+++ b/source/common/vue/form/elements/ShortcutCaptureControl.vue
@@ -1,12 +1,36 @@
 <template>
-  <input
-    ref="inputElement"
-    v-model="shortcut"
-    type="text"
-    v-bind:placeholder="placeholderLabel"
-    v-on:keydown.prevent.stop="handleKeydown"
-    v-on:focus="handleFocus"
+  <div
+    v-bind:class="{ inline: props.inline, 'form-control': true, 'shortcut-line': true }"
   >
+    <label v-if="label" v-bind:for="fieldID" v-html="label"></label>
+    <div
+      v-bind:class="{
+        'input-text-button-group': true,
+        'has-reset': reset !== undefined
+      }"
+      style="display: inline-grid"
+    >
+      <input
+        ref="inputElement"
+        v-model="shortcut"
+        type="text"
+        v-bind:placeholder="placeholderLabel"
+        v-on:keydown.prevent.stop="handleKeydown"
+        v-on:focus="handleFocus"
+        v-on:blur="handleBlur"
+      >
+      <button
+        v-if="reset !== undefined"
+        type="button"
+        class="input-reset-button"
+        v-bind:title="resetLabel"
+        v-on:click.prevent="typeof reset === 'boolean' ? model = '' : model = reset"
+      >
+        <cds-icon shape="times"></cds-icon>
+      </button>
+    </div>
+    <p v-if="props.info !== undefined" class="info" v-html="props.info"></p>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -25,18 +49,37 @@
  * END HEADER
  */
 import { trans } from 'source/common/i18n-renderer'
-import { ref } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { keyName } from 'w3c-keyname'
+
+const props = defineProps<{
+  disabled?: boolean
+  placeholder?: string
+  label?: string
+  name?: string
+  reset?: string|boolean
+  inline?: boolean
+  info?: string
+}>()
 
 const model = defineModel<string>()
 
-const placeholderLabel = trans('Click to set your shortcut')
+watch(model, () => { shortcut.value = model.value ?? '' })
 
-const shortcut = ref(model.value)
+const placeholderLabel = trans('Click to set your shortcut')
+const resetLabel = trans('Reset')
+
+const shortcut = ref<string>(model.value ?? '')
 const inputElement = ref<HTMLInputElement|null>(null)
+
+const fieldID = computed<string>(() => 'field-input-' + (props.name ?? ''))
 
 function handleFocus (event: FocusEvent) {
   shortcut.value = ''
+}
+
+function handleBlur (event: FocusEvent) {
+  shortcut.value = model.value ?? ''
 }
 
 function handleKeydown (event: KeyboardEvent): void {
@@ -76,4 +119,9 @@ function handleKeydown (event: KeyboardEvent): void {
 </script>
 
 <style lang="css" scoped>
+.shortcut-line {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 50% 50%;
+}
 </style>

--- a/source/pinia/config.ts
+++ b/source/pinia/config.ts
@@ -14,7 +14,7 @@
 
 import { type ConfigOptions } from '@providers/config/get-config-template'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import _ from 'underscore'
 
 const ipcRenderer = window.ipc
@@ -30,6 +30,7 @@ function retrieveConfig (): ConfigOptions {
 
 export const useConfigStore = defineStore('config', () => {
   const config = ref<ConfigOptions>(retrieveConfig())
+  const customShortcuts = computed(() => config.value.editor.keyboardShortcuts)
 
   // Throttle the retrieve function to once a second. We want the config to
   // update some values extremely frequently, and with the throttle in place, we
@@ -52,5 +53,5 @@ export const useConfigStore = defineStore('config', () => {
     })
   }
 
-  return { config, setConfigValue }
+  return { config, customShortcuts, setConfigValue }
 })

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -49,6 +49,7 @@ import { isAbsolutePath, pathBasename, pathDirname, resolvePath } from '@common/
 import type { DocumentManagerIPCAPI, DocumentsUpdateContext } from 'source/app/service-providers/documents'
 import type { CiteprocProviderIPCAPI } from 'source/app/service-providers/citeproc'
 import type { ProjectInfo } from 'source/common/modules/markdown-editor/plugins/project-info-field'
+import { shortcutUpdateEffect } from 'source/common/modules/markdown-editor/keymaps'
 
 const ipcRenderer = window.ipc
 
@@ -325,6 +326,24 @@ workspacesStore.$subscribe(_mutation => {
   }
 })
 // END: PROJECT INFO
+
+// Update the editor keyboard shortcuts whenever the config changes.
+// TODO: Do this also for various other things. This will break up this insanely
+// large config object into smaller chunks that are more separable. This here is
+// the preferred way of updating the editor config, rather than doing the large
+// config thing, that is merely due to me not fully understanding the CodeMirror
+// API back when I migrated from CM5 to CM6.
+configStore.$subscribe((_mutation, state) => {
+  if (currentEditor === null) {
+    return
+  }
+
+  currentEditor.instance.dispatch({
+    effects: [
+      shortcutUpdateEffect.of(state.config.editor.keyboardShortcuts)
+    ]
+  })
+})
 
 // External commands/"event" system
 watch(toRef(props.editorCommands, 'jumpToLine'), () => {

--- a/source/win-preferences/schema/editor.ts
+++ b/source/win-preferences/schema/editor.ts
@@ -16,6 +16,7 @@ import { trans } from '@common/i18n-renderer'
 import { type PreferencesFieldset } from '../App.vue'
 import { PreferencesGroups } from './_preferences-groups'
 import type { ConfigOptions } from 'source/app/service-providers/config/get-config-template'
+import { getPlatformSpecificDefaultKeybinding } from 'source/common/modules/markdown-editor/keymaps/default-map'
 
 export function getEditorFields (config: ConfigOptions): PreferencesFieldset[] {
   return [
@@ -228,6 +229,27 @@ export function getEditorFields (config: ConfigOptions): PreferencesFieldset[] {
           min: 0,
           max: 100,
           model: 'display.imageHeight'
+        }
+      ]
+    },
+    {
+      title: trans('Keyboard shortcuts'),
+      group: PreferencesGroups.Editor,
+      help: undefined,
+      fields: [
+        {
+          type: 'shortcut',
+          label: trans('Insert Image'),
+          inline: false,
+          model: 'editor.keyboardShortcuts.insertImage',
+          reset: getPlatformSpecificDefaultKeybinding('insertImage')
+        },
+        {
+          type: 'shortcut',
+          label: trans('Add footnote'),
+          inline: false,
+          model: 'editor.keyboardShortcuts.addFootnote',
+          reset: getPlatformSpecificDefaultKeybinding('addFootnote')
         }
       ]
     },

--- a/source/win-preferences/schema/editor.ts
+++ b/source/win-preferences/schema/editor.ts
@@ -16,7 +16,7 @@ import { trans } from '@common/i18n-renderer'
 import { type PreferencesFieldset } from '../App.vue'
 import { PreferencesGroups } from './_preferences-groups'
 import type { ConfigOptions } from 'source/app/service-providers/config/get-config-template'
-import { getPlatformSpecificDefaultKeybinding } from 'source/common/modules/markdown-editor/keymaps/default-map'
+import { getPlatformSpecificDefaultKeybinding } from 'source/common/modules/markdown-editor/keymaps/custom-map'
 
 export function getEditorFields (config: ConfigOptions): PreferencesFieldset[] {
   return [


### PR DESCRIPTION
## Description

This PR adds support for custom keyboard shortcuts for the editor of Zettlr. This allows users to customize which keyboard shortcuts do what in the editor. Users can mitigate three specific issues with this:

1. The default keybindings are uncommon, and they would like to remap them to more convenient shortcuts to retain their muscle memory from other apps.
2. The default keybindings do not work on the user's keyboard layout. The custom shortcut input essentially records the new shortcut based on the platform specific keyboard layout, making it easier to find shortcuts that actually work.
3. The default keybindings are uncomfortable for their specific keyboard (hardware or layout; think ortholinear or Dvorak).

## Changes

This PR makes the following changes:

1. Add a new preference key for custom keyboard shortcuts in the config.
2. Remove specific keyboard shortcuts and replace them with dynamic keyboard assignments in the default keymap.
3. Add a new control to record shortcuts, utilizing the CodeMirror-specific libraries to mimic its behavior as closely as possible.
4. As a proof of concept, "dynamicize" two key bindings, for adding images and adding footnotes.

## Additional information

There are still a few todos and caveats:

1. [ ] The preference shortcuts are not yet passed into the keymap constructor.
2. [ ] The keymaps cannot be dynamically updated yet.
3. [ ] We need to reach a consensus as to which commands should be customizable. I don't believe we should customize, e.g., arrow key movement.

***

- fixes #818

<!-- Please provide any testing system -->
Tested on: macOS Sequoia 15.4.1
