### PR TITLE
Fixes #5641 : Add select/deselect all files toggle in project export settings

### DIFF
--- a/source/win-project-properties/App.vue
+++ b/source/win-project-properties/App.vue
@@ -43,6 +43,10 @@
       <!-- First, the files to be included in the export -->
       <p>{{ exportFilesLabel }}</p>
 
+      <button @click="toggleSelectAllFiles" style="margin-bottom: 10px">
+        {{ toggleSelectAllFilesLabel }}
+      </button>
+
       <div v-if="missingFiles.length > 0" class="export-file-list">
         <ZtrAdmonition>{{ missingFilesMessage }}</ZtrAdmonition>
         <div v-for="file in missingFiles" v-bind:key="file" class="export-file-item">
@@ -193,10 +197,24 @@ const upButtonTitle = trans('Move file up')
 const downButtonTitle = trans('Move file down')
 const noFilesSelectedMessage = trans('You have not selected any files for export.')
 const missingFilesMessage = trans('Some files are selected for export but no longer exist in the directory.')
+const toggleSelectAllFilesLabel = computed(() => {
+  return areAllFilesSelected.value
+    ? trans('Deselect All Files')
+    : trans('Select All Files')
+})
+
 
 const configStore = useConfigStore()
 const useH1 = computed(() => configStore.config.fileNameDisplay.includes('heading'))
 const useTitle = computed(() => configStore.config.fileNameDisplay.includes('title'))
+
+const areAllFilesSelected = computed(() => {
+  const allPaths = availableFiles.value.map(file =>
+    pathToUnix(file.path.slice(dirPath.length + 1))
+  )
+  return allPaths.every(path => projectSettings.value.files.includes(path))
+})
+
 
 const tabs: WindowTab[] = [
   {
@@ -479,6 +497,22 @@ function moveFileUpInExportList (relativeFilePath: string): void {
   projectSettings.value.files.splice(idx, 1)
   projectSettings.value.files.splice(idx - 1, 0, relativeFilePath)
 }
+
+function toggleSelectAllFiles (): void {
+  const allPaths = availableFiles.value.map(file =>
+    pathToUnix(file.path.slice(dirPath.length + 1))
+  )
+
+  if (areAllFilesSelected.value) {
+    // Deselect all
+    projectSettings.value.files = []
+  } else {
+    // Select all
+    projectSettings.value.files = allPaths
+  }
+}
+
+
 </script>
 
 <style lang="less">


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Fixes #5641

This PR introduces a "Select/Deselect All Files" toggle button in the Project Settings → Files panel. The feature allows users to quickly select all available files for export or clear the current selection with a single click. This enhancement addresses the usability challenge described in [Issue #5641](https://github.com/Zettlr/Zettlr/issues/5641)

The toggle intelligently switches between:

Select All: Adds all files from the project directory to the export list.

Deselect All: Clears all files from the export list.

The selection state is determined dynamically, so if all files are already selected, clicking the button will deselect them—and vice versa.

This feature improves the workflow for users managing large Zettlr projects by reducing the manual effort required to configure exports.

## Changes

Added a new "Select/Deselect All Files" button to the Files tab in the Project Settings view (source/win-project-properties/App.vue).

Introduced a toggleSelectAllFiles() method to manage bulk selection and deselection of files.

Added a computed property areAllFilesSelected to determine if all project files are currently selected.

UI dynamically updates the button label between “Select All” and “Deselect All” based on the current selection state.

Ensured no breaking changes to existing file selection logic or project export functionality.

## Additional information
This feature addresses issue [#5641](https://github.com/Zettlr/Zettlr/issues/5641) by allowing users to bulk-select or deselect all project files for export with a single click.
It enhances the user experience when managing large projects with numerous files.
The implementation is backward-compatible and introduces no breaking changes.

<!-- Please provide any testing system -->
Tested on Windows 10 with multiple files and verified proper state updates and UI behavior.


https://github.com/user-attachments/assets/582a416a-e3a3-4512-b5ed-2828f1476913


