### PR TITLE
fix: Fixes #5493. Modified asterisk remains when file is closed and opened

### DIFF
--- a/source/pinia/document-tree-store.ts
+++ b/source/pinia/document-tree-store.ts
@@ -200,6 +200,12 @@ export const useDocumentTreeStore = defineStore('document-tree', () => {
             case DP_EVENTS.CHANGE_FILE_STATUS:
             case DP_EVENTS.OPEN_FILE:
             case DP_EVENTS.CLOSE_FILE:
+              copyDelta(paneData, treedata, context)
+              // Immediately clear out any closed file from the “modified” list
+              ipcRenderer.invoke('documents-provider', { command: 'get-file-modification-status' })
+                .then((modifiedFiles: string[]) => { modifiedDocuments.value = modifiedFiles })
+                .catch(err => console.error(err))
+              break
             case DP_EVENTS.FILES_SORTED:
               copyDelta(paneData, treedata, context)
               break


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Fixes #5493
Fixes the bug that keeps a file updated asterisk in the document tabs even after the file is closed and the changes are removed. 
## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Added to the case case DP_EVENTS.CLOSE_FILE to ensure the modifiedDocuments.value is cleared on close. 
## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
Tested on: EndevaourOS 2024.06.25 