### PR TITLE
feat: add Insert footnote context menu item and handler

### DIFF
--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -21,6 +21,10 @@ import { type SyntaxNode } from '@lezer/common'
 import { forEachDiagnostic, type Diagnostic, forceLinting, setDiagnostics } from '@codemirror/lint'
 import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList } from '../commands/markdown'
 import { cut, copyAsPlain, copyAsHTML, paste, pasteAsPlain } from '../util/copy-paste-cut'
+// import { addNewFootnote } from '..'
+
+
+
 
 const ipcRenderer = window.ipc
 const suggestionCache = new Map<string, string[]>()
@@ -173,6 +177,12 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       enabled: true
     },
     {
+      label: trans('Insert footnote'),
+      id: 'markdownInsertFootnote',
+      type: 'normal',
+      enabled: true
+    },
+    {
       label: trans('Insert unordered list'),
       id: 'markdownMakeUnorderedList',
       type: 'normal',
@@ -258,7 +268,7 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
     tpl.unshift(...suggestionItems)
   }
 
-  showPopupMenu(coords, tpl, (clickedID) => {
+  showPopupMenu(coords, tpl, async (clickedID) => {
     if (clickedID === 'markdownBold') {
       applyBold(view)
     } else if (clickedID === 'markdownItalic') {
@@ -275,7 +285,10 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       applyBlockquote(view)
     } else if (clickedID === 'markdownInsertTable') {
       // TODO
-    } else if (clickedID === 'cut') {
+    }else if (clickedID === 'markdownInsertFootnote') {
+      const { addNewFootnote } = await import('../commands/footnotes')
+      addNewFootnote(view)
+    }else if (clickedID === 'cut') {
       cut(view)
     } else if (clickedID === 'copy') {
       copyAsPlain(view)

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -840,3 +840,7 @@ export default class MarkdownEditor extends EventEmitter {
     return this.representedDocument
   }
 }
+
+
+
+


### PR DESCRIPTION
This PR introduces a new context menu item for the Markdown editor: “Insert footnote”.

New Features:
- Adds `Insert footnote` to the context menu in `default-menu.ts`
- Handles `markdownInsertFootnote` ID with logic invoking `addNewFootnote(view)`

Tested and working successfully.

Closes #5745