### PR TITLE
feat: hide double square brackets in internal links

### DIFF
--- a/source/common/modules/markdown-editor/renderers/render-links.ts
+++ b/source/common/modules/markdown-editor/renderers/render-links.ts
@@ -68,6 +68,18 @@ function hideLinkMarkers (view: EditorView): RangeSet<Decoration> {
     })
   }
 
+  // Fallback: Manually hide [[ and ]] using RegExp
+  const docText = view.state.doc.toString()
+  const bracketPattern = /\[\[(.*?)\]\]/g
+  let match
+  while ((match = bracketPattern.exec(docText)) !== null) {
+    const start = match.index
+    const end = match.index + match[0].length
+    ranges.push(
+      hiddenDeco.range(start, start + 2),     // hide [[
+      hiddenDeco.range(end - 2, end)          // hide ]]
+    )
+  }
   return Decoration.set(ranges, true)
 }
 


### PR DESCRIPTION
This pull request hides the double square brackets ([[ and ]]) used in internal links in the editor view, improving visual clarity.
If ZknLink AST nodes are available, the plugin hides the pipe (|) and internal target.
As a fallback, it uses a RegExp to hide brackets manually when no AST is available.
This resolves [#5783](https://github.com/Zettlr/Zettlr/issues/5783).
I'm happy to receive feedback and make any changes as needed.