### PR TITLE
feat: Show more information in the Pomodoro timer.

### DIFF
--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -915,28 +915,28 @@ function pomodoroTick (): void {
   // Progresses the pomodoro counter by one second
   pomodoro.value.phase.elapsed += 1
 
-  if (pomodoro.value.phase.type === 'task') {
-    pomodoro.value.totalTasks += 1 //Increment only for task phases
-  }
-
-  const totalPhases =
-    pomodoro.value.counter.task +
-    pomodoro.value.counter.short +
-    pomodoro.value.counter.long
-
-  if (totalPhases >= 8) {
-    // Reset counters to restart a fresh cycle
-    pomodoro.value.counter.task = 0
-    pomodoro.value.counter.short = 0
-    pomodoro.value.counter.long = 0
-  }
-
   const currentPhaseDur = pomodoro.value.durations[pomodoro.value.phase.type]
   const phaseIsFinished = pomodoro.value.phase.elapsed === currentPhaseDur
 
   if (phaseIsFinished) {
     pomodoro.value.phase.elapsed = 0
     pomodoro.value.counter[pomodoro.value.phase.type] += 1
+
+    if (pomodoro.value.phase.type === 'task') {
+      pomodoro.value.totalTasks += 1 //Increment only for task phases
+    }
+
+    const totalPhases =
+    pomodoro.value.counter.task +
+    pomodoro.value.counter.short +
+    pomodoro.value.counter.long
+
+    if (totalPhases >= 8) {
+    // Reset counters to restart a fresh cycle
+      pomodoro.value.counter.task = 0
+      pomodoro.value.counter.short = 0
+      pomodoro.value.counter.long = 0
+    }
 
     if (pomodoro.value.phase.type === 'task' && pomodoro.value.counter.task % 4 === 0) {
       pomodoro.value.phase.type = 'long'

--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -243,6 +243,7 @@ export interface PomodoroConfig {
     short: number
     long: number
   }
+  totalTasks: number
   colour: {
     task: string
     short: string
@@ -258,6 +259,7 @@ const pomodoro = ref<PomodoroConfig>({
   durations: { task: 1500, short: 300, long: 1200 },
   phase: { type: 'task', elapsed: 0 },
   counter: { task: 0, short: 0, long: 0 },
+  totalTasks: 0,
   colour: { task: '#ff3366', short: '#ddff00', long: '#33ffcc' }
 })
 
@@ -912,6 +914,22 @@ function startPomodoro (): void {
 function pomodoroTick (): void {
   // Progresses the pomodoro counter by one second
   pomodoro.value.phase.elapsed += 1
+
+  if (pomodoro.value.phase.type === 'task') {
+    pomodoro.value.totalTasks += 1 //Increment only for task phases
+  }
+
+  const totalPhases =
+    pomodoro.value.counter.task +
+    pomodoro.value.counter.short +
+    pomodoro.value.counter.long
+
+  if (totalPhases >= 8) {
+    // Reset counters to restart a fresh cycle
+    pomodoro.value.counter.task = 0
+    pomodoro.value.counter.short = 0
+    pomodoro.value.counter.long = 0
+  }
 
   const currentPhaseDur = pomodoro.value.durations[pomodoro.value.phase.type]
   const phaseIsFinished = pomodoro.value.phase.elapsed === currentPhaseDur

--- a/source/win-main/PopoverPomodoro.vue
+++ b/source/win-main/PopoverPomodoro.vue
@@ -1,12 +1,31 @@
 <template>
   <PopoverWrapper v-bind:target="target" v-on:close="$emit('close')">
     <template v-if="isRunning">
+      <!--Display pomodoro timer progress-->
+      <div class="pomodoro-progress">
+        <span
+          v-for="(phase, index) in cycle"
+          v-bind:key="index"
+          v-bind:title="phaseTitles[phase as keyof typeof phaseTitles]"
+          class="phase-indicator"
+          v-bind:class="{
+            completed: index < currentCycleIndex,
+            task: phase === 'task',
+            short: phase === 'short',
+            long: phase === 'long'
+          }"
+        />
+      </div>
+
       <!-- Display running time -->
       <p class="pomodoro-big">
         {{ remainingTimeFormatted }}
       </p>
       <p class="pomodoro-big">
         {{ currentPhaseLabel }}
+      </p>
+      <p class="pomodoro-info">
+        Total work sessions completed: {{ props.pomodoro.totalTasks }}
       </p>
       <hr>
       <button v-on:click="stopPomodoro">
@@ -139,6 +158,21 @@ const currentPhaseLabel = computed(() => {
   }
 })
 
+// Pomodoro progress display
+const cycle = [ 'task', 'short', 'task', 'short', 'task', 'short', 'task', 'long' ]
+const currentCycleIndex = computed(() => {
+  const count = props.pomodoro.counter
+  const progress = count.task + count.short + count.long
+  return Math.min(progress, cycle.length)
+})
+  
+const phaseTitles: Record<'task' | 'short' | 'long', string> = {
+  task: 'Work Session',
+  short: 'Short Break',
+  long: 'Long Break'
+}
+
+
 watch(internalTaskDuration, updateConfig)
 watch(internalShortDuration, updateConfig)
 watch(internalLongDuration, updateConfig)
@@ -176,5 +210,43 @@ p.pomodoro-big {
   font-size: 200%;
   text-align: center;
   margin: 10px;
+}
+
+.pomodoro-progress {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+  gap: 6px;
+}
+  
+.phase-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  border: 1px solid #555; 
+  box-sizing: border-box;
+}
+
+//Incomplete phase colours 
+.phase-indicator.task {
+  background-color: #f8d7da;
+}
+.phase-indicator.short {
+  background-color: #d4edda;
+}
+.phase-indicator.long {
+  background-color: #d1ecf1;
+}
+  
+//Completed phase colours
+.phase-indicator.completed.task {
+  background-color: #e74c3c;
+}
+.phase-indicator.completed.short {
+  background-color: #2ecc71;
+}
+.phase-indicator.completed.long {
+  background-color: #3498db;
 }
 </style>


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Closes #5668 
This PR adds a visual indicator of the user's progress through the cycle in the pomodoro timer popover. It also displays the number of work sessions a user has completed.

## Changes
In the PopoverPomodoro.vue file, I modified the 'v-if="isRunning"' block to include a visual pomodoro cycle tracker using coloured dots for each phase. The coloured dots remain muted until completed. I've also added a line showing the total number of work sessions. 
In the App.vue file, I added a new 'totalTasks' field to the 'pomodoro' object to track cumulative work sessions. I've also modified the 'pomodoroTick()' to increment 'totalTasks' and reset 'counter' after a full 8-phase Pomodoro cycle. 

<!-- Please provide any testing system -->
Tested on: Ubuntu 24.04.1 LTS (noble) via WSL2 on Windows 11
Tested and working successfully.
