### PR TITLE
Feat/transform quotes context menu ,Text transform: Paired quotes to double quotes,Text transform: Paired quotes to double quotes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## GUI and Functionality
 
+
+### Added transform
+- Added new context menu items in the Markdown editor to transform paired and smart quotes:
+  - Convert paired backticks (``) and paired single quotes ('') to double quotes (")
+  - Convert smart double quotes (“”）to plain double quotes (")
+  - Convert smart single quotes (‘’) to plain single quotes (')
+  - Convert all single quotes (') to double quotes (") on demand
+  - Update 'Automate common text transforms. #5659
+  - Update Text transform: Paired quotes to double quotes. #5680
+  - Update Text transform: Straighten quotes. #5675
+
 - **Feature**: The code editors (in the assets manager and elsewhere) now share
   the same keymap as the main editor.
 - **Feature**: The image renderer now acknowledges and respects the presence of

--- a/source/common/modules/markdown-editor/commands/markdown.ts
+++ b/source/common/modules/markdown-editor/commands/markdown.ts
@@ -502,3 +502,62 @@ export function applyTaskList (target: EditorView): boolean {
   applyList(target, 'task')
   return true
 }
+
+export function straightenQuotes(view: EditorView): boolean {
+ 
+  const transaction = view.state.changeByRange(range => {
+    const text = view.state.doc.sliceString(range.from, range.to)
+    const newText = text
+      .replace(/[“”]/g, '"')  
+      .replace(/[‘’]/g, "'")  
+    
+    
+    return {
+      changes: { from: range.from, to: range.to, insert: newText },  
+      range  
+    }
+  })
+
+  
+  view.dispatch(transaction)
+
+  return true
+}
+
+export function convertPairedQuotes(view: EditorView): boolean {
+  const transaction = view.state.changeByRange(range => {
+    const text = view.state.doc.sliceString(range.from, range.to)
+
+    // change `` and '' to " and ' respectively
+    const newText = text
+      .replace(/``/g, '"')   //  → "
+      .replace(/''/g, '"')   //  → "
+      .replace(/[“”]/g, '"') //  → "
+      .replace(/[‘’]/g, "'") //  → '
+
+    return {
+      changes: { from: range.from, to: range.to, insert: newText },
+      range
+    }
+  })
+
+  view.dispatch(transaction)
+  return true
+}
+
+export function convertSingleToDoubleQuotes(view: EditorView): boolean {
+  const transaction = view.state.changeByRange(range => {
+    const text = view.state.doc.sliceString(range.from, range.to)
+
+    // change every ' to "
+    const newText = text.replace(/'/g, '"')
+
+    return {
+      changes: { from: range.from, to: range.to, insert: newText },
+      range
+    }
+  })
+
+  view.dispatch(transaction)
+  return true
+}

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -19,7 +19,7 @@ import showPopupMenu from '@common/modules/window-register/application-menu-help
 import { type AnyMenuItem } from '@dts/renderer/context'
 import { type SyntaxNode } from '@lezer/common'
 import { forEachDiagnostic, type Diagnostic, forceLinting, setDiagnostics } from '@codemirror/lint'
-import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList } from '../commands/markdown'
+import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList,convertPairedQuotes,convertSingleToDoubleQuotes  } from '../commands/markdown'
 import { cut, copyAsPlain, copyAsHTML, paste, pasteAsPlain } from '../util/copy-paste-cut'
 
 const ipcRenderer = window.ipc
@@ -250,7 +250,31 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       id: 'selectAll',
       type: 'normal',
       enabled: true
-    }
+    },
+
+    {
+      label: trans('Transform'),
+      id: 'transformMenu',
+      type: 'submenu',
+      enabled: true,
+    submenu: [
+      {
+        label: trans('Convert paired quotes'),
+        id: 'convertPairedQuotes',
+        type: 'normal',
+        enabled: true
+      },
+      {
+        label: trans('Convert single to double quotes'),
+        id: 'convertSingleToDoubleQuotes',
+        type: 'normal',
+        enabled: true
+      }
+  ]
+},
+{
+  type: 'separator'
+},
   ]
 
   // If we found a diagnostic earlier and a word, add the suggestion items
@@ -289,10 +313,15 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } })
     } else if (clickedID === 'no-suggestion') {
       // Do nothing
+    } else if (clickedID === 'straightenQuotes') {
+    convertPairedQuotes(view)
+    } else if (clickedID === 'convertSingleToDoubleQuotes') {
+    convertSingleToDoubleQuotes(view)
     } else if (clickedID === 'add-to-dictionary' && word !== undefined) {
       ipcRenderer.invoke(
         'dictionary-provider',
         { command: 'add', terms: [word] }
+
       )
         .then(() => {
           // After we've added the word to the dictionary, we have to invalidate


### PR DESCRIPTION
Description
This pull request adds new context menu items to the Markdown editor to transform paired quotes. The features allow users to:
- Update 'Automate common text transforms. #5659
 - Update Text transform: Paired quotes to double quotes. #5680
 - Update Text transform: Straighten quotes. #5675
Convert smart quotes (“”, ‘’) into plain quotes (" and ')

Convert paired quotes like ```` and '' to "

Convert single quotes ' to double quotes "

These functions improve editing experience for users who deal with copy-pasted or auto-formatted text.
changed files：
- changelog.md
- source/common/modules/markdown-editor/commands/markdown.ts
- source/common/modules/markdown-editor/context-menu/default-menu.ts
