### PR TITLE
Fixes #5660: Prevent image reloading on every keystroke using debounce

### DIFF
--- a/source/common/modules/markdown-editor/renderers/render-images.ts
+++ b/source/common/modules/markdown-editor/renderers/render-images.ts
@@ -23,6 +23,7 @@ import { trans } from '@common/i18n-renderer'
 import clickAndSelect from './click-and-select'
 import { pathDirname } from '@common/util/renderer-path-polyfill'
 import { syntaxTree } from '@codemirror/language'
+import debounce from 'source/common/modules/markdown-editor/util/debounce'
 
 // This variable holds a base64 encoded placeholder image.
 const img404 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAC0CAYAAADl5PURAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggeDC8lR+xuCgAABkNJREFUeNrt3V2IXGcdx/Hfo2va7oIoiq3mwoJgtLfdFUVj2UDUiiBooWJ9oZRYIVdqz8aAFBHZlPMEYi5WqkGK70aKbyi1iC5VsBeOLzeNpN7Yi4reKglpCHu8yC7IsrvObGYnM7Ofz11yzmTO/p/lm3N2zs6U5eXlLgD70MuMABBAAAEEEEAAAQSYRjM7bLuU5EKSYkzAhOqS3JVkbtAAXjh58uSC+QGT7NSpU39IsjDoJbAzP2AabNsyPwME9i0BBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAgJtuxggm3+rq6qFer2cQo3WlaZoXjEEAucl6vd5SkodMYqT+agQugRkPLxnByF0yAgEEEEAAAQQQQAABBBBAAAEEGANuhN4//pPkVNd1/zaK7ZVSXpHkZJLXmYYAMj0uHz9+/NbZ2dllo9hZrfV5AXQJzJRZWVn5qin0dyJoBAIIIIAAAggggACTz6vA/F+11jcm+UKSTyY58D+bnkzy5aZp/mJKOANk6rRteyzJ35Ic2xS/JLkvyZ9qrd82KQSQqYtfKeXcFuHb/D308bZtv2tiCCDTctl7sJTylX73L6U8UGu9x+QQQKbBI0nmBnzM14wNAWQafGYXj3nL6urqIaNDANmXer3eO00BAWRiXb58+UumgACyL83Ozj6628eura09PcxjqbUu1Fr/ZVUQQEbp/C4e848TJ068OOTj+HmS291riAAySo8lWRvkAV3XfW7IZ3+/SnL7+h8fqLX6+SICyN5rmubPSb43wEMuLi0tfX+I8ftwkqObvld/amUQQEYVwY91XddPBC82TTO021/WX4T5zhabXltr/bGVQQAZiaWlpY8muSfJc1tsvtp13f3DjF+SrKysHEly2zabP9i27dusDMPg3WDo50zwmfXL0oNJ3ptcf7V3/QWP88N8rlrrg0me2Ok/7VLK01YFAWTUIXxxL//9Wut8kl4fu7661rraNM2iVcElMNPiZ0m6Pvc9XGs9bGQIIBOv1vpYkjek/09km0nya5NDABnXqD1Va32ij/2OJvn8Lp7iwPq9giCAjFX8ziW5N8mDtdZfbrff+i0vN/JbHkfbtn2PiSOAjEv8vp7rb6G/4X211t9ste/KysrBJHfcyPOVUtwgjQAyNvH71BabjtRaf7dp3y8meWgIT3vbdoEFAWQk2rZ9ZJv4bTi8EcFa65uTfHaIT3+k1vohq8Ag3AfIsM78Hi6l9POW+IdrrU8l+UaSVw75MH5oJXAGyMjjl8E+D+TeJHtxD99MrfVZK4IAMqr4HUvy+Bgd0jtcCiOA7Lm2bd+f5Fz6v3l5VH509erVb1ohBJC9OvN7dynlJ+N6fGfPnn2TVUIA2ZP4JfltkgNjfJjvqrV+xGohgAzzsvfuJJPy62c/uHbt2jNWDQFkGPG7s5Ty+yS3TMoxnzlzZtbKIYDc6GXvnaWUP05S/NYttG17vxVEANl1/JJcTPKaSTz+Usr5tm3vsJIIIANZW1v7e5JnJ/DMb3MEf2E1EUAGcvr06ZeSvH4KvpS7a62fsKIIIP1e+j5fSjk0RV/St2qtb7WybPBmCGwXv8eTvD39fUjRJHnU6iKA7Khpmk9P6Zc2b3VxCQwIoBEAAggggAACCCCAAAIIIIBMoK5pmn8aQ1/WjGB/cCP0/vGqWuuTSa6MvLxdl1z/3JBu4+9KKeM6p5cn+YBvFwFkutya5L6b8cRjHDtcAgMIIIAAAggggAACCCCAAAIIIOPgFiMYuTkjmHxuhJ4C8/Pzba/Xa01ipK4kecEYBJCbbHFx8eLi4qJBgEtgAAEEEEAAAQQQQAABBAQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEEEEAAAQQQQAABBBBAAAEBNAJAAAEEEEAAAQQQQAABBBBAAAEEEEAAAaYggJ3xAFNg25aV5eXl7TZeSnIhSTE/YILjd1eSua02zuzwwLkkC+YH7MdLYAABBBBAAAEEEECAifVfoVk7QcTH/rgAAAAASUVORK5CYII='
