### PR TITLE
feat: Show more information in the Pomodoro timer (the circular ring-based solution).

### DIFF
--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -243,6 +243,7 @@ export interface PomodoroConfig {
     short: number
     long: number
   }
+  totalTasks: number
   colour: {
     task: string
     short: string
@@ -258,6 +259,7 @@ const pomodoro = ref<PomodoroConfig>({
   durations: { task: 1500, short: 300, long: 1200 },
   phase: { type: 'task', elapsed: 0 },
   counter: { task: 0, short: 0, long: 0 },
+  totalTasks: 0,
   colour: { task: '#ff3366', short: '#ddff00', long: '#33ffcc' }
 })
 
@@ -919,6 +921,22 @@ function pomodoroTick (): void {
   if (phaseIsFinished) {
     pomodoro.value.phase.elapsed = 0
     pomodoro.value.counter[pomodoro.value.phase.type] += 1
+
+    if (pomodoro.value.phase.type === 'task') {
+      pomodoro.value.totalTasks += 1 //Increment only for task phases
+    }
+
+    const totalPhases =
+    pomodoro.value.counter.task +
+    pomodoro.value.counter.short +
+    pomodoro.value.counter.long
+
+    if (totalPhases >= 8) {
+    // Reset counters to restart a fresh cycle
+      pomodoro.value.counter.task = 0
+      pomodoro.value.counter.short = 0
+      pomodoro.value.counter.long = 0
+    }
 
     if (pomodoro.value.phase.type === 'task' && pomodoro.value.counter.task % 4 === 0) {
       pomodoro.value.phase.type = 'long'

--- a/source/win-main/PopoverPomodoro.vue
+++ b/source/win-main/PopoverPomodoro.vue
@@ -1,17 +1,79 @@
 <template>
   <PopoverWrapper v-bind:target="target" v-on:close="$emit('close')">
     <template v-if="isRunning">
-      <!-- Display running time -->
-      <p class="pomodoro-big">
-        {{ remainingTimeFormatted }}
-      </p>
-      <p class="pomodoro-big">
-        {{ currentPhaseLabel }}
-      </p>
-      <hr>
-      <button v-on:click="stopPomodoro">
-        {{ stopLabel }}
-      </button>
+      <!-- Display pomodoro timer & phase progress -->
+      <div class="pomodoro-visual-wrapper">
+        <svg viewBox="0 0 120 120" class="pomodoro-ring">
+          <!-- Outer Progress Circle (Background) -->
+          <circle
+            class="outer-bg"
+            cx="60" cy="60" r="54"
+            fill="none" stroke="#eee"
+            stroke-width="8"
+          />
+          <!-- Outer Progress Circle (Dynamic Progress) -->
+          <circle
+            class="outer-progress"
+            cx="60" cy="60" r="54"
+            fill="none"
+            stroke="#4caf50"
+            stroke-width="8"
+            stroke-linecap="round"
+            v-bind:stroke-dasharray="circumference"
+            v-bind:stroke-dashoffset="progressOffset"
+            transform="rotate(-90 60 60)"
+          />
+
+          <!-- Inner Segmented Circle -->
+          <g v-for="(phase, index) in cycle" v-bind:key="index">
+            <path
+              v-bind:d="describeArc(60, 60, 40, index * 45, (index + 1) * 45)"
+              v-bind:stroke="index < currentCycleIndex ? segmentColors[phase as 'task' | 'short' | 'long'] : 
+                dimmedSegmentColors[phase as 'task' | 'short' | 'long']"
+              stroke-width="8"
+              fill="none"
+            >
+              <title>{{ phaseTitles[phase as 'task' | 'short' | 'long'] }}</title>
+            </path>
+
+            <circle
+              v-if="index === currentCycleIndex"
+              v-bind:cx="polarToCartesian(60, 60, 44, (index + 0.5) * anglePerSegment).x"
+              v-bind:cy="polarToCartesian(60, 60, 44, (index + 0.5) * anglePerSegment).y"
+              r="3"
+              fill="#000"
+            />
+          </g>
+
+
+          <text
+            x="60"
+            y="65"
+            text-anchor="middle"
+            alignment-baseline="middle"
+            font-size="8"
+            fill="#333"
+          >
+            {{ props.pomodoro.totalTasks }} Work Sessions ✔
+          </text>
+
+        </svg>
+
+        <!-- Display running time -->
+        <p class="pomodoro-big"> 
+          {{ remainingTimeFormatted }}
+        </p>
+        <p class="pomodoro-big"> 
+          {{ currentPhaseLabel }}
+        </p>
+        <p class="pomodoro-info"> 
+          Total work sessions completed: {{ props.pomodoro.totalTasks }}
+        </p>
+        <hr>
+        <button v-on:click="stopPomodoro">
+          {{ stopLabel }}
+        </button>
+      </div>
     </template>
     <template v-else>
       <!-- Display set up -->
@@ -90,6 +152,7 @@ const longLabel = trans('Break')
 const soundEffectsLabel = trans('Sound Effect')
 const volumeLabel = trans('Volume')
 
+
 const props = defineProps<{
   target: HTMLElement
   pomodoro: PomodoroConfig
@@ -139,6 +202,62 @@ const currentPhaseLabel = computed(() => {
   }
 })
 
+// Pomodoro progress display
+const cycle = [ 'task', 'short', 'task', 'short', 'task', 'short', 'task', 'long' ]
+const currentCycleIndex = computed(() => {
+  const count = props.pomodoro.counter
+  const progress = count.task + count.short + count.long
+  return Math.min(progress, cycle.length)
+})
+  
+const anglePerSegment = 360 / cycle.length
+
+const phaseTitles: Record<'task' | 'short' | 'long', string> = {
+  task: 'Work Session',
+  short: 'Short Break',
+  long: 'Long Break'
+}
+
+const circumference = 2 * Math.PI * 54
+const percentage = computed(() => {
+  const elapsed = props.pomodoro.phase.elapsed
+  const total = props.pomodoro.durations[props.pomodoro.phase.type]
+  return (elapsed / total) * 100
+})
+const progressOffset = computed(() => {
+  return circumference * (1 - percentage.value / 100)
+})
+
+// For phase coloring
+const segmentColors: Record<'task' | 'short' | 'long', string> = {
+  task: '#e74c3c',
+  short: '#2ecc71',
+  long: '#3498db'
+}
+
+const dimmedSegmentColors: Record<'task' | 'short' | 'long', string> = {
+  task: '#f8d7da',
+  short: '#d4edda',
+  long: '#d1ecf1'
+}
+
+// Arc helpers
+function polarToCartesian (cx: number, cy: number, r: number, angle: number) {
+  const rad = (angle - 90) * Math.PI / 180.0
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad)
+  }
+}
+
+function describeArc (cx: number, cy: number, r: number, startAngle: number, endAngle: number) {
+  const start = polarToCartesian(cx, cy, r, endAngle)
+  const end = polarToCartesian(cx, cy, r, startAngle)
+  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1'
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`
+}
+
+
 watch(internalTaskDuration, updateConfig)
 watch(internalShortDuration, updateConfig)
 watch(internalLongDuration, updateConfig)
@@ -176,5 +295,56 @@ p.pomodoro-big {
   font-size: 200%;
   text-align: center;
   margin: 10px;
+}
+.pomodoro-progress {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+  gap: 6px;
+}
+.phase-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  border: 1px solid #555; 
+  box-sizing: border-box;
+}
+//Incomplete phase colours 
+.phase-indicator.task {
+  background-color: #f8d7da;
+}
+.phase-indicator.short {
+  background-color: #d4edda;
+}
+.phase-indicator.long {
+  background-color: #d1ecf1;
+}
+//Completed phase colours
+.phase-indicator.completed.task {
+  background-color: #e74c3c;
+}
+.phase-indicator.completed.short {
+  background-color: #2ecc71;
+}
+.phase-indicator.completed.long {
+  background-color: #3498db;
+}
+.pomodoro-visual-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 20px 0;
+}
+.outer-progress {
+  transition: stroke-dashoffset 0.5s ease-in-out;
+}
+.pomodoro-ring {
+  width: 200px;
+  height: 200px;
+  //transform: rotate(90deg);
+}
+.outer-bg {
+  stroke: #ddd;
 }
 </style>


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Closes #5668 
This PR adds the proposed circular solution using two circular rings to display more information in the Pomodoro timer. The outer circle shows the current phase's progression, while the inner circle shows all the phases and an indicator through the entire cycle. The counter at the centre keeps a tally of the work sessions completed so far. 

## Changes
In the PopoverPomodoro.vue file, I modified the PopoverPomodoro.vue file to include and customize and create the SVG circular rings and visualize the progress. The phases in the inner circle remain muted until completed, and tooltips are enabled so that the user can get more information upon hovering. I've also added a text at the centre showing the total number of completed work sessions.

In the App.vue file, I added a new 'totalTasks' field to the 'pomodoro' object to track cumulative work sessions. I've also modified the 'pomodoroTick()' to increment 'totalTasks' and reset 'counter' after a full 8-phase Pomodoro cycle.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: Ubuntu 24.04.1 LTS (noble) via WSL2 on Windows 11
Tested and working successfully.

