### PR TITLE
Fix: Related files list disappearing when switching sidebar tabs

### DIFF
--- a/source/win-main/sidebar/MainSidebar.vue
+++ b/source/win-main/sidebar/MainSidebar.vue
@@ -9,13 +9,13 @@
     <!-- Now the tab containers -->
     <div id="sidebar-tab-container">
       <ToCTab
-        v-if="currentTab === 'toc'"
+        v-show="currentTab === 'toc'"
         v-on:move-section="emit('move-section', $event)"
         v-on:jump-to-line="emit('jump-to-line', $event)"
       ></ToCTab>
-      <ReferencesTab v-if="currentTab === 'references'"></ReferencesTab>
-      <RelatedFilesTab v-if="currentTab === 'relatedFiles'"></RelatedFilesTab>
-      <OtherFilesTab v-if="currentTab === 'attachments'"></OtherFilesTab>
+      <ReferencesTab v-show="currentTab === 'references'"></ReferencesTab>
+      <RelatedFilesTab v-show="currentTab === 'relatedFiles'"></RelatedFilesTab>
+      <OtherFilesTab v-show="currentTab === 'attachments'"></OtherFilesTab>
     </div>
   </div>
 </template>
@@ -227,4 +227,4 @@ body.darwin, body.linux {
     }
   }
 }
-</style>
+</style> 


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.
  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:
  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues
  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
Fixes #5789 - Related files list disappears when switching tabs in the sidebar.

## Changes
Changed `v-if` to `v-show` for all sidebar tab components in `MainSidebar.vue` to prevent component destruction and maintain state during tab switching.

**Technical Details**:
- **Root Cause**: `v-if` completely destroys and recreates components, causing the `RelatedFilesTab` component to lose its state
- **Fix**: Using `v-show` only toggles visibility while preserving component instances and their state

**Files Modified**:
- `source/win-main/sidebar/MainSidebar.vue`: Changed 4 instances of `v-if` to `v-show` for tab components

## Additional information
**Testing**:
- [x] Created test files with shared tags and internal links
- [x] Confirmed Related Files tab displays the related files list
- [x] Switched to other tabs and back to Related Files tab
- [x] Verified the list persists and doesn't disappear

**Impact**:
- Only affects sidebar tab switching logic
- No breaking changes to existing functionality
- Improves user experience by maintaining state consistency

**Checklist Notes**:
- Items 4 and 5 (yarn lint/test and CHANGELOG.md) - Need guidance on these
- All other checklist items completed

Tested on: Windows 11