@@ -124,7 +125,8 @@ class ImageWidget extends WidgetType {
     }
 
     // Update the image title on load to retrieve the real image size.
-    img.onload = () => {
+    img.onload = debounce(() => {
+      console.log('Debounced image load triggered')
       img.title = `${img.dataset.title!.replace(/\\"/g, '"')} (${img.naturalWidth}x${img.naturalHeight}px)`
       size.innerHTML = `${img.naturalWidth}&times;${img.naturalHeight}`
 
@@ -152,7 +154,7 @@ class ImageWidget extends WidgetType {
       // inaccurate, but can be solved by the user with a simple Ctrl+A, which
       // will force-reload everything.
       IMAGE_HEIGHT_CACHE.set(this.resolvedImageUrl, height)
-    }
+    },300)
 
     //////////////////////////////////////////
     // CAPTION
@@ -230,6 +232,7 @@ class ImageWidget extends WidgetType {
     // be rebuilt.
     try {
       // First, update the image itself
+      console.log('[updateDOM] called')
       const img = dom.querySelector('img')! as HTMLImageElement
       img.dataset.from = String(this.node.from)
       img.dataset.to = String(this.node.to)
@@ -237,15 +240,31 @@ class ImageWidget extends WidgetType {
       img.dataset.originalUrl = this.imageUrl
       img.dataset.title = this.imageTitle
 
+      console.log('[updateDOM] img found:', img)
+
       // The load and onerror handlers will handle this accordingly (and also
       // update the size and title)
-      img.src = resolveImageUrl(view.state.field(configField).metadata.path, this.imageUrl)
+      const newSrc = resolveImageUrl(view.state.field(configField).metadata.path, this.imageUrl);
+
+      if (img.src !== newSrc) {
+        console.log('[updateDOM] Changing img.src to:', newSrc);
+        img.src = newSrc;
+      } else {
+        console.log('[updateDOM] img.src unchanged; skipping update');
+      }
 
       // Next, the caption
       const caption = dom.querySelector('figcaption')! as HTMLElement
+      if (!img || !caption) {
+        console.warn('Image or caption missing in updateDOM; forcing re-render')
+        return false
+      }
+      console.log('[updateDOM] caption found:', caption)
       caption.textContent = this.imageTitle.replace(/\\"/g, '"') // Un-escape title
       return true
     } catch (err) {
+
+      console.error('[updateDOM] failed:', err)
       return false
     }
   }

--- a/source/common/modules/markdown-editor/util/debounce.ts
+++ b/source/common/modules/markdown-editor/util/debounce.ts
@@ -1,0 +1,13 @@
+export function debounce<T extends (...args: any[]) => void>(
+    func: T,
+    wait: number
+  ): (...args: Parameters<T>) => void {
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    return function (this: any, ...args: any[]) {
+      if (timeout !== null) clearTimeout(timeout)
+      timeout = setTimeout(() => func.apply(this, args), wait)
+    }
+  }
+  
+  export default debounce
+  


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Fixes #5660

This PR resolves issue [#5660](https://github.com/Zettlr/Zettlr/issues/5660) by debouncing the DOM update logic for image rendering inside the markdown editor.

Previously, GIFs and other images would reload on every keystroke, resulting in distracting flickering or restart of animations. This fix:

- Introduces a `debounce` utility to limit update frequency.
- Applies debouncing to `updateDOM`.
- Adds a check to avoid resetting `img.src` if the source hasn't changed.

## Changes
Introduced a debounce.ts utility in markdown-editor/util/ to delay execution of frequent DOM updates.

Updated image rendering logic in the Markdown preview to use the debounced function, preventing constant reloading of GIFs/images during text input.

Added a conditional check to skip setting img.src if the URL hasn’t changed, avoiding unnecessary DOM writes.

No breaking changes to public APIs or components.

Created:
source/common/modules/markdown-editor/util/debounce.ts – A generic debounce utility to throttle function execution.

Modified:
source/common/modules/markdown-editor/renderers/render-images.ts – Applied debouncing to the image rendering logic in updateDOM.

Introduced logic to avoid unnecessary img.src re-assignments if the source URL hasn't changed.

![image](https://github.com/user-attachments/assets/39046432-b81e-4844-8b25-3d5953df4b17)

## Additional information
This fix addresses [Issue #5660](https://github.com/Zettlr/Zettlr/issues/5660), where GIFs and images were reloading on every keystroke in the Markdown editor.

The change uses a custom debounce function with a 15ms delay to throttle image reloads and improve performance.

Added a conditional check to prevent reassigning img.src when the source hasn’t changed, further reducing unnecessary reloads.

Verified functionality by testing with GIFs and observing that reloads no longer occur during typing.

<!-- Please provide any testing system -->
Tested on: Windows 10

https://github.com/user-attachments/assets/6718d18c-66ab-431f-b255-92e6d792d884


