### PR TITLE
feat(graph): Add folder filter dropdown to restrict graph view

### DIFF
--- a/static/i18n.pot
+++ b/static/i18n.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Zettlr 3.4.3\n"
+"Project-Id-Version: Zettlr 3.4.4\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-16 09:47+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr ""
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr ""
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,140 +81,6 @@ msgstr ""
 msgid "Option %s is required."
 msgstr ""
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr ""
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr ""
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr ""
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -218,23 +98,95 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
 msgstr ""
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
+msgstr ""
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr ""
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr ""
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr ""
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
 msgstr ""
 
 #: source/app/service-providers/commands/import.ts:34
@@ -289,46 +241,6 @@ msgstr ""
 msgid "Import failed"
 msgstr ""
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr ""
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr ""
@@ -346,27 +258,48 @@ msgstr ""
 msgid "The file/directory %s already exists in target."
 msgstr ""
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
 msgstr ""
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
 msgstr ""
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
 msgstr ""
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
+msgid "An error occurred during export: %s"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
 msgstr ""
 
 #: source/app/service-providers/commands/root-open.ts:59
@@ -392,10 +325,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -409,124 +344,33 @@ msgstr ""
 msgid "Could not import language file %s!"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
+msgid "Copy of %s"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr ""
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr ""
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr ""
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:44
@@ -639,6 +483,12 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr ""
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -657,15 +507,15 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr ""
 
@@ -677,8 +527,8 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr ""
 
@@ -690,8 +540,8 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr ""
 
@@ -931,9 +781,159 @@ msgstr ""
 msgid "Bring All to Front"
 msgstr ""
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr ""
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
 msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
@@ -948,140 +948,1131 @@ msgstr ""
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
 msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr ""
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ""
-
-#: source/common/util/localise-number.ts:29
-msgid "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
 
 #: source/common/util/format-date.ts:33
@@ -1490,261 +2481,445 @@ msgstr ""
 msgid "Chinese"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
+#: source/common/util/localise-number.ts:29
+msgid "."
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr ""
+
+#: source/tmp/win-paste-image/App.vue.ts:57
+msgid "Insert Image from Clipboard"
+msgstr ""
+
+#: source/tmp/win-paste-image/App.vue.ts:59
+msgid "Retain aspect ratio"
+msgstr ""
+
+#: source/tmp/win-paste-image/App.vue.ts:60
+msgid "Resize image to"
+msgstr ""
+
+#: source/tmp/win-paste-image/App.vue.ts:61
+msgid "Filename"
+msgstr ""
+
+#: source/tmp/win-paste-image/App.vue.ts:62
+#: source/tmp/win-paste-image/App.vue.ts:63
+msgid "A unique filename"
+msgstr ""
+
+#: source/tmp/win-about/App.vue.ts:41
+msgid "Other projects"
+msgstr ""
+
+#: source/tmp/win-about/App.vue.ts:47
+msgid "Sponsors"
+msgstr ""
+
+#: source/tmp/win-about/App.vue.ts:53
+msgid "License"
+msgstr ""
+
+#: source/tmp/win-about/General-Tab.vue.ts:21
+msgid ""
+"Zettlr is a project by Hendrik Erz, licensed under the GNU GPL v3 license. "
+"It is Open Source, free of charge and based upon the Electron framework. "
+"Zettlr would like to thank the developers of Electron, the Node.js framework "
+"and the CodeMirror editor for their work. Without them, Zettlr would not be "
+"possible. Below you can find all projects that Zettlr uses."
+msgstr ""
+
+#: source/tmp/win-about/General-Tab.vue.ts:22
+msgid ""
+"Zettlr makes use of citeproc to display citations directly in the editor. To "
+"this end, Zettlr uses the CitationStyleLanguage (CSL) language and style "
+"files. The files have been shipped unaltered with author metadata. More "
+"information:"
+msgstr ""
+
+#: source/tmp/win-about/General-Tab.vue.ts:23
+msgid ""
+"All logos and brand names are subject to their rightful owners. Besides "
+"using their code, Zettlr is in no way affiliated with any of these projects. "
+"Node.js is a trademark of Joyent, Inc."
+msgstr ""
+
+#: source/tmp/win-about/General-Tab.vue.ts:24
+msgid ""
+"Zettlr offers an integration with LanguageTool.org, a service provided by "
+"LanguageTooler GmbH. Using this service requires an internet connection and "
+"is subject to the privacy policy of LanguageTooler GmbH or the corresponding "
+"server that you use."
+msgstr ""
+
+#: source/tmp/win-about/Projects-Tab.vue.ts:19
+msgid "Zettlr also makes use of these projects:"
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
+msgid "Saving …"
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr ""
+
+#: source/tmp/win-assets/DefaultsTab.vue.ts:56
+msgid ""
+"This profile is protected. This means that it will be restored when you "
+"remove or rename it."
+msgstr ""
+
+#: source/tmp/win-assets/DefaultsTab.vue.ts:57
+msgid ""
+"This profile is invalid. It may contain errors, or it may be missing the "
+"writer or reader property."
+msgstr ""
+
+#: source/tmp/win-assets/DefaultsTab.vue.ts:59
+msgid "Open defaults folder"
+msgstr ""
+
+#: source/tmp/win-assets/DefaultsTab.vue.ts:60
+msgid "Edit the default settings for imports or exports here."
+msgstr ""
+
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr ""
+
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
 #: source/tmp/win-tag-manager/App.vue.ts:27
@@ -1796,175 +2971,6 @@ msgstr ""
 msgid "Rename tag…"
 msgstr ""
 
-#: source/tmp/win-paste-image/App.vue.ts:57
-msgid "Insert Image from Clipboard"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:59
-msgid "Retain aspect ratio"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:60
-msgid "Resize image to"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:61
-msgid "Filename"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:62
-#: source/tmp/win-paste-image/App.vue.ts:63
-msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr ""
-
-#: source/tmp/win-about/App.vue.ts:41
-msgid "Other projects"
-msgstr ""
-
-#: source/tmp/win-about/App.vue.ts:47
-msgid "Sponsors"
-msgstr ""
-
-#: source/tmp/win-about/App.vue.ts:53
-msgid "License"
-msgstr ""
-
-#: source/tmp/win-about/General-Tab.vue.ts:21
-msgid ""
-"Zettlr is a project by Hendrik Erz, licensed under the GNU GPL v3 license. "
-"It is Open Source, free of charge and based upon the Electron framework. "
-"Zettlr would like to thank the developers of Electron, the Node.js framework "
-"and the CodeMirror editor for their work. Without them, Zettlr would not be "
-"possible. Below you can find all projects that Zettlr uses."
-msgstr ""
-
-#: source/tmp/win-about/General-Tab.vue.ts:22
-msgid ""
-"Zettlr makes use of citeproc to display citations directly in the editor. To "
-"this end, Zettlr uses the CitationStyleLanguage (CSL) language and style "
-"files. The files have been shipped unaltered with author metadata. More "
-"information:"
-msgstr ""
-
-#: source/tmp/win-about/General-Tab.vue.ts:23
-msgid ""
-"All logos and brand names are subject to their rightful owners. Besides "
-"using their code, Zettlr is in no way affiliated with any of these projects. "
-"Node.js is a trademark of Joyent, Inc."
-msgstr ""
-
-#: source/tmp/win-about/General-Tab.vue.ts:24
-msgid ""
-"Zettlr offers an integration with LanguageTool.org, a service provided by "
-"LanguageTooler GmbH. Using this service requires an internet connection and "
-"is subject to the privacy policy of LanguageTooler GmbH or the corresponding "
-"server that you use."
-msgstr ""
-
-#: source/tmp/win-about/Projects-Tab.vue.ts:19
-msgid "Zettlr also makes use of these projects:"
-msgstr ""
-
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
-#: source/tmp/win-assets/SnippetsTab.vue.ts:106
-msgid "Saving …"
-msgstr ""
-
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
-
-#: source/tmp/win-assets/DefaultsTab.vue.ts:56
-msgid ""
-"This profile is protected. This means that it will be restored when you "
-"remove or rename it."
-msgstr ""
-
-#: source/tmp/win-assets/DefaultsTab.vue.ts:57
-msgid ""
-"This profile is invalid. It may contain errors, or it may be missing the "
-"writer or reader property."
-msgstr ""
-
-#: source/tmp/win-assets/DefaultsTab.vue.ts:59
-msgid "Open defaults folder"
-msgstr ""
-
-#: source/tmp/win-assets/DefaultsTab.vue.ts:60
-msgid "Edit the default settings for imports or exports here."
-msgstr ""
-
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr ""
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr ""
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr ""
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr ""
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr ""
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr ""
-
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr ""
-
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
 msgstr ""
@@ -1989,75 +2995,113 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
@@ -2068,8 +3112,8 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr ""
 
@@ -2083,9 +3127,25 @@ msgstr ""
 msgid "Words"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
@@ -2115,15 +3175,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2184,13 +3235,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2401,129 +3445,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2546,11 +3470,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2564,1045 +3483,132 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr ""
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr ""
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr ""
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""

--- a/static/lang/ar-AR.po
+++ b/static/lang/ar-AR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "تعذر تحميل قاعدة بيانات الاقتباس"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "تم الكشف عن تغييرات في ملف المكتبة. جارٍ إعادة التحميل…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "مساحات العمل"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,141 +81,6 @@ msgstr "يجب أن يكون الخيار٪ s٪ s على الأقل (طول ال
 msgid "Option %s is required."
 msgstr "الخيار٪ s مطلوب."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "مغادرة"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "تعذر التحقق من وجود تحديثات: خطأ في الخادم (رمز الحالة:٪ s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "تعذر البحث عن تحديثات: خطأ في العميل (رمز الحالة:٪ s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"تعذر التحقق من وجود تحديثات: حاول الخادم إعادة التوجيه (رمز الحالة:٪ s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "تعذر التحقق من وجود تحديثات: تعذر إنشاء اتصال"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "تعذر التحقق من وجود تحديثات: لم يرسل الخادم أي بيانات"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "تعذر إنشاء الملف"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "لا يبدو أن المرجع بالمفتاح٪ s يحتوي على مرفقات."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "تعذر فتح المرفق. هل Zotero قيد التشغيل؟"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +98,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "حسنا"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "إلغاء"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "هل ترغب حقًا في الحذف؟"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "هل تريد حقًا إزالة٪ s؟"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "لا يبدو أن المرجع بالمفتاح٪ s يحتوي على مرفقات."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "تعذر فتح المرفق. هل Zotero قيد التشغيل؟"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "حزمة نص غير صحيحة:٪ s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "تصدير مشروع"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "تصدير…"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -291,48 +244,6 @@ msgstr "تعذر استيراد ملفات٪ s التالية لأن نوع مل
 msgid "Import failed"
 msgstr "فشل التصدير"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "تصدير مشروع"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "حسنا"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "تصدير…"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "لا يمكن نقل الدليل"
@@ -350,28 +261,49 @@ msgstr "لا يمكن نقل الدليل أو الملف"
 msgid "The file/directory %s already exists in target."
 msgstr "الملف / الدليل٪ s موجود بالفعل في الهدف."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "بدون عنوان"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "الاسم المقدم لا يحتوي على أي أحرف مسموح بها."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "تعذر إنشاء الدليل"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "لم يتم العثور على الدليل المطلوب."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "هل ترغب حقًا في الحذف؟"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "فشل التصدير"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "حدث خطأ أثناء التصدير:٪ s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "حفظ"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "هل تريد حقًا إزالة٪ s؟"
+msgid "Exporting to %s"
+msgstr "تصدير إلى٪ s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "حدث خطأ أثناء التصدير:٪ s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -396,10 +328,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -413,126 +347,34 @@ msgstr "تم استيراد ملف اللغة:٪ s"
 msgid "Could not import language file %s!"
 msgstr "تعذر استيراد ملف اللغة٪ s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "فشل التصدير"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "تعذر إنشاء الملف"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "حدث خطأ أثناء التصدير:٪ s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "حفظ"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "تصدير إلى٪ s"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "بدون عنوان"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "تعذر إنشاء الدليل"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "حدث خطأ أثناء التصدير:٪ s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "الاسم المقدم لا يحتوي على أي أحرف مسموح بها."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "لم يتم العثور على الدليل المطلوب."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "حزمة نص غير صحيحة:٪ s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "قم دائمًا بتحميل التغييرات عن بُعد إلى الملف الحالي"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "الكتابة على مستند موجود"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "الملف٪ s موجود بالفعل في هذا الدليل. الكتابة فوق؟"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "افتح الملف"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "هناك تغييرات غير محفوظة على الملف الحالي. هل تريد حذفها أو حفظها؟"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "افتح مجلد المشروع"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "تعذر تحميل قاعدة بيانات الاقتباس"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "تم الكشف عن تغييرات في ملف المكتبة. جارٍ إعادة التحميل…"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -644,6 +486,12 @@ msgstr "إعادة تسمية الملف"
 msgid "Delete file"
 msgstr "حذف الملف"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "مغادرة"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -662,15 +510,15 @@ msgstr "إعادة"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "قص"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "نسخ"
 
@@ -682,8 +530,8 @@ msgstr "نسخ بصيغة HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "لصق"
 
@@ -695,8 +543,8 @@ msgstr "لصق بدون أسلوب"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "اختر الكل"
 
@@ -938,10 +786,162 @@ msgstr "توقف عن الكلام"
 msgid "Bring All to Front"
 msgstr "إحضار الكل إلى المقدمة"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "مساحات العمل"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "افتح مجلد المشروع"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "قم دائمًا بتحميل التغييرات عن بُعد إلى الملف الحالي"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "هناك تغييرات غير محفوظة على الملف الحالي. هل تريد حذفها أو حفظها؟"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "افتح الملف"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "الكتابة على مستند موجود"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "الملف٪ s موجود بالفعل في هذا الدليل. الكتابة فوق؟"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "تعذر التحقق من وجود تحديثات: خطأ في الخادم (رمز الحالة:٪ s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "تعذر البحث عن تحديثات: خطأ في العميل (رمز الحالة:٪ s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"تعذر التحقق من وجود تحديثات: حاول الخادم إعادة التوجيه (رمز الحالة:٪ s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "تعذر التحقق من وجود تحديثات: تعذر إنشاء اتصال"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "تعذر التحقق من وجود تحديثات: لم يرسل الخادم أي بيانات"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -958,143 +958,1181 @@ msgstr "حذف التغييرات غير المحفوظة؟"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "هناك تغييرات غير محفوظة على الملف الحالي. هل تريد حذفها أو حفظها؟"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "وضع مدير الملفات"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "تشغيل التصحيح التلقائي"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "خصائص"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "ملف مكرر"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "نسخ الهوية"
+msgid "Double Quotes"
+msgstr "تعطيل الاقتباسات السحرية"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "نسخ اسم الملف"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "تعطيل الاقتباسات السحرية"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "تعطيل الاقتباسات السحرية"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "استبدل الملف"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "علامات التصفية"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "جدول"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "إيقاف"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "اتبع نظام التشغيل"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "بدء"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS مخصص"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "افتح المجلد"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "تصدير إلى٪ s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "استخدم Pandoc الداخلي للتصدير"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "إزالة العلامات من الملفات"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "فك الروابط الداخلية"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "إزالة الروابط الداخلية بالكامل"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "فك الروابط الداخلية"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "لا تلمس الروابط الداخلية"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "إظهار معلومات الملف"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "تعليق"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "نمط لأسماء الملفات الجديدة"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "نمط لأسماء الملفات الجديدة"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "لا تطالب باسم الملف عند إنشاء ملفات جديدة"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "استخدم مظهر النافذة الأصلي"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "استخدم مظهر النافذة الأصلي"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "حجم خط المحرر"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "تنشيط استطلاع مراقب"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "يعتبر وقت الانتظار قبل كتابة الملف قد تم (بالمللي ثانية)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "حذف الملف"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "تفعيل وضع التصحيح"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "تفعيل وضع التصحيح"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "أعلمني حول الإصدارات التجريبية"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "وضع إدخال المحرر"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "البحث في الدليل/المجلد"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "إخفاء أحرف العنوان"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "خط عريض"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "خط مائل"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "تمكين محرر الجدول"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "كتم صوت الخطوط غير المركزة في وضع خالٍ من اﻹلهاء"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "عد الأحرف بدلاً من الكلمات (على سبيل المثال ، للصينية)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "صورة"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "حجم خط المحرر"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "مسافة بادئة بعدد المسافات التالي"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "مسافة بادئة بعدد المسافات التالي"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "قبول المسافات أثناء الإكمال التلقائي"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "إغلاق أزواج الأحرف المطابقة تلقائيًا"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "إظهار معلومات الملف"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "وقت آخر تعديل"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "وقت إنشاء الملف"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "تصدير…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "المستند الأخير"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "الترتيب الطبيعي (10 بعد 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ترتيب ASCII (2 بعد 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "تقديم الاقتباسات"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "عرض الملف"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "يستخدم النمط لإنشاء معرفات جديدة"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "التعبير العادي للمعرف"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "يستخدم النمط لإنشاء معرفات جديدة"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "عند ربط الملفات ، أضف اسم الملف ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "دائما"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "فقط عند الربط باستخدام المعرف"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "أبدا"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "ابدأ بحثًا عند اتباع روابط Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "إنشاء ملفات غير موجودة تلقائيًا عند اتباع الروابط الداخلية"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "CSS مخصص"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "CSS مخصص"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "الشفرة"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "حدد اللغات التي تريد تمكين التدقيق الإملائي التلقائي لها."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "قاموس المستخدم. إزالة الكلمات عن طريق النقر عليها."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "وقت آخر تعديل"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "٪ s كلمات"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "CSS مخصص"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "تعذر إنشاء الملف"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "فتح"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "رابط"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "صورة"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "تعليق"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "افتح الملف"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "لا توجد اقتراحات"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "أضف إلى القاموس"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "خط مائل"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "ادراج رابط"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "أدخل قائمة غير مرتبة"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "ادراج قائمة مرقمة"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "اغلق الملف"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "إعادة تسمية الدليل/المجلد"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "حذف المجلد"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "تحقق من الدليل ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "تصدير مشروع"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "أغلق كل علامات التبويب"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "تحديد فاصلة الألوف"
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "تحديد الفاصلة العشرية"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1526,324 +2564,322 @@ msgstr "الصينية (الصين)"
 msgid "Chinese"
 msgstr "الصينية (الصين)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "تحديد فاصلة الألوف"
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "تحديد الفاصلة العشرية"
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "خصائص"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "ملف مكرر"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "CSS مخصص"
+msgid "Copy path"
+msgstr "نسخ الهوية"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "٪ s كلمات"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "نسخ اسم الملف"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "اغلق الملف"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "إعادة تسمية الدليل/المجلد"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "حذف المجلد"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "تحقق من الدليل ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "تصدير مشروع"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "أغلق كل علامات التبويب"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "خط عريض"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "خط مائل"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "رابط"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "صورة"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "تعليق"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "الشفرة"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "فتح"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "افتح الملف"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "لا توجد اقتراحات"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "أضف إلى القاموس"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "خط مائل"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "ادراج رابط"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "أدخل قائمة غير مرتبة"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "ادراج قائمة مرقمة"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "تعذر إنشاء الملف"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "تحديث جديد متاح"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "الإصدار الخاص بك"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "يتوفر إصدار جديد من Zettlr للتنزيل. يرجى قراءة سجل التغيير أدناه."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "علامات التصفية"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "افتح مجلد المشروع"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "حذف الملف"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "حذف الملف"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "صورة"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1860,10 +2896,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1923,44 +2955,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "أيضا يجعل زيتلر استخدام هذه المشاريع:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"هنا يمكنك تجاوز أنماط Zettlr لتخصيصها بشكل أكبر. <strong> تنبيه: هذا الملف "
-"يتجاوز جميع توجيهات CSS! لا تقم أبدًا بتغيير هندسة العناصر ، وإلا فقد يعرض "
-"التطبيق السلوك غير المرغوب فيه! </ strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS مخصص"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1983,39 +2998,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr ""
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"هنا يمكنك تجاوز أنماط Zettlr لتخصيصها بشكل أكبر. <strong> تنبيه: هذا الملف "
+"يتجاوز جميع توجيهات CSS! لا تقم أبدًا بتغيير هندسة العناصر ، وإلا فقد يعرض "
+"التطبيق السلوك غير المرغوب فيه! </ strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "كلمات"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "أحرف ورموز"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "بدء"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "علامات التصفية"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2041,76 +3094,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "كلمات الشهر الماضي"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "المعدل اليومي"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "كلمات اليوم"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 أنت تشتعل حماسًا!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 أنت على وشك الوصول إلى المعدل اليومي!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 استمر بالكتابة لتتجاوز المعدل اليومي."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "المزيد من الإحصائيات ..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "افتح المجلد"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "المراجع"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "لا توجد اقتباسات في هذا المستند."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "سحابة الوسم"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "تصدير…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "تصدير…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2120,8 +3213,8 @@ msgstr "دلائل/مجلدات"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "الملفات"
 
@@ -2135,10 +3228,26 @@ msgstr "اﻷحرف والرموز"
 msgid "Words"
 msgstr "كلمات"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "مساحات العمل"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "لا توجد ملفات أو مجلدات مفتوحة"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "لا توجد نتائج"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "لم يتم تحديد دليل/مجلد"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "دليل/مجلد فارغ"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2167,15 +3276,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2236,13 +3336,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2453,131 +3546,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "تحديد هدف الكتابة ..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "لا توجد نتائج"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "لم يتم تحديد دليل/مجلد"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "دليل/مجلد فارغ"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "مساحات العمل"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "لا توجد ملفات أو مجلدات مفتوحة"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "كلمات الشهر الماضي"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "المعدل اليومي"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "كلمات اليوم"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 أنت تشتعل حماسًا!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 أنت على وشك الوصول إلى المعدل اليومي!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 استمر بالكتابة لتتجاوز المعدل اليومي."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "المزيد من الإحصائيات ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "تصدير…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "تصدير…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2600,11 +3571,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2618,1094 +3584,134 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "سحابة الوسم"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "كلمات"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "أحرف ورموز"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "حذف الملف"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "افتح مجلد المشروع"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "حذف الملف"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "تشغيل التصحيح التلقائي"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "تقديم الاقتباسات"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "يستخدم النمط لإنشاء معرفات جديدة"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "التعبير العادي للمعرف"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "يستخدم النمط لإنشاء معرفات جديدة"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "فك الروابط الداخلية"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "عند ربط الملفات ، أضف اسم الملف ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "دائما"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "فقط عند الربط باستخدام المعرف"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "أبدا"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "ابدأ بحثًا عند اتباع روابط Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "إنشاء ملفات غير موجودة تلقائيًا عند اتباع الروابط الداخلية"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "تعطيل الاقتباسات السحرية"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "تعطيل الاقتباسات السحرية"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "تعطيل الاقتباسات السحرية"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "استبدل الملف"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "علامات التصفية"
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "وضع إدخال المحرر"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "البحث في الدليل/المجلد"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "إخفاء أحرف العنوان"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "تمكين محرر الجدول"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "كتم صوت الخطوط غير المركزة في وضع خالٍ من اﻹلهاء"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "عد الأحرف بدلاً من الكلمات (على سبيل المثال ، للصينية)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "حجم خط المحرر"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "مسافة بادئة بعدد المسافات التالي"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "مسافة بادئة بعدد المسافات التالي"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "قبول المسافات أثناء الإكمال التلقائي"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "إغلاق أزواج الأحرف المطابقة تلقائيًا"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "جدول"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "إيقاف"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "اتبع نظام التشغيل"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "افتح المجلد"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "المراجع"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "لا توجد اقتباسات في هذا المستند."
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "CSS مخصص"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "CSS مخصص"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "حدد اللغات التي تريد تمكين التدقيق الإملائي التلقائي لها."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "قاموس المستخدم. إزالة الكلمات عن طريق النقر عليها."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "إظهار معلومات الملف"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "وقت آخر تعديل"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "وقت إنشاء الملف"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "تصدير…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "المستند الأخير"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "الترتيب الطبيعي (10 بعد 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ترتيب ASCII (2 بعد 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "تصدير إلى٪ s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "استخدم Pandoc الداخلي للتصدير"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "إزالة العلامات من الملفات"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "إزالة الروابط الداخلية بالكامل"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "فك الروابط الداخلية"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "لا تلمس الروابط الداخلية"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "إظهار معلومات الملف"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "تعليق"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "نمط لأسماء الملفات الجديدة"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "نمط لأسماء الملفات الجديدة"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "لا تطالب باسم الملف عند إنشاء ملفات جديدة"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "استخدم مظهر النافذة الأصلي"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "استخدم مظهر النافذة الأصلي"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "تحديث جديد متاح"
 
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "الإصدار الخاص بك"
 
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "حجم خط المحرر"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "تنشيط استطلاع مراقب"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "يعتبر وقت الانتظار قبل كتابة الملف قد تم (بالمللي ثانية)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "حذف الملف"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "تفعيل وضع التصحيح"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "تفعيل وضع التصحيح"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "أعلمني حول الإصدارات التجريبية"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "وقت آخر تعديل"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "يتوفر إصدار جديد من Zettlr للتنزيل. يرجى قراءة سجل التغيير أدناه."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "عرض الملف"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Open Link"

--- a/static/lang/ca-ES.po
+++ b/static/lang/ca-ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Ander Romero <anderromeroaldana@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "No s'ha pogut carregar la base de dades de referències"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "S'han detectat canvis a la biblioteca. S'està recarregant…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "S'està carregant l'espai de treball %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,150 +81,6 @@ msgstr "L'opció %s ha de tenir com a mínim %s caràcters de llargària"
 msgid "Option %s is required."
 msgstr "L'opció %s és obligatòria"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Mostra el Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Surt"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Hi ha una actualització a la versió %s disponible!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"No s'ha pogut comprovar si hi ha actualitzacions: Error del servidor (codi "
-"d'estat: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"No s'ha pogut comprovar si hi ha actualitzacions: Error del client (codi "
-"d'estat: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"No s'ha pogut comprovar si hi ha actualitzacions: el servidor ha intentat "
-"redirigir (Codi d'estat: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"No s'ha pogut comprovar si hi ha actualitzacions: no s'ha pogut establir la "
-"connexió"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "No s'ha pogut comprovar si hi ha actualitzacions. %s:%s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"No s'ha pogut comprovar si hi ha actualitzacions: el servidor no ha enviat "
-"cap dada"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Document massa llarg"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "sense connexió"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "No s'ha pogut crear el fitxer"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "La referència amb la clau %s no sembla tenir adjunts"
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "No s'ha pogut obrir l'adjunt. El Zotero està funcionant?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -228,24 +98,97 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Reemplaça l'etiqueta \"%s\" per \"%s\" a %s fitxers?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "D'acord"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancel·lar"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Realment esborrar?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Realment voleu esborrar %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "La referència amb la clau %s no sembla tenir adjunts"
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "No s'ha pogut obrir l'adjunt. El Zotero està funcionant?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Paquet de text amb malformacions: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "No s'ha pogut exportar el projecte"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, fuzzy, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Projecte exportat satisfactòriament. Feu clic per mostrar."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exporta"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -302,47 +245,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "L'exportació ha fallat"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "No s'ha pogut exportar el projecte"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "D'acord"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, fuzzy, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Projecte exportat satisfactòriament. Feu clic per mostrar."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exporta"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "No es pot moure la carpeta"
@@ -360,28 +262,49 @@ msgstr "No s'ha pogut moure la carpeta o el fitxer"
 msgid "The file/directory %s already exists in target."
 msgstr "El fitxer o la carpeta %s ja existeix com a objectiu"
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sense títol"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "El nom que heu donat conté algun caràcter invàlid"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "No s'ha pogut crear la carpeta"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "No s'ha trobat la carpeta sol·licitada"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Realment esborrar?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "L'exportació ha fallat"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Hi ha hagut un problema durant l'exportació: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Exporta a"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Desa"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Realment voleu esborrar %s?"
+msgid "Exporting to %s"
+msgstr "Exporta a %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Hi ha hagut un problema a l'exportar: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -406,11 +329,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Còpia de %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Document massa llarg"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "sense connexió"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -423,125 +348,34 @@ msgstr "Fitxer d'idioma importat: %s"
 msgid "Could not import language file %s!"
 msgstr "No s'ha pogut importar el fitxer d'idioma %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "L'exportació ha fallat"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "No s'ha pogut crear el fitxer"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Hi ha hagut un problema durant l'exportació: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Exporta a"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Desa"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exporta a %s"
+msgid "Copy of %s"
+msgstr "Còpia de %s"
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sense títol"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "No s'ha pogut crear la carpeta"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Hi ha hagut un problema a l'exportar: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "El nom que heu donat conté algun caràcter invàlid"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "No s'ha trobat la carpeta sol·licitada"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Paquet de text amb malformacions: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Reemplaça el fitxer"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Carrega sempre canvis remots al fitxer actual"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Sobreescriu el fitxer existent"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "El fitxer %s ja existeix en aquesta carpeta. Sobreescriure'l?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Obre el fitxer"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Canvis no desats"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Hi ha canvis no desats. Voleu desar-los primer?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Obre la carpeta del projecte"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "No s'ha pogut carregar la base de dades de referències"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "S'han detectat canvis a la biblioteca. S'està recarregant…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Reemplaça l'etiqueta \"%s\" per \"%s\" a %s fitxers?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -653,6 +487,12 @@ msgstr "Reanomena el fitxer"
 msgid "Delete file"
 msgstr "Elimina el fitxer"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Surt"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -671,15 +511,15 @@ msgstr "Refés"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Retalla"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copia"
 
@@ -691,8 +531,8 @@ msgstr "Copia com a HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Enganxa"
 
@@ -704,8 +544,8 @@ msgstr "Enganxa sense estil"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Selecciona-ho tot"
 
@@ -947,10 +787,170 @@ msgstr "Deixeu de parlar"
 msgid "Bring All to Front"
 msgstr "Porta tot al capdavant"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Obre la carpeta del projecte"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Reemplaça el fitxer"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "S'està carregant l'espai de treball %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Carrega sempre canvis remots al fitxer actual"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Canvis no desats"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Hi ha canvis no desats. Voleu desar-los primer?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Obre el fitxer"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Sobreescriu el fitxer existent"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "El fitxer %s ja existeix en aquesta carpeta. Sobreescriure'l?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Mostra el Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Hi ha una actualització a la versió %s disponible!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"No s'ha pogut comprovar si hi ha actualitzacions: Error del servidor (codi "
+"d'estat: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"No s'ha pogut comprovar si hi ha actualitzacions: Error del client (codi "
+"d'estat: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"No s'ha pogut comprovar si hi ha actualitzacions: el servidor ha intentat "
+"redirigir (Codi d'estat: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"No s'ha pogut comprovar si hi ha actualitzacions: no s'ha pogut establir la "
+"connexió"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "No s'ha pogut comprovar si hi ha actualitzacions. %s:%s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"No s'ha pogut comprovar si hi ha actualitzacions: el servidor no ha enviat "
+"cap dada"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -967,142 +967,1200 @@ msgstr "Canvis no desats"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Hi ha canvis no desats. Voleu desar-los primer?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Mode del gestor de fitxers"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Encén l'Autocorrector"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Propietats"
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Cap"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplica el fitxer"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Cap"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copia el camí"
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Cap"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copia el nom del fitxer"
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "Si està marcat, l'autocorrector mai substituirà parts d'una paraula"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Substitut"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtre…"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Planificació"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Desactivat"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Segueix el sistema operatiu"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Comença"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Mostra la barra d'estat"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personalitzat"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Obre la carpeta"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Exporta a %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Utilitza el Pandoc intern per exportar"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Elimina les etiquetes dels fitxers"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Desenllaça els enllaços interns"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Elimina els enllaços interns completament"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Desenllaça els enllaços interns"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "No toquis els enllaços interns"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Mostra la informació del fitxer"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Nom de visualització"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Ordre"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Introduïu ordres personalitzades per executar l'exportador. Cada ordre rep "
+"l'arxiu o carpeta a exportar com a primer argument."
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Patró pels noms dels nous fitxers"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Patró pels noms dels nous fitxers"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "No preguntis pel nom del fitxer al crear nous arxius"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Utilitza l'aspecte de la finestra del sistema operatiu"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Utilitza l'aspecte de la finestra del sistema operatiu"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Mostra l'aplicació a l'àrea de notificació"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Deixa l'aplicació funcionant a l'àrea de notificació"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportament del zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "El zoom canvia tota la GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "El zoom canvia la mida de la lletra de l'editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Llista blanca de renderitzacions iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nom de la màquina"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Activeu la connexió Watchdog"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Temps que cal esperar per considerar que un fitxer escrit està acabat (en ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Elimina el fitxer"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Habilita el mode de depuració"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Habilita el mode de depuració"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notifica els llançaments beta"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Mode d'entrada de l'editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Troba a la carpeta"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Amaga els caràcters d'encapçalament"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Renderitza els èmfasi"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Negreta"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Cursiva"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Comprova si hi ha errades d'estil de Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Activa l'editor de taules"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr ""
+"Silencia les línies que no s'estan utilitzant en el mode lliure de "
+"distraccions"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Recompte de paraules"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Compta caràcters en lloc de paraules (per exemple, per al xinès)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Imatge"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Màxima amplada de les imatges (%)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Màxima alçada de les imatges (en %)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Altres fitxers"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Editor de la mida de la lletra"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Sagna a partir del número d'espais"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Sagna amb tabulació"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Accepta espais durant la compleció automàtica"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Mostra previsualitzacions dels enllaços"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Tanca automàticament les parelles de caràcters"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Nom de visualització"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Mostra la informació del fitxer"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Mostra les carpetes sobre els fitxers"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Només nom del fitxer"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Títol (si és aplicable)"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Primer encapçalament de nivell 1 (si és possible)"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Títol o primer encapçalament de nivell 1 (si és possible)"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Mostra l'extensió del fitxer Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Hora de l'última modificació"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Hora de creació del fitxer"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "S'està exportant…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Documents recents"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordre natural (el 10 va després del 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Ordre ASCII (el 2 va després del 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Renderitza les cites"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Com vols que s'autocompletin les teves cites?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Afegeix al fitxer"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Patró utilitzat per a generar noves IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Expressió ID regular"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Patró utilitzat per a generar noves IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Enllaç amb només el nom del fitxer"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Quan s'enllacin fitxers, afegeix el nom de visualització…"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "sempre"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "només quan s'enllaci utilitzant les IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "mai"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Comença una cerca quan es segueixin els enllaços Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Crea automàticament fitxers no-existents quan es segueixin enllaços interns"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+#, fuzzy
+msgid "LanguageTool"
+msgstr "Fes servir LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Rigor"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Estàndard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Minuciós"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+#, fuzzy
+msgid "Mother language"
+msgstr "Llengua materna"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "No definida"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Proveïdor de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Servidor personalitzat"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Servidor personalitzat"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+#, fuzzy
+msgid "LanguageTool Premium"
+msgstr "Proveïdor de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Nom d'usuari de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "Clau d'API de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Actiu"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Language"
+msgstr "Codi de la llengua"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Codi"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Seleccioneu les llengües de la verificació ortogràfica automàtica"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Diccionari de la usuària. Elimina les paraules clicant-les"
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Entrada de diccionari"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Cerca les entrades…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Idioma de l'aplicació"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Desa automàticament"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Hora de l'última modificació"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Immediatament"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Després d'una petita pausa"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Comportament del zoom"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Evita, quan sigui possible, obrir fitxers a noves pestanyes"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Actualitzador"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Cerca actualitzacions automàticament"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caràcters"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s Paraules"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Ves a la referència de la nota"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Obre el panell de diagnòstic"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Detecta automàticament"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "No s'ha pogut crear el fitxer"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Imatge no trobada: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Errada ortogràfica"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "El fitxer %s no existeix."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Recompte de paraules"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificat"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Obre…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Obre en una pestanya nova"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Enllaç"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Imatge"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comentari"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "No s'ha trobat cap text a la nota al peu de pàgina."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copia el codi de l'equació"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copia la imatge al porta-retalls"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Obre el fitxer"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Mostra al Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Mostra a l'Explorador"
-
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
 msgstr "Mostra al Navegador de fitxers"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Tanca el fitxer"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Sense suggeriments"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Reanomena la carpeta"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Afegeix al diccionari"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Esborra la carpeta"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Cursiva"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Revisa la carpeta…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Insereix un enllaç"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exporta el projecte"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Insereix una llista desendreçada"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Insereix una llista numerada"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Tanca les altres pestanyes"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Tanca totes les pestanyes"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "No fixis la pestanya"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Fixa la pestanya"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-clic per seguir aquest enllaç"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1511,327 +2569,320 @@ msgstr "Xinès (Taiwan)"
 msgid "Chinese"
 msgstr "Xinès"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Detecta automàticament"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Desactivat"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-#, fuzzy
-msgid "Custom"
-msgstr "Personalitzat"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s Paraules"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caràcters"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Obre el panell de diagnòstic"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Errada ortogràfica"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Ves a la referència de la nota"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Propietats"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplica el fitxer"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Negreta"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copia el camí"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Cursiva"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copia el nom del fitxer"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Enllaç"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Mostra a l'Explorador"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Imatge"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comentari"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Codi"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "No s'ha trobat cap text a la nota al peu de pàgina."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "El fitxer %s no existeix."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Recompte de paraules"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificat"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Obre…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Obre en una pestanya nova"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copia la imatge al porta-retalls"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Obre el fitxer"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr "Mostra al Navegador de fitxers"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Sense suggeriments"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Tanca el fitxer"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Afegeix al diccionari"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Reanomena la carpeta"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Cursiva"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Esborra la carpeta"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Insereix un enllaç"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Revisa la carpeta…"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Insereix una llista desendreçada"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exporta el projecte"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Insereix una llista numerada"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Tanca les altres pestanyes"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Tanca totes les pestanyes"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "No fixis la pestanya"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Fixa la pestanya"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendari"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Gràfics"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copia el codi de l'equació"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Gener"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Febrer"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Març"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Abril"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maig"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Juny"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Juliol"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agost"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Setembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Octubre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Novembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Desembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Per sota de la mitjana mensual"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Per sobre de la mitjana mensual"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Més del doble de la mitjana mensual"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
+msgid ""
+"Some files are selected for export but no longer exist in the directory."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Readability mode (%s)"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Cerca"
+
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:199
 #, javascript-format
-msgid "Image not found: %s"
-msgstr "Imatge no trobada: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+msgid "Searching: %s"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reinicia"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
 #, fuzzy
-msgid "Could not render Graph:"
-msgstr "No s'ha pogut crear el fitxer"
+msgid "Select folder…"
+msgstr "Obre la carpeta del projecte"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-clic per seguir aquest enllaç"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Elimina el fitxer"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Actualitzador"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Afegeix"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Nova actualització disponible"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Accions"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "La teva versió"
-
-#: source/tmp/win-update/App.vue.ts:34
-msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Hi ha una nova versió de Zettlr disponible per descarregar. Llegiu el "
-"registre de canvis a sota."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Descarregant l'actualització"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "No hi ha actualitzacions disponibles. Ja tens la versió més recent."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Clica per començar l'actualització"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
-#, javascript-format
-msgid "Last checked: %s"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "S'està començant l'actualització…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Recompte"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrar etiquetes…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Suprimeix"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Imatge"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1848,10 +2899,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1919,46 +2966,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr també fa ús d'aquests projectes:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Aquí podeu substituir els estils de Zettlr per personalitzar-lo encara més. "
-"<strong>Atenció: aquest fitxer substitueix totes les directrives CSS! No "
-"modifiqueu mai la geometria dels elements; en cas contrari, l'aplicació es "
-"pot exposar a un comportament no desitjat!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Reanomena el fragment"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Els fragments permeten treballar amb trossos de text amb variables"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "S'està desant…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "No s'ha pogut desar"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personalitzat"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Desat!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1983,39 +3012,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Edita els paràmetres per importar i exportar aquí"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Desat!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Reanomena el fragment"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Els fragments permeten treballar amb trossos de text amb variables"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "paraules"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caràcters"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Aquí podeu substituir els estils de Zettlr per personalitzar-lo encara més. "
+"<strong>Atenció: aquest fitxer substitueix totes les directrives CSS! No "
+"modifiqueu mai la geometria dels elements; en cas contrari, l'aplicació es "
+"pot exposar a un comportament no desitjat!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Cap document obert"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "No s'ha pogut desar"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Comença"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Recompte"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrar etiquetes…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2041,76 +3109,114 @@ msgstr "Efecte de so"
 msgid "Volume"
 msgstr "Volum"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "paraules escrites l'últim mes"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Fitxers relacionats"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "Mitjana diària"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "No hi ha fitxers relacionats"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "Paraules escrites avui"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Aquesta relació està basada en un enllaç bidireccional."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Ho estàs petant!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Aquesta relació està basada en un enllaç de sortida."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Estàs a punt de superar la mitjana diària!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Aquesta relació està basada en un retroenllaç."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Segueix escrivint per a superar la mitjana diària"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Més estadístiques…"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Aquesta relació està basada en %s etiquetes compartides: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Altres fitxers"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Obre la carpeta"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Cap altre fitxer"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referències"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "No hi ha cites en aquest document"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Nom"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Núvol d'etiquetes"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "S'està exportant…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exporta"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "ordre"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2120,8 +3226,8 @@ msgstr "Carpetes"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Fitxers"
 
@@ -2135,10 +3241,26 @@ msgstr "Caràcters"
 msgid "Words"
 msgstr "Paraules"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Espais de treball"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "No hi ha ni fitxers ni carpetes oberts"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Sense resultats"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "No s'ha seleccionat cap carpeta"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Carpeta buida"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2168,15 +3290,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reinicia"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2237,13 +3350,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendari"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2453,130 +3559,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Estableix un objectiu d'escriptura…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Sense resultats"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "No s'ha seleccionat cap carpeta"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Carpeta buida"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Espais de treball"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "No hi ha ni fitxers ni carpetes oberts"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "paraules escrites l'últim mes"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "Mitjana diària"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "Paraules escrites avui"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Ho estàs petant!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Estàs a punt de superar la mitjana diària!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Segueix escrivint per a superar la mitjana diària"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Més estadístiques…"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "S'està exportant…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exporta"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "ordre"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2598,11 +3584,6 @@ msgstr "Restringeix  la cerca a la carpeta"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Cerca"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Neteja la cerca"
@@ -2616,1112 +3597,137 @@ msgstr "Més / Menys detalls"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Nom"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Núvol d'etiquetes"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "paraules"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caràcters"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Cap document obert"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Fitxers relacionats"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "No hi ha fitxers relacionats"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Aquesta relació està basada en un enllaç bidireccional."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Aquesta relació està basada en un enllaç de sortida."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Aquesta relació està basada en un retroenllaç."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Afegeix"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Accions"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Suprimeix"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Obre la carpeta del projecte"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Elimina el fitxer"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Encén l'Autocorrector"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Renderitza les cites"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Gener"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Febrer"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Març"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Abril"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maig"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Juny"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Juliol"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agost"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Setembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Octubre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Novembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Desembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Per sota de la mitjana mensual"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Per sobre de la mitjana mensual"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Més del doble de la mitjana mensual"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Gràfics"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Patró utilitzat per a generar noves IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Expressió ID regular"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Patró utilitzat per a generar noves IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Desenllaça els enllaços interns"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Enllaç amb només el nom del fitxer"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Quan s'enllacin fitxers, afegeix el nom de visualització…"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "sempre"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "només quan s'enllaci utilitzant les IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "mai"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Comença una cerca quan es segueixin els enllaços Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Crea automàticament fitxers no-existents quan es segueixin enllaços interns"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Cap"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Cap"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Cap"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "Si està marcat, l'autocorrector mai substituirà parts d'una paraula"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Substitut"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtre…"
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Mode d'entrada de l'editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Troba a la carpeta"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Amaga els caràcters d'encapçalament"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Renderitza els èmfasi"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Comprova si hi ha errades d'estil de Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Activa l'editor de taules"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr ""
-"Silencia les línies que no s'estan utilitzant en el mode lliure de "
-"distraccions"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Recompte de paraules"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Compta caràcters en lloc de paraules (per exemple, per al xinès)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Màxima amplada de les imatges (%)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Màxima alçada de les imatges (en %)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Aquesta relació està basada en %s etiquetes compartides: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Altres fitxers"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Editor de la mida de la lletra"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Sagna a partir del número d'espais"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Sagna amb tabulació"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Accepta espais durant la compleció automàtica"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Mostra previsualitzacions dels enllaços"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Tanca automàticament les parelles de caràcters"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Planificació"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Desactivat"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Segueix el sistema operatiu"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Mostra la barra d'estat"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Obre la carpeta"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-#, fuzzy
-msgid "LanguageTool"
-msgstr "Fes servir LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Cap altre fitxer"
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Rigor"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Estàndard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Minuciós"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-#, fuzzy
-msgid "Mother language"
-msgstr "Llengua materna"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "No definida"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referències"
 
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "No hi ha cites en aquest document"
 
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Proveïdor de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Servidor personalitzat"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Servidor personalitzat"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-#, fuzzy
-msgid "LanguageTool Premium"
-msgstr "Proveïdor de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Nom d'usuari de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "Clau d'API de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Actiu"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Language"
-msgstr "Codi de la llengua"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Seleccioneu les llengües de la verificació ortogràfica automàtica"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Diccionari de la usuària. Elimina les paraules clicant-les"
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Entrada de diccionari"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Cerca les entrades…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Nom de visualització"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Mostra la informació del fitxer"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Mostra les carpetes sobre els fitxers"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Només nom del fitxer"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Títol (si és aplicable)"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Primer encapçalament de nivell 1 (si és possible)"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Títol o primer encapçalament de nivell 1 (si és possible)"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Mostra l'extensió del fitxer Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Hora de l'última modificació"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Hora de creació del fitxer"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "S'està exportant…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Documents recents"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordre natural (el 10 va després del 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Ordre ASCII (el 2 va després del 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Exporta a %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Utilitza el Pandoc intern per exportar"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Elimina les etiquetes dels fitxers"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Elimina els enllaços interns completament"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Desenllaça els enllaços interns"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "No toquis els enllaços interns"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Mostra la informació del fitxer"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Nom de visualització"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Ordre"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Introduïu ordres personalitzades per executar l'exportador. Cada ordre rep "
-"l'arxiu o carpeta a exportar com a primer argument."
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Patró pels noms dels nous fitxers"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Patró pels noms dels nous fitxers"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "No preguntis pel nom del fitxer al crear nous arxius"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Utilitza l'aspecte de la finestra del sistema operatiu"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Utilitza l'aspecte de la finestra del sistema operatiu"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Mostra l'aplicació a l'àrea de notificació"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Deixa l'aplicació funcionant a l'àrea de notificació"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportament del zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "El zoom canvia tota la GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "El zoom canvia la mida de la lletra de l'editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Llista blanca de renderitzacions iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nom de la màquina"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Activeu la connexió Watchdog"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Temps que cal esperar per considerar que un fitxer escrit està acabat (en ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Elimina el fitxer"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Habilita el mode de depuració"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Habilita el mode de depuració"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notifica els llançaments beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Idioma de l'aplicació"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Desa automàticament"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Hora de l'última modificació"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Immediatament"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Després d'una petita pausa"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Comportament del zoom"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Evita, quan sigui possible, obrir fitxers a noves pestanyes"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Actualitzador"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Cerca actualitzacions automàticament"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Nova actualització disponible"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Com vols que s'autocompletin les teves cites?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "La teva versió"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Hi ha una nova versió de Zettlr disponible per descarregar. Llegiu el "
+"registre de canvis a sota."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Descarregant l'actualització"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "No hi ha actualitzacions disponibles. Ja tens la versió més recent."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Clica per començar l'actualització"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Afegeix al fitxer"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "S'està començant l'actualització…"
 
 #~ msgid "Open Link"
 #~ msgstr "Obre l'enllaç"

--- a/static/lang/cs-CZ.po
+++ b/static/lang/cs-CZ.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2023-09-23 23:15+0200\n"
 "Last-Translator: Ales Nehyba <neal.cz@gmail.com>\n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Databázi citací nelze nahrát"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Zjištěna změna souboru knihovny. Načítá se znovu…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Nahrává se pracovní prostor %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,143 +81,6 @@ msgstr "Možnost %s musí být nejméně %s (znaků dlouhá)."
 msgid "Option %s is required."
 msgstr "Možnost %s je vyžadována."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Zobrazit Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Ukončit"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Je dostupná novější verze %s."
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Nelze zkontrolovat aktualizace: Chyba serveru (Stavový kód: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Nelze zkontrolovat aktualizace: Chyba na straně klienta (Stavový kód: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Nelze zkontrolovat aktualizace: Server se pokoušel o přesměrování (Stavový "
-"kód: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Nelze zkontrolovat aktualizace: Nelze se spojit"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Aktualizace nelze ověřit. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Nelze zkontrolovat aktualizace: Server neodeslal žádná data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Dokument je příliš dlouhý"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Nelze vytvořit soubor"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Odkaz s klíčem %s zřejmě nemá přílohy."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Přílohu nejde otevřít. Běží aplikace Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -221,24 +98,96 @@ msgstr "Ano"
 msgid "No"
 msgstr "Ne"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Nahradit štítek „%s“ za „%s“ v %s souborech?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Zrušit"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Opravdu smazat?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Opravdu chcete odstranit %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Odkaz s klíčem %s zřejmě nemá přílohy."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Přílohu nejde otevřít. Běží aplikace Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Chybný Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Projekt nelze exportovat"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Projekt „%s“ byl úspěšně exportován. Klikněte pro zobrazení."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Exportovat projekt"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -294,46 +243,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Export selhal"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Projekt nelze exportovat"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Projekt „%s“ byl úspěšně exportován. Klikněte pro zobrazení."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Exportovat projekt"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Složku nelze přesunout"
@@ -351,28 +260,49 @@ msgstr "Složku nebo soubor nelze přesunout"
 msgid "The file/directory %s already exists in target."
 msgstr "Soubor nebo složka %s už existuje."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Bez názvu"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Dodaný název neobsahuje žádná povolené písmena."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Nelze vytvořit složku"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Požadovaná složka nebyla nalezena."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Opravdu smazat?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Export selhal"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Opravdu chcete odstranit %s?"
+msgid "An error occurred during export: %s"
+msgstr "Během exportu se objevila chyba: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Vyberte místo exportu"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Uložit"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Probíhá export do %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Během exportu se objevila chyba: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -397,11 +327,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Kopie %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Dokument je příliš dlouhý"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -414,125 +346,34 @@ msgstr "Importován jazykový soubor: %s"
 msgid "Could not import language file %s!"
 msgstr "Nelze importovat jazykový soubor %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Export selhal"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Nelze vytvořit soubor"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Během exportu se objevila chyba: %s"
+msgid "Copy of %s"
+msgstr "Kopie %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Vyberte místo exportu"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Bez názvu"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Uložit"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Nelze vytvořit složku"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Probíhá export do %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Během exportu se objevila chyba: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Dodaný název neobsahuje žádná povolené písmena."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Požadovaná složka nebyla nalezena."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Chybný Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Vždy aktualizovat vzdálené změny aktuálního souboru"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Přepsat existující soubor"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Soubor %s ve složce již existuje. Přepsat?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Otevřít soubor"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Neuložené změny"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "V aktuálním souboru jsou neuložené změny. Chcete je nejprve uložit?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Uložit soubor"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Otevřít složku projektu"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Databázi citací nelze nahrát"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Zjištěna změna souboru knihovny. Načítá se znovu…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Nahradit štítek „%s“ za „%s“ v %s souborech?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -644,6 +485,12 @@ msgstr "Přejmenovat soubor"
 msgid "Delete file"
 msgstr "Smazat soubor"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Ukončit"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -662,15 +509,15 @@ msgstr "Znovu"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Vyjmout"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopírovat"
 
@@ -682,8 +529,8 @@ msgstr "Zkopírovat jako HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Vložit"
 
@@ -695,8 +542,8 @@ msgstr "Vložit bez formátování"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Vybrat vše"
 
@@ -941,10 +788,163 @@ msgstr "Zastavit předčítání"
 msgid "Bring All to Front"
 msgstr "Vše do popředí"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Otevřít složku projektu"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Nahrává se pracovní prostor %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Vždy aktualizovat vzdálené změny aktuálního souboru"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Neuložené změny"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "V aktuálním souboru jsou neuložené změny. Chcete je nejprve uložit?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Otevřít soubor"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Uložit soubor"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Přepsat existující soubor"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Soubor %s ve složce již existuje. Přepsat?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Zobrazit Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Je dostupná novější verze %s."
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Nelze zkontrolovat aktualizace: Chyba serveru (Stavový kód: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Nelze zkontrolovat aktualizace: Chyba na straně klienta (Stavový kód: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Nelze zkontrolovat aktualizace: Server se pokoušel o přesměrování (Stavový "
+"kód: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Nelze zkontrolovat aktualizace: Nelze se spojit"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Aktualizace nelze ověřit. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Nelze zkontrolovat aktualizace: Server neodeslal žádná data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -961,142 +961,1198 @@ msgstr "Neuložené změny"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "V aktuálním souboru jsou neuložené změny. Chcete je nejprve uložit?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Režim správce souborů"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Zapnout automatické opravy"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Vlastnosti"
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Žádný"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplikovat soubor"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Žádný"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Zkopírovat cestu"
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Žádný"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopírovat název souboru"
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Shoda v celých slovech"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "Pokud je vybráno, AutoCorrect nikdy nenahrazuje části slov"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Náhrada"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtrovat …"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Plán"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Vyp."
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Podle operačního systému"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Spustit"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Zobrazit stavovou lištu"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Vlastní CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Otevřít složku"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Probíhá export do %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Použít pro export interní pandoc"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Odstranit ze souborů štítky"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Odpojit interní odkazy"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Zcela odstranit interní odkazy"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Odpojit interní odkazy"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Interní odkazy nechat být"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Zobrazit informace o souboru"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Zobrazit název"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Příkaz"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Vložte vlastní příkazy, se kterými proběhne export. Každý příkaz obdrží jako "
+"první argument soubor nebo adresář projektu, který se exportuje."
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Šablona pro nové názvy souborů"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Šablona pro nové názvy souborů"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Nepožadovat zadání názvu souboru při vytváření nových souborů"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Použít nativní vzhled oken"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Zobrazit aplikaci v oznamovací oblasti"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Nechat aplikaci běžet v oznamovací oblasti"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Chování zvětšování"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Zvětšování mění velikost celého GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Zvětšování mění velikost písma editoru"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Whitelist pro vykreslení iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktivovat hlídání změn"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Jak dlouho čekat než je zápis souboru považován za ukončený (v ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Smazat soubor"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Vývojářský režim"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Povolit vývojářský režim"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta verze"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Informovat o beta vydáních"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Režim editoru"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Najít ve složce"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Skrýt znaky záhlaví"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Vykreslit zvýraznění"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Tučné"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kurzíva"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Zkontrolovat stylové problémy v Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Povolit Editor tabulek"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "V režimu soustředění ztlumit neaktivní řádky"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Počet slov"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Počítat znaky místo slov (např. pro čínštinu)"
+
+#: source/win-preferences/schema/editor.ts:195
+#, fuzzy
+msgid "Readability mode"
+msgstr "Režim čitelnosti (%s)"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Obrázek"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Maximální šířka obrázků (procenta)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Maximální výška obrázků (procenta)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Další soubory"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Velikost písma v editoru"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Odsadit o určený počet mezer"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Odsadit pomocí tabulátorů"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Automatické doplňování včetně mezer"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Zobrazit náhled odkazu"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Automaticky uzavírat odpovídající párové znaky"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Zobrazit název"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Zobrazit informace o souboru"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Zobrazit složky před soubory"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Pouze názvy souborů"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Název, pokud je to možné"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "První nadpis první úrovně"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Název nebo první nadpis první úrovně"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Zobrazit přípony souborů markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Čas poslední změny"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Čas vytvoření souboru"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Probíhá export…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Nedávné dokumenty"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Přirozené pořadí (10 po 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII pořadí (2 po 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Generovat citace"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Jak má automatické dokončování vkládat citace?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Přidat do souboru"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Vzor pro generování nových ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Regulární výraz ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Vzor pro generování nových ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Vytvářet odkaz jen z názvu souboru"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Při vytváření odkazů mezi soubory, zobrazovat název …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "vždy"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "pouze při propojování za použití ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "nikdy"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Spustit hledání při následování odkazů kartotéky"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Automaticky vytvářet neexistující soubory při následování vnitřních odkazů"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Otevřít editor útržků"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+#, fuzzy
+msgid "LanguageTool"
+msgstr "Použít LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Přesnost"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Běžná"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Přísná"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+#, fuzzy
+msgid "Mother language"
+msgstr "Mateřský jazyk"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Není nastaveno"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Poskytovatel LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Vlastní server"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Vlastní server"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+#, fuzzy
+msgid "LanguageTool Premium"
+msgstr "Poskytovatel LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Uživatelské jméno LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "API klíč LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Aktivní"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Language"
+msgstr "Kód jazyka"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kód"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Vyberte jazyky, pro které chcete zapnout automatickou kontrolu pravopisu."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Uživatelský slovník. Slova odstraníte klepnutím na ně."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Záznam ve slovníku"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Hledat položky …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Jazyk aplikace"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automatické ukládání"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Uložit změny"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Ihned"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Po krátké prodlevě"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Výchozí složka pro obrázky"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Klepněte na \"Vybrat složku...\" nebo zadejte absolutní či relativní cestu "
+"přímo do vstupního pole."
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Chování"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Pokud možno, neotevírat soubory v nových záložkách"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Aktualizace"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Automaticky zjišťovat aktualizace"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s znaků"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s slov"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Přejít na poznámku pod čarou"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Žádné zvýraznění"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Otevřít panel diagnostiky"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Vlastní"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Automatická detekce"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Mermaid vytváří graf…"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Nelze vytvořit graf:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Režim čitelnosti (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Obrázek nenalezen: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Pravopisná chyba"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Soubor %s neexistuje."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Počet slov"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Upraveno"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Otevřít …"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Otevřít na nové záložce"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Odkaz"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Obrázek"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Komentář"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Nebyl nalezen text poznámky pod čarou."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Zkopírovat kód rovnice"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Zkopírovat obrázek do schránky"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Otevřít soubor"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Otevřít ve Finderu"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Otevřít v Průzkumníku"
-
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
 msgstr "Otevřít v prohlížeči souborů"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Zavřít soubor"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Bez návrhů"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Přejmenovat složku"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Přidat do složky"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Smazat složku"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kurzíva"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Hledat složku…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Vložit odkaz"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportovat projekt"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Vložit odrážkový seznam"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Vložit číslovaný seznam"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Zavřít ostatní karty"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Zavřít všechny karty"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Odepnout"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Připnout"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "&nbsp;"
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Pro otevření odkazu klepněte se stisknutou klávesou Cmd/Ctrl"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1504,323 +2560,320 @@ msgstr "Čínština (Taiwan)"
 msgid "Chinese"
 msgstr "Čínština"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Automatická detekce"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "&nbsp;"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Zakázáno"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Vlastní"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s slov"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s znaků"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Otevřít panel diagnostiky"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Pravopisná chyba"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Přejít na poznámku pod čarou"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Vlastnosti"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplikovat soubor"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Tučné"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Zkopírovat cestu"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kurzíva"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopírovat název souboru"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Odkaz"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Otevřít v Průzkumníku"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Obrázek"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Komentář"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kód"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Nebyl nalezen text poznámky pod čarou."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Soubor %s neexistuje."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Počet slov"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Upraveno"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Otevřít …"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Otevřít na nové záložce"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Žádné zvýraznění"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Zkopírovat obrázek do schránky"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Otevřít soubor"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr "Otevřít v prohlížeči souborů"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Bez návrhů"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Zavřít soubor"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Přidat do složky"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Přejmenovat složku"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kurzíva"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Smazat složku"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Vložit odkaz"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Hledat složku…"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Vložit odrážkový seznam"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportovat projekt"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Vložit číslovaný seznam"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Zavřít ostatní karty"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Zavřít všechny karty"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Odepnout"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Připnout"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalendář"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Grafy"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Zkopírovat kód rovnice"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Režim čitelnosti (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Obrázek nenalezen: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Mermaid vytváří graf…"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Leden"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Nelze vytvořit graf:"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Únor"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Pro otevření odkazu klepněte se stisknutou klávesou Cmd/Ctrl"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Březen"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Aktualizace"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Duben"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Je dostupná aktualizace"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Květen"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Vaše verze"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Červen"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Červenec"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Srpen"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Září"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Říjen"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Listopad"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Prosinec"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Méně než měsíční průměr"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Více než měsíční průměr"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Více než dvojnásobek měsíčního průměru"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Zettlr je k dispozici v novější verzi. Přečtěte si changelog níže."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Aktualizace se stahuje"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Máte nejnovější verzi."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klepnutím spustíte aktualizaci"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Spouští se aktualizace …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Hledat"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Počet"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrovat štítky…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Otevřít složku projektu"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Smazat soubor"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Přidat"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Akce"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Smazat"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Obrázek"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1837,10 +2890,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1906,45 +2955,29 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr používá také tyto projekty:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Zde si můžete přizpůsobit styly, které Zettlr používá. <strong>Pozor: Tento "
-"soubor přepíše všechny CSS direktivy! Nikdy neměňte geometrii prvků, jinak "
-"se může aplikace chovat nepředvídatelně!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Přejmenovat útržek"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Útržky vám umožňují definovat opakovaně použitelné části textu s proměnnými."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Ukládá se …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Ukládání selhalo"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Vlastní CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Uloženo!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1970,40 +3003,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Zde upravíte výchozí nastavení pro import a export."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Uloženo!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Přejmenovat útržek"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-"Útržky vám umožňují definovat opakovaně použitelné části textu s proměnnými."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "slov"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "znaků"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Zde si můžete přizpůsobit styly, které Zettlr používá. <strong>Pozor: Tento "
+"soubor přepíše všechny CSS direktivy! Nikdy neměňte geometrii prvků, jinak "
+"se může aplikace chovat nepředvídatelně!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Žádný otevřený dokument"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Ukládání selhalo"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Spustit"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Počet"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrovat štítky…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2029,76 +3099,114 @@ msgstr "Zvukový efekt"
 msgid "Volume"
 msgstr "Hlasitost"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "slov minulý měsíc"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Související soubory"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "denní průměr"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Žádné související soubory"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "slov dnes"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Tento vztah je založen na obousměrném odkazu."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🥇 Jste šampión!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Tento vztah je založen na odchozím odkazu."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Jste blízko dosažení svého denního průměru!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Tento vztah je založen na zpětném odkazu."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Pište, a překonáte svůj denní průměr."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Další statistiky …"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Tento vztah je založen na %s sdílených štítků: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Další soubory"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Otevřít složku"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Žádné další soubory"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Odkazy"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "V dokumentu nejsou žádné citace."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Název"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Tag cloud"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Probíhá export…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exportovat"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "příkaz"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2108,8 +3216,8 @@ msgstr "Složky"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Soubory"
 
@@ -2123,10 +3231,26 @@ msgstr "Znaků"
 msgid "Words"
 msgstr "Slov"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Pracovní plochy"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Žádné otevřené soubory nebo složky"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Žádné výsledky"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Není vybrána žádná složka"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Prázdná složka"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2156,15 +3280,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2225,13 +3340,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalendář"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2441,130 +3549,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Nastavit autorský cíl …"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Žádné výsledky"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Není vybrána žádná složka"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Prázdná složka"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Pracovní plochy"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Žádné otevřené soubory nebo složky"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "slov minulý měsíc"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "denní průměr"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "slov dnes"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🥇 Jste šampión!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Jste blízko dosažení svého denního průměru!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Pište, a překonáte svůj denní průměr."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Další statistiky …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Probíhá export…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exportovat"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "příkaz"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2586,11 +3574,6 @@ msgstr "Hledat pouze ve složce"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Hledat"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Vyčistit pole"
@@ -2604,1112 +3587,135 @@ msgstr "Rozbalit výsledky"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Název"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Tag cloud"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "slov"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "znaků"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Žádný otevřený dokument"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Související soubory"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Žádné související soubory"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Tento vztah je založen na obousměrném odkazu."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Tento vztah je založen na odchozím odkazu."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Tento vztah je založen na zpětném odkazu."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Přidat"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Akce"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Smazat"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Otevřít složku projektu"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Smazat soubor"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Zapnout automatické opravy"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Generovat citace"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Leden"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Únor"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Březen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Duben"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Květen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Červen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Červenec"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Srpen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Září"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Říjen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Listopad"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Prosinec"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Méně než měsíční průměr"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Více než měsíční průměr"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Více než dvojnásobek měsíčního průměru"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Grafy"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Vzor pro generování nových ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Regulární výraz ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Vzor pro generování nových ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Odpojit interní odkazy"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Vytvářet odkaz jen z názvu souboru"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Při vytváření odkazů mezi soubory, zobrazovat název …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "vždy"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "pouze při propojování za použití ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "nikdy"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Spustit hledání při následování odkazů kartotéky"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Automaticky vytvářet neexistující soubory při následování vnitřních odkazů"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Žádný"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Žádný"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Žádný"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Shoda v celých slovech"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "Pokud je vybráno, AutoCorrect nikdy nenahrazuje části slov"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Náhrada"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtrovat …"
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Režim editoru"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Najít ve složce"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Skrýt znaky záhlaví"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Vykreslit zvýraznění"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Zkontrolovat stylové problémy v Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Povolit Editor tabulek"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "V režimu soustředění ztlumit neaktivní řádky"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Počet slov"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Počítat znaky místo slov (např. pro čínštinu)"
-
-#: source/win-preferences/schema/editor.ts:195
-#, fuzzy
-msgid "Readability mode"
-msgstr "Režim čitelnosti (%s)"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Maximální šířka obrázků (procenta)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Maximální výška obrázků (procenta)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Tento vztah je založen na %s sdílených štítků: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Další soubory"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Velikost písma v editoru"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Odsadit o určený počet mezer"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Odsadit pomocí tabulátorů"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Automatické doplňování včetně mezer"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Zobrazit náhled odkazu"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Automaticky uzavírat odpovídající párové znaky"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Plán"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Vyp."
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Podle operačního systému"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Zobrazit stavovou lištu"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Otevřít složku"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-#, fuzzy
-msgid "LanguageTool"
-msgstr "Použít LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Žádné další soubory"
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Přesnost"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Běžná"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Přísná"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-#, fuzzy
-msgid "Mother language"
-msgstr "Mateřský jazyk"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Není nastaveno"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Odkazy"
 
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "V dokumentu nejsou žádné citace."
 
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Poskytovatel LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Vlastní server"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Vlastní server"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-#, fuzzy
-msgid "LanguageTool Premium"
-msgstr "Poskytovatel LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Uživatelské jméno LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "API klíč LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Aktivní"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Language"
-msgstr "Kód jazyka"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Vyberte jazyky, pro které chcete zapnout automatickou kontrolu pravopisu."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Uživatelský slovník. Slova odstraníte klepnutím na ně."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Záznam ve slovníku"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Hledat položky …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Zobrazit název"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Zobrazit informace o souboru"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Zobrazit složky před soubory"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Pouze názvy souborů"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Název, pokud je to možné"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "První nadpis první úrovně"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Název nebo první nadpis první úrovně"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Zobrazit přípony souborů markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Čas poslední změny"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Čas vytvoření souboru"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Probíhá export…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Nedávné dokumenty"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Přirozené pořadí (10 po 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII pořadí (2 po 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Probíhá export do %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Použít pro export interní pandoc"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Odstranit ze souborů štítky"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Zcela odstranit interní odkazy"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Odpojit interní odkazy"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Interní odkazy nechat být"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Zobrazit informace o souboru"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Zobrazit název"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Příkaz"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Vložte vlastní příkazy, se kterými proběhne export. Každý příkaz obdrží jako "
-"první argument soubor nebo adresář projektu, který se exportuje."
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Šablona pro nové názvy souborů"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Šablona pro nové názvy souborů"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Nepožadovat zadání názvu souboru při vytváření nových souborů"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Použít nativní vzhled oken"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Zobrazit aplikaci v oznamovací oblasti"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Nechat aplikaci běžet v oznamovací oblasti"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Chování zvětšování"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Zvětšování mění velikost celého GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Zvětšování mění velikost písma editoru"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Whitelist pro vykreslení iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktivovat hlídání změn"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Jak dlouho čekat než je zápis souboru považován za ukončený (v ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Smazat soubor"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Vývojářský režim"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Povolit vývojářský režim"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta verze"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Informovat o beta vydáních"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Otevřít editor útržků"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Jazyk aplikace"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automatické ukládání"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Uložit změny"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Ihned"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Po krátké prodlevě"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Výchozí složka pro obrázky"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Klepněte na \"Vybrat složku...\" nebo zadejte absolutní či relativní cestu "
-"přímo do vstupního pole."
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Chování"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Pokud možno, neotevírat soubory v nových záložkách"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Aktualizace"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Automaticky zjišťovat aktualizace"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Je dostupná aktualizace"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Jak má automatické dokončování vkládat citace?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Vaše verze"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Zettlr je k dispozici v novější verzi. Přečtěte si changelog níže."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Aktualizace se stahuje"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Máte nejnovější verzi."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klepnutím spustíte aktualizaci"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Přidat do souboru"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Spouští se aktualizace …"
 
 #~ msgid "Open Link"
 #~ msgstr "Otevřít odkaz"

--- a/static/lang/da-DA.po
+++ b/static/lang/da-DA.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-04-28 18:07+0200\n"
 "Last-Translator: Hendrik Erz <info@zettlr.com>\n"
 "Language-Team: \n"
@@ -17,6 +17,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Citations databasen kunne ikke indlæses"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Der er registreret ændringer i biblioteksfilen. Genindlæser ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Arbejdsområder"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -69,142 +83,6 @@ msgstr "Valgmuligheden %s skal være minimum %s (karakterer lang)."
 msgid "Option %s is required."
 msgstr "Valgmuligheden %s er nødvendig"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Vis Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Afslut"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "En opdatering til version %s er tilgængelig"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Kunne ikke søge efter opdateringer: Server fejl (Status kode: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Kunne ikke søge efter opdateringer: Klient fejl (Status kode: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Kunne ikke søge efter opdateringer: Serveren forsøgte at redirecte (Status "
-"kode: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Kunne ikke søge efter opdateringer: Kunne ikke etablere forbindelse"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Kunne ikke søge efter opdateringer. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Kunne ikke søge efter opdateringer: Serveren har ikke sendt noget data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Kunne ikke oprette fil"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Referencen med nøglen %s ser ikke ud til at have vedhæftninger."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Kunne ikke åbne vedhæftning. Kører Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -222,24 +100,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Annullér"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Bekræft sletning"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Vil du virkelig slette %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Referencen med nøglen %s ser ikke ud til at have vedhæftninger."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Kunne ikke åbne vedhæftning. Kører Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "misdannet tekstbundt: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Eksportér projekt"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Eksporter..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -296,48 +248,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Eksporten fejlede"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Eksportér projekt"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Eksporter..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Kan ikke flytte mappe"
@@ -355,28 +265,49 @@ msgstr "Kan ikke flytte mappe eller fil"
 msgid "The file/directory %s already exists in target."
 msgstr "Filen/mappen %s eksisterer allerede."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Uden navn"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Det angivne navn indeholdt ingen tilladte bogstaver"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Kunne ikke oprette mappe"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Mappen kunne ikke findes."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Bekræft sletning"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Eksporten fejlede"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "En fejl opstod under eksport: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Gem"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Vil du virkelig slette %s?"
+msgid "Exporting to %s"
+msgstr "Eksporterer til %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "En fejl opstod under eksport: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -401,10 +332,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -418,130 +351,34 @@ msgstr "Sprog fil importeret: %s"
 msgid "Could not import language file %s!"
 msgstr "Kunne ikke importere sprog fil %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Eksporten fejlede"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Kunne ikke oprette fil"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "En fejl opstod under eksport: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
+#, javascript-format
+msgid "Copy of %s"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Gem"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Uden navn"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Kunne ikke oprette mappe"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Eksporterer til %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "En fejl opstod under eksport: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Det angivne navn indeholdt ingen tilladte bogstaver"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Mappen kunne ikke findes."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "misdannet tekstbundt: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Erstat fil"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Filen %s er blevet ændret eksternt. Vil du udskifte den indlæste version, "
-"med den nyere version fra fil systemet?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Indlæs altid eksterne ændringer til den aktuelle fil"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Overskriv eksisterende fil"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Filen %s eksisterer allerede i mappen. Vil du overskrive?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Åben fil"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Ikke gemte ændringer"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Der er ikke gemte ændringer i den følgende fil. Vil du kassere dem eller "
-"gemme?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Åbn projekt mappe"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Citations databasen kunne ikke indlæses"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Der er registreret ændringer i biblioteksfilen. Genindlæser ..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -653,6 +490,12 @@ msgstr "Omdøb fil"
 msgid "Delete file"
 msgstr "Slet fil"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Afslut"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -671,15 +514,15 @@ msgstr "Gentag"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Klip"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopiér"
 
@@ -691,8 +534,8 @@ msgstr "Kopiér som HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Indsæt"
 
@@ -704,8 +547,8 @@ msgstr "Indsæt uden formatering"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Vælg alle"
 
@@ -948,10 +791,167 @@ msgstr "Stop med at tale"
 msgid "Bring All to Front"
 msgstr "Bring alle til front"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Arbejdsområder"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Åbn projekt mappe"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Erstat fil"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Filen %s er blevet ændret eksternt. Vil du udskifte den indlæste version, "
+"med den nyere version fra fil systemet?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Indlæs altid eksterne ændringer til den aktuelle fil"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Ikke gemte ændringer"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Der er ikke gemte ændringer i den følgende fil. Vil du kassere dem eller "
+"gemme?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Åben fil"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Overskriv eksisterende fil"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Filen %s eksisterer allerede i mappen. Vil du overskrive?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Vis Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "En opdatering til version %s er tilgængelig"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Kunne ikke søge efter opdateringer: Server fejl (Status kode: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Kunne ikke søge efter opdateringer: Klient fejl (Status kode: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Kunne ikke søge efter opdateringer: Serveren forsøgte at redirecte (Status "
+"kode: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Kunne ikke søge efter opdateringer: Kunne ikke etablere forbindelse"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Kunne ikke søge efter opdateringer. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Kunne ikke søge efter opdateringer: Serveren har ikke sendt noget data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -970,143 +970,1175 @@ msgstr ""
 "Der er ikke gemte ændringer i den følgende fil. Vil du kassere dem eller "
 "gemme?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Fil administrations tilstand"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Kunne ikke gemme fil"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, fuzzy, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Kunne ikke gemme fil"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Slå Auto korrektur til"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Indstillinger"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplikér fil"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Kopiér ID"
+msgid "Double Quotes"
+msgstr "Ingen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopiér filnavn"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Ingen"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Ingen"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Erstat fil"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filtrer ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Tidsindstillinger"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Slået fra"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Følg styresystem"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Vis Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Custom CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Åbn mappe"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Eksporterer til %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Brug den interne Pandoc til eksporter"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Fjern mærkater fra filer"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Af-link interne links"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Fjern interne links fuldstændigt"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Af-link interne links"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Lav ingen ændringer på interne links"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Vis fil information"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Kommentar"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Mønster for nye filnavne"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Mønster for nye filnavne"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Spørg ikke efter filnavn, når der oprettes nye filer"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Brug nativ vindues udseende"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Brug nativ vindues udseende"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Vis programmet i notifikationsområdet"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Lad programmet køre i systembakken"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Redigerings skriftstørrelse"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "IFrame rendering hvid liste"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktivér \"vagthunds\" overvågning"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Tid før skrivning af en fil forventes færdigt (i ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Slet fil"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Aktiver debugging"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Aktiver debugging"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Orienter om betaudgivelser"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Editor input tilstand"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Find i mappe"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Skjul Overskrifts tegn"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Fed"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursiv"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Slå tabel editor til"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Nedton ikke-fokuserede linjer i distraktionsfri tilstand"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Ordoptælling"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Tæl tegn i stedet for ord (f.eks. på kinesisk)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Billede"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Billeders maksimal vidde (i procent)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Billeders maksimal højde (i procent)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Andre filer"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Redigerings skriftstørrelse"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Indentér med det følgende antal mellemrum"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Indentér med det følgende antal mellemrum"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Acceptér mellemrum ved autofuldførelse"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Luk automatisk matchende karaktér par"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Mørk tilstand"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Vis fil information"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Vis mapper over filer"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Sidste ændringstidspunkt"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Dato for filoprettelse"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Eksporter..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Nylige dokumenter"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Naturlig rækkefølge (10 efter 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII rækkefølge (2 efter 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Rendér citationer"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Ønsker du at autofuldfør indsætter citationer for dig?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Tilføj til fil"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Mønster brugt til at generere nye ID'er"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID regular expression"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Mønster brugt til at generere nye ID'er"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Når der linkes mellem filer, tilføj da filnavnet ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "altid"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "kun når der linkes ved hjælp af ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "aldrig"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+#, fuzzy
+msgid "Link format"
+msgstr "Link begyndelse"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Start en søgning når Zettelkasten-links følges"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Opret automatisk ikke-eksisterende filer når interne links følges"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalender"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Custom CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Custom CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Handlinger"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kode"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Vælg de sprog som du vil slå automatisk stavekontrol til for."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Bruger ordbog: Fjern ord ved at klikke på dem."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Ordbogs indlæg"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Søg efter indlæg ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automatisk gem"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Sidste ændringstidspunkt"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Med det samme"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Efter en kort forsinkelse"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Undgå at åbne filer i nye faner hvis muligt"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Opdatering"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s karakterer"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s ord"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Custom CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Kunne ikke oprette fil"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Ordoptælling"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificeret"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Åbn..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Åben i et nyt faneblad"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Billede"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Kommentar"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Kopier udregning"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Kopier billede til udklipsholder"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Åben fil"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Åben i browser"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Ingen forslag"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Tilføj til ordbog"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursiv"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Indsæt link"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Indsæt punktliste"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Indsæt nummeret liste"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Luk fil"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Omdøb mappe"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Slet mappe"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Scan efter mapper ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Eksportér projekt"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Luk andre faneblade"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Luk alle faneblade"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,328 +2564,322 @@ msgstr "Kinesisk (Kina)"
 msgid "Chinese"
 msgstr "Kinesisk (Kina)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Indstillinger"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplikér fil"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Custom CSS"
+msgid "Copy path"
+msgstr "Kopiér ID"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s ord"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopiér filnavn"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s karakterer"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Luk fil"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Omdøb mappe"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Slet mappe"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Scan efter mapper ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Eksportér projekt"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Luk andre faneblade"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Luk alle faneblade"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Fed"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursiv"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Billede"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Kommentar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kode"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Diagrammer"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Ordoptælling"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificeret"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Åbn..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Åben i et nyt faneblad"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "januar"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "februar"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "marts"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "april"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "maj"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "juni"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "juli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "august"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "september"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "oktober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "november"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "december"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Under det månedlige gennemsnit"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Over det månedlige gennemsnit"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Mere end det dobbelte af det månedlige gennemsnit"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Kopier billede til udklipsholder"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Åben fil"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Åben i browser"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Ingen forslag"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Tilføj til ordbog"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursiv"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Indsæt link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Indsæt punktliste"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Indsæt nummeret liste"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Kopier udregning"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Kunne ikke oprette fil"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Opdatering"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Ny opdatering tilgængelig"
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Din version"
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Der er en ny version af Zettlr tilgængelig. Læs venligst ændringer i den nye "
-"version nedenfor."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Henter din opdatering"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Ingen opdatering tilgængelig. Du har den seneste version."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klik for at starte opdatering"
-
-#: source/tmp/win-update/App.vue.ts:45
-#, fuzzy
-msgid "never"
-msgstr "aldrig"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Starter opdatering ..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Søg"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrer tags..."
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Nulstil"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Åbn projekt mappe"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Slet fil"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Tilføj"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Handlinger"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Slet fil"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Billede"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1870,10 +2896,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1935,49 +2957,31 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr støtter sig også til disse projekter:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Her kan du ændre på styles i Zettlr for at tilpasse det yderligere. "
-"<strong>Bemærk: Denne fil har forret over alle CSS-instrukser. Man bør "
-"aldrig ændre på elementernes størrelse, så kan app'en opføre sig uventet!</"
-"strong>Her kan du ændre på styles i Zettlr for at tilpasse det yderligere. "
-"<strong>Bemærk: Denne fil har forret over alle CSS-instrukser. Man bør "
-"aldrig ændre på elementernes størrelse, så kan app'en opføre sig uventet!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Omdøb snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Snippets lader dig definere genbrugelige stykker af tekst med variabler."
+"Snippets lader dig definere genbrugelige stykker af tekst med variabler."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+#, fuzzy
+msgid "Open snippets folder"
+msgstr "Åbn projekt mappe"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Gemmer ..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Kunne ikke gemme"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Custom CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Gemt!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1999,42 +3003,81 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Redigér standard indstillingerne for import og export her."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Gemt!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Omdøb snippet"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
-"Snippets lader dig definere genbrugelige stykker af tekst med variabler."
-"Snippets lader dig definere genbrugelige stykker af tekst med variabler."
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-#, fuzzy
-msgid "Open snippets folder"
-msgstr "Åbn projekt mappe"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "ord"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Her kan du ændre på styles i Zettlr for at tilpasse det yderligere. "
+"<strong>Bemærk: Denne fil har forret over alle CSS-instrukser. Man bør "
+"aldrig ændre på elementernes størrelse, så kan app'en opføre sig uventet!</"
+"strong>Her kan du ændre på styles i Zettlr for at tilpasse det yderligere. "
+"<strong>Bemærk: Denne fil har forret over alle CSS-instrukser. Man bør "
+"aldrig ændre på elementernes størrelse, så kan app'en opføre sig uventet!</"
+"strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "tegn"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Kunne ikke gemme"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Intet åbent dokument"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrer tags..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2060,76 +3103,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "Ord i sidste måned"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Relaterede filer"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "Dagligt gennemsnit"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Ingen relaterede filer"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "ord idag"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Vi kan ikke brænde dig, for du' allerede ild!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Du er tæt på at nå dit daglige gennemsnit"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Kom igang med at skrive så du kan overgå dit daglige gennemsnit"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Flere statistikker ..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Andre filer"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Åbn mappe"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Ingen andre filer"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referencer"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Der er ingen citationer i dette dokument"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Mærkat sky"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Eksporter..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Eksporter..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2139,8 +3222,8 @@ msgstr "Mapper"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Filer"
 
@@ -2154,10 +3237,26 @@ msgstr "Tegn"
 msgid "Words"
 msgstr "Ord"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Arbejdsområder"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Ingen åbne filer eller mapper"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Ingen resultater"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Intet bibliotek valgt"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Tom mappe"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2187,15 +3286,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Nulstil"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2256,13 +3346,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2472,131 +3555,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Vælg mål for skrivning..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Ingen resultater"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Intet bibliotek valgt"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Tom mappe"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Arbejdsområder"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Ingen åbne filer eller mapper"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "Ord i sidste måned"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "Dagligt gennemsnit"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "ord idag"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Vi kan ikke brænde dig, for du' allerede ild!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Du er tæt på at nå dit daglige gennemsnit"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Kom igang med at skrive så du kan overgå dit daglige gennemsnit"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Flere statistikker ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Eksporter..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Eksporter..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2619,11 +3580,6 @@ msgstr "Forbehold søgning til mappe"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Søg"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Ryd søgning"
@@ -2637,1088 +3593,138 @@ msgstr "Slå resultater til eller fra"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Mærkat sky"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "ord"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "tegn"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Intet åbent dokument"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Relaterede filer"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Ingen relaterede filer"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Tilføj"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Handlinger"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Slet fil"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Åbn projekt mappe"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Slet fil"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Slå Auto korrektur til"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Rendér citationer"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "januar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "februar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "marts"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "april"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "maj"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "juni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "juli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "august"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "september"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "oktober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "november"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "december"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Under det månedlige gennemsnit"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Over det månedlige gennemsnit"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Mere end det dobbelte af det månedlige gennemsnit"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Diagrammer"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Mønster brugt til at generere nye ID'er"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID regular expression"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Mønster brugt til at generere nye ID'er"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Af-link interne links"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Når der linkes mellem filer, tilføj da filnavnet ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "altid"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "kun når der linkes ved hjælp af ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "aldrig"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-#, fuzzy
-msgid "Link format"
-msgstr "Link begyndelse"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Start en søgning når Zettelkasten-links følges"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Opret automatisk ikke-eksisterende filer når interne links følges"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Erstat fil"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filtrer ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Editor input tilstand"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Find i mappe"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Skjul Overskrifts tegn"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Slå tabel editor til"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Nedton ikke-fokuserede linjer i distraktionsfri tilstand"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Ordoptælling"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Tæl tegn i stedet for ord (f.eks. på kinesisk)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Billeders maksimal vidde (i procent)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Billeders maksimal højde (i procent)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Andre filer"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Redigerings skriftstørrelse"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Indentér med det følgende antal mellemrum"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Indentér med det følgende antal mellemrum"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Acceptér mellemrum ved autofuldførelse"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Luk automatisk matchende karaktér par"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Tidsindstillinger"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Slået fra"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Følg styresystem"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Vis Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Åbn mappe"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Ingen andre filer"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalender"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referencer"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Der er ingen citationer i dette dokument"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Custom CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Custom CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Handlinger"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Vælg de sprog som du vil slå automatisk stavekontrol til for."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Bruger ordbog: Fjern ord ved at klikke på dem."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Ordbogs indlæg"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Søg efter indlæg ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Mørk tilstand"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Vis fil information"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Vis mapper over filer"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Sidste ændringstidspunkt"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Dato for filoprettelse"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Eksporter..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Nylige dokumenter"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Naturlig rækkefølge (10 efter 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII rækkefølge (2 efter 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Eksporterer til %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Brug den interne Pandoc til eksporter"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Fjern mærkater fra filer"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Fjern interne links fuldstændigt"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Af-link interne links"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Lav ingen ændringer på interne links"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Vis fil information"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Kommentar"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Mønster for nye filnavne"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Mønster for nye filnavne"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Spørg ikke efter filnavn, når der oprettes nye filer"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Brug nativ vindues udseende"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Brug nativ vindues udseende"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Vis programmet i notifikationsområdet"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Lad programmet køre i systembakken"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Redigerings skriftstørrelse"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "IFrame rendering hvid liste"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktivér \"vagthunds\" overvågning"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Tid før skrivning af en fil forventes færdigt (i ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Slet fil"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Aktiver debugging"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Aktiver debugging"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Orienter om betaudgivelser"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automatisk gem"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Sidste ændringstidspunkt"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Med det samme"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Efter en kort forsinkelse"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Undgå at åbne filer i nye faner hvis muligt"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Opdatering"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Ny opdatering tilgængelig"
+
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Din version"
+
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
+"Der er en ny version af Zettlr tilgængelig. Læs venligst ændringer i den nye "
+"version nedenfor."
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Ønsker du at autofuldfør indsætter citationer for dig?"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Henter din opdatering"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Ingen opdatering tilgængelig. Du har den seneste version."
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klik for at starte opdatering"
+
+#: source/tmp/win-update/App.vue.ts:45
 #, fuzzy
-msgid "Path to file"
-msgstr "Tilføj til fil"
+msgid "never"
+msgstr "aldrig"
 
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Starter opdatering ..."
 
 #~ msgid "Open Link"
 #~ msgstr "Åbn link"

--- a/static/lang/de-DE.po
+++ b/static/lang/de-DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2025-03-28 23:15+0100\n"
 "Last-Translator: Cornelius Wilkening <mail@cornelius-wilkening.de>\n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Die Zitationsdatenbank konnte nicht geladen werden"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Änderung in der Bibliothek entdeckt. Lade neu …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Lade Arbeitsverzeichnis %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,150 +81,6 @@ msgstr "Option %s muss mindestens %s Zeichen lang bzw. groß sein."
 msgid "Option %s is required."
 msgstr "Option %s ist erforderlich."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Zettlr anzeigen"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Beenden"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr "Kann nicht auf Updates prüfen"
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr "Beim Update-Check ist ein Fehler aufgetreten. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Update verfügbar"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Eine Update auf Version %s ist verfügbar!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-"Bitte aktualisiere bald. Du kannst das Update jetzt oder später durchführen."
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr "Updater öffnen"
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr "Nicht jetzt"
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Konnte nicht nach Updates suchen: Server Error (Statuscode: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Konnte nicht nach Updates suchen: Clientfehler (Statuscode: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Konnte nicht nach Updates suchen: Der Server hat eine Weiterleitung gesendet "
-"(Statuscode: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"Konnte nicht nach Updates suchen: Verbindung konnte nicht hergestellt werden"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Konnte nicht auf Aktualisierungen prüfen. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Konnte nicht nach Updates suchen: Server hat keine Daten gesendet"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr "Die SHA256 Prüfsummendatei scheint bei diesem Update zu fehlen."
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr "Kann SHA256 Prüfsummen nicht finden: %s"
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr "Kann keine Daten empfangen: Dateistream nicht gefunden."
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-"Kann die Integrität der Update-Datei nicht verifizieren. Bitte erneut "
-"versuchen oder manuell updaten."
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-"Die heruntergeladene Datei hat eine andere Prüfsumme als vom Server "
-"angegeben. Bitte erneut versuchen oder manuell updaten."
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-"Konnte Update nicht starten. Bitte erneut versuchen oder manuell updaten. "
-"Fehler: %s"
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Dokument zu lang"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Konnte Datei nicht erstellen"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Die Referenz mit dem Schlüssel %s scheint keine Anhänge zu haben."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Konnte Anhang nicht öffnen. Läuft Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -228,24 +98,101 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nein"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Ersetze Schlagwort “%s“ mit “%s“ in %s Dateien?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Wirklich löschen?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Möchtest du %s wirklich löschen?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Die Referenz mit dem Schlüssel %s scheint keine Anhänge zu haben."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Konnte Anhang nicht öffnen. Läuft Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Fehlerhaftes Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Import-Profil auswählen"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "Mehrere Profile können %s importieren. Bitte eines Auswählen."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Kann Projekt nicht exportieren"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"Für den Export sind keine Dateien ausgewählt. Bitte wähle Dateien in den "
+"Projekteinstellungen aus."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Fehlende Projektdateien"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Eine oder mehrere für den Export ausgewählte Dateien sind nicht mehr "
+"auffindbar. Sie könnten gelöscht oder umbenannt worden sein. Bitte "
+"verifiziere die zu exportierenden Dateien in den Projekteinstellungen."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Projekt \"%s\" wurde erfolgreich exportiert. Zum Anzeigen klicken."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Projektexport"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -302,51 +249,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Import fehlgeschlagen"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Kann Projekt nicht exportieren"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"Für den Export sind keine Dateien ausgewählt. Bitte wähle Dateien in den "
-"Projekteinstellungen aus."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Fehlende Projektdateien"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Eine oder mehrere für den Export ausgewählte Dateien sind nicht mehr "
-"auffindbar. Sie könnten gelöscht oder umbenannt worden sein. Bitte "
-"verifiziere die zu exportierenden Dateien in den Projekteinstellungen."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Projekt \"%s\" wurde erfolgreich exportiert. Zum Anzeigen klicken."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Projektexport"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Kann Verzeichnis nicht verschieben"
@@ -364,28 +266,49 @@ msgstr "Kann Datei oder Verzeichnis nicht verschieben"
 msgid "The file/directory %s already exists in target."
 msgstr "Die Datei bzw. das Verzeichnis %s existiert am Zielort bereits."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Unbenannt"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Der Name enthielt keine erlaubten Zeichen."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Konnte Verzeichnis nicht erstellen"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Das angefragte Verzeichnis wurde nicht gefunden."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Wirklich löschen?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Export fehlgeschlagen"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Möchtest du %s wirklich löschen?"
+msgid "An error occurred during export: %s"
+msgstr "Beim Export ist ein Fehler aufgetreten: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Exportieren nach"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Speichern"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Exportiere nach %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Ein Fehler ist beim Export aufgetreten: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -410,11 +333,13 @@ msgstr "Kann Arbeitsverzeichnis nicht öffnen"
 msgid "Cannot open workspace \"%s\"."
 msgstr "Kann Arbeitsverzeichnis “%s“ nicht öffnen."
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Kopie von %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Dokument zu lang"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -427,127 +352,34 @@ msgstr "Sprachdatei %s wurde erfolgreich importiert"
 msgid "Could not import language file %s!"
 msgstr "Die Sprachdatei %s konnte nicht importiert werden!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Export fehlgeschlagen"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Konnte Datei nicht erstellen"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Beim Export ist ein Fehler aufgetreten: %s"
+msgid "Copy of %s"
+msgstr "Kopie von %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Exportieren nach"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Unbenannt"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Speichern"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Konnte Verzeichnis nicht erstellen"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exportiere nach %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Ein Fehler ist beim Export aufgetreten: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Der Name enthielt keine erlaubten Zeichen."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Das angefragte Verzeichnis wurde nicht gefunden."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Import-Profil auswählen"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "Mehrere Profile können %s importieren. Bitte eines Auswählen."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Fehlerhaftes Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Datei ersetzen"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Datei %s wurde extern verändert. Soll die angezeigte Version mit den "
-"externen Änderungen ersetzt werden?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Lade externe Änderungen an der aktuellen Datei automatisch"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Datei überschreiben"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Die Date %s existiert bereits in diesem Verzeichnis. Überschreiben?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Datei öffnen"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Ungespeicherte Änderungen"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Die Datei enthält ungesicherte Änderungen. Änderungen jetzt speichern?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Datei speichern"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Projektverzeichnis öffnen"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Die Zitationsdatenbank konnte nicht geladen werden"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Änderung in der Bibliothek entdeckt. Lade neu …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Ersetze Schlagwort “%s“ mit “%s“ in %s Dateien?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -659,6 +491,12 @@ msgstr "Datei umbenennen"
 msgid "Delete file"
 msgstr "Datei löschen"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Beenden"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -677,15 +515,15 @@ msgstr "Wiederholen"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Ausschneiden"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -697,8 +535,8 @@ msgstr "Als HTML kopieren"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Einfügen"
 
@@ -710,8 +548,8 @@ msgstr "Ohne Format einfügen"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Alles auswählen"
 
@@ -955,10 +793,172 @@ msgstr "Sprechen anhalten"
 msgid "Bring All to Front"
 msgstr "Alle in den Vordergrund"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Projektverzeichnis öffnen"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Datei ersetzen"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Lade Arbeitsverzeichnis %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Datei %s wurde extern verändert. Soll die angezeigte Version mit den "
+"externen Änderungen ersetzt werden?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Lade externe Änderungen an der aktuellen Datei automatisch"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Ungespeicherte Änderungen"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Die Datei enthält ungesicherte Änderungen. Änderungen jetzt speichern?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Datei öffnen"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Datei speichern"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Datei überschreiben"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Die Date %s existiert bereits in diesem Verzeichnis. Überschreiben?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Zettlr anzeigen"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr "Kann nicht auf Updates prüfen"
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr "Beim Update-Check ist ein Fehler aufgetreten. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Update verfügbar"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Eine Update auf Version %s ist verfügbar!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+"Bitte aktualisiere bald. Du kannst das Update jetzt oder später durchführen."
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr "Updater öffnen"
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr "Nicht jetzt"
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Konnte nicht nach Updates suchen: Server Error (Statuscode: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Konnte nicht nach Updates suchen: Clientfehler (Statuscode: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Konnte nicht nach Updates suchen: Der Server hat eine Weiterleitung gesendet "
+"(Statuscode: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"Konnte nicht nach Updates suchen: Verbindung konnte nicht hergestellt werden"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Konnte nicht auf Aktualisierungen prüfen. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Konnte nicht nach Updates suchen: Server hat keine Daten gesendet"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr "Die SHA256 Prüfsummendatei scheint bei diesem Update zu fehlen."
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr "Kann SHA256 Prüfsummen nicht finden: %s"
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr "Kann keine Daten empfangen: Dateistream nicht gefunden."
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+"Kann die Integrität der Update-Datei nicht verifizieren. Bitte erneut "
+"versuchen oder manuell updaten."
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+"Die heruntergeladene Datei hat eine andere Prüfsumme als vom Server "
+"angegeben. Bitte erneut versuchen oder manuell updaten."
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
+"Konnte Update nicht starten. Bitte erneut versuchen oder manuell updaten. "
+"Fehler: %s"
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -972,16 +972,16 @@ msgstr "Änderungen verwerfen"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Die Datei enthält ungesicherte Änderungen. Speichern oder verwerfen?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "Datei auf der Festplatte verändert"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s wurde verändert"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -991,129 +991,1158 @@ msgstr ""
 "ungespeicherte Änderungen. Sollen die Änderungen im Editor erhalten werden, "
 "oder die Datei neu geladen werden?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Sollen die aktuellen Änderungen im Editor erhalten bleiben, oder die Datei "
 "neu geladen werden?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Änderungen im Editor behalten"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Datei neu laden"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Änderungen an Dateien automatisch laden, wenn der Editor keine "
 "ungespeicherten Änderungen enthält"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Konnte Datei nicht speichern"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Konnte Datei %s nicht speichern: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "AutoCorrect"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Typographische Anführungszeichen"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Normale Anführungszeichen"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Magic Quotes ausschalten"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Einfache Anführungszeichen"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Automatischer Textersatz"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Ersetze nur ganze Wörter"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+"AutoCorrect ersetzt niemals Teile von Wörtern, wenn diese Option aktiv ist"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Ersetzen"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "Mit"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filter"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Zeitplan"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Aus"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Folge Betriebssystem"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Ein"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Ende"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Theme"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Toolbar-Einstellungen"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr "Linker Bereich"
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr "Zeige “Einstellungen öffnen“"
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr "Zeige “Neue Datei“"
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr "Zeige “Vorherige Datei“"
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr "Zeige “Nächste Datei“"
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr "Mittlerer Bereich"
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr "Zeige “Lesbarkeitsmodus“"
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr "Zeige “Kommentar einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr "Zeige “Link einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr "Zeige “Bild einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr "Zeige “Aufgabenliste einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr "Zeige “Tabelle einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr "Zeige “Fußnote einfügen“"
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr "Rechter Bereich"
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr "Zeige Wort/Zeichenanzahl"
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr "Zeige Pomodoro-Uhr"
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Statusleiste"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr "Statusleiste einblenden"
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Benutzerdefiniertes CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Öffne CSS-Editor"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Import- und Export-Profile"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Importprofil-Editor öffnen"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Exportprofil-Editor öffnen"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Einstellungen für Export"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Nutze die interne Pandoc-Bibliothek für Exporte"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Entferne Schlagwörter aus den Dateien"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Interne Verlinkungen"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Entferne interne Links komplett"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Entferne interne Links"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Lasse interne Links unverändert"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Zielordner für exportierte Dateien"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Temporäres Verzeichnis"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Wie Dateiort"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Frage nach Ordner beim Export"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Achtung! Dateien im temporären Verzeichnis werden regelmäßig gelöscht. "
+"Exportieren zum Dateiort wird Dateien mit demselben Dateinamen überschreiben."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Benutzerdefinierte Export-Befehle"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Anzeigename"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Befehl"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Definiere benutzerdefinierte Befehle für den Exporter. Jeder Befehl erhält "
+"als erstes Argument die Datei oder den Projektordner, welche(r) exportiert "
+"werden soll."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Muster für neue Dateinamen"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Bestimme ein Muster für neue Dateinamen"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Verfügbare Variablen: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Dateinamen bei Dateierstellung nicht abfragen"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Erscheinungsbild"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Nutze natives Fensterdesign"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+"Nur verfügbar für Linux; das ist die Standardeinstellung für macOS und "
+"Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Aktiviere Fenster-vibrancy"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Nur verfügbar für macOS; macht den Fensterhintergrund undurchsichtig."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "App-Icon in der Menüleiste anzeigen"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "App in der Statusleiste anzeigen"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoom-Verhalten"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Skaliert die gesamte GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Ändert nur die Editor-Schriftgröße"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Anhänge"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "Dateinamenerweiterungen, die in den Anhängen angezeigt werden"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Whitelist für iFrames"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Watchdog-Polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr "Watchdog-Polling aktivieren"
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Wartezeit, bis das Schreiben einer Datei als beendet erachtet wird (in "
+"Millisekunden)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Dateien löschen"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+"Dateien unwiderruflich löschen, wenn Verschieben in den Papierkorb "
+"fehlschlägt"
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Entwicklermodus"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Entwicklermodus aktivieren"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta-Versionen"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Informiere mich über Beta-Releases"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Eingabemodus"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Der Eingabemodus bestimmt deine Interaktion mit dem Editor. Wir empfehlen "
+"die Einstellung “Normal“. Wähle “Vim“ oder “Emacs“ nur, wenn du weißt, was "
+"das bedeutet."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Schreibrichtung"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown-Darstellung"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Aktiviert die formatierte Live-Darstellung von verschiedenen Markdown-"
+"Elementen. Das versteckt Formatierungszeichen (wie **Text**) oder stellt "
+"Bilder direkt dar, anstelle ihres Links."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr "Zitate rendern"
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr "iframes rendern"
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr "Bilder rendern"
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr "Links rendern"
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr "Formeln rendern"
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr "Aufgaben rendern"
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Überschrift-Zeichen verstecken"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Hervorhebungen darstellen"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr "Formatierungszeichen für fett und kursiv"
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Fett"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursiv"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Überprüfe Markdown auf stilistische Probleme"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Table Editor"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"Der Table Editor ist ein interaktives Bedienelement für das Bearbeiten von "
+"Tabellen. Er stellt generelle Funktionalitäten bereit und formatiert "
+"Markdown-Quellcode."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Blende nicht fokussierte Zeilen im ablenkungsfreien Modus ab"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr "Werkzeugleiste im Ablenkungsfreien Modus ausblenden"
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Wortzähler"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Zeichen statt Wörter zählen (z.B. für Chinesisch)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Lesbarkeitsmodus"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algorithmus"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Bildgröße"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Maximale Bildbreite (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Maximale Bildhöhe (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Andere Einstellungen"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Schriftgröße"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Einrückungsgröße (Anzahl Leerzeichen)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Mit Tab-Zeichen einrücken"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr "Zeige Formatierungsleiste für Textauswahl"
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Leerzeichen anzeigen"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Empfehle Emojis während der Autovervollständigung"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Link-Vorschauen anzeigen"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Schließe Zeichenpaare automatisch"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Darstellungsmodus"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Dünn"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Erweitert"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Kombiniert"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"Der dünne Darstellungsmodus zeigt Ordner und Dateien separat an. Wähle einen "
+"Ordner aus, um seinen Inhalt in der Dateiliste anzuzeigen. Wechsle zwischen "
+"Dateiliste und Verzeichnisbaum durch Klicken auf Verzeichnisse oder den "
+"Pfeil-Button, der in der linken oberen Ecke der Dateiliste angezeigt wird."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Zusätzliche Dateiinformationen"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Zeige Ordner vor Dateien"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Anzeige von Dokumentnamen"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Nur Dateiname"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Titel falls vorhanden"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Erste Überschrift falls vorhanden"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Titel oder erste Überschrift falls vorhanden"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Zeige Markdown Dateierweiterungen an"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Zeitanzeige"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Letzter Bearbeitungszeitpunkt"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Dateierstellungszeitpunkt"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Sortierung"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Beim Sortieren von Dokumenten…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Nutze die Natürliche Reihenfolge (2 kommt vor 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Nutze die ASCII-Reihenfolge (2 kommt nach 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Zitationen"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Wie soll Autocomplete Zitate einfügen?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr "Zitationsdatenbank (CSL JSON oder BibTex)"
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Dateipfad"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr "CSL-Stil (optional)"
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten-IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Muster für Zettelkasten-IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Nutzt ECMAScript für Reguläre Ausdrücke"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Muster für neue IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Verfügbare Variablen: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Nur mit Dateinamen verlinken"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "Beim Verlinken von Dateien, füge den Dateititel ein …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Immer an"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Nur, wenn mit ID verlinkt wird"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Niemals"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Format für interne Links"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Du kannst optionale Titel zu internen Links hinzufügen, separiert durch "
+"einen vertikalen Strich. Hier kannst du bestimmen, was zuerst kommt."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Titel]]: Link zuerst (empfohlen)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Titel|Link]]: Titel zuerst"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Starte eine Suche beim Klick auf einen Zettelkasten-Link"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "Die Suche entspricht dem Inhalt zwischen den Klammern: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Erstelle nicht existierende Dateien automatisch beim Klick auf interne Links"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Das funktioniert nur, wenn der Ordner als Arbeitsverzeichnis in Zettlr "
+"geöffnet ist."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Pfad zu Ordner"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Snippets"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Öffne Vorlagen-Editor"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Strenge der Empfehlungen"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Standard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Akribisch"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Muttersprache"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Nicht eingestellt"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Bevorzugte Sprachvarianten"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"Klicke “Ordner auswählen…” oder füge einen relativen oder absoluten Pfad in "
+"das Feld ein."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Interpretiere Englisch als"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Interpretiere Deutsch als"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Interpretiere Portugiesisch als"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Interpretiere Katalanisch als"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageTool-Anbieter"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Benutzerdefinierter Server"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Benutzerdefinierter Server"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr ignoriert die “LanguageTool-Anbieter”-Einstellungen, wenn du hier "
+"Zugangsdaten eingibst."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool-Benutzername"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool API key"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Rechtschreibprüfung"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Aktiv"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Sprache"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Codeblock"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Wähle die Sprachen aus, für welche du die Rechtschreibprüfung einschalten "
+"möchtest."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Benutzerdefiniertes Wörterbuch. Entferne Wörter mittels Klick."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Wörterbucheintrag"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Nach Einträgen suchen …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Sprache"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automatisches Speichern"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Änderungen speichern"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Sofort"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Mit Verzögerung"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Standard-Bildordner"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Klicke “Ordner auswählen…” oder füge einen relativen oder absoluten Pfad in "
+"das Feld ein."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Verhalten"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Vermeide neue Tabs für Dokumente, falls möglich"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Updates"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Automatisch auf Updates überprüfen"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s Zeichen"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s Wörter"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr "Diese Datei ist Teil von Projekt \"%s”"
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Gehe zu Fußnotendefinition"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Keine Syntax"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Prüfpaneel öffnen"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Automatisch erkennen"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Lade Mermaid-Graph …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Konnte Graph nicht darstellen:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Lesbarkeitsmodus (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Bild konnte nicht geladen werden: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "Bild extern öffnen"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Rechtschreibfehler"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Datei %s existiert nicht."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Wörter"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Bearbeitet"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Öffnen…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
 msgstr "In neuem Tab öffnen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Eigenschaften"
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Generiere Linkvorschau…"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Datei duplizieren"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Dateipfad kopieren"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Bild"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Dateinamen kopieren"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Kommentar"
 
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Kein Fußnotentext gefunden."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Formel-Code kopieren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr "Link öffnen"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr "E-Mail-Adresse kopieren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr "Link kopieren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr "Link entfernen"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Bild in Zwischenablage kopieren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Bild öffnen"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "In Finder zeigen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "In Explorer zeigen"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Im Dateibrowser anzeigen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "In Dateibrowser zeigen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Keine Vorschläge"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Datei schließen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Zum Wörterbuch hinzufügen"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Verzeichnis umbenennen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursiv"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Verzeichnis löschen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Link einfügen"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Überprüfe Verzeichnis …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Ungeordnete Liste einfügen"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Projekt exportieren"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Numerierte Liste einfügen"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
-msgstr "Arbeitsverzeichnis schließen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
+msgstr "Aufgabenliste einfügen"
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
-msgstr "Tab schließen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
+msgstr "Blockzitat einfügen"
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Alle anderen Tabs schließen"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr "Tabelle einfügen"
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Alle Tabs schließen"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Tab lösen"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Tab anheften"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Dem Link mit Cmd/Strg+Klick folgen"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1521,325 +2550,319 @@ msgstr "Chinesisch (Taiwan)"
 msgid "Chinese"
 msgstr "Chinesisch"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Automatisch erkennen"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Deaktiviert"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s Wörter"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s Zeichen"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Prüfpaneel öffnen"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Rechtschreibfehler"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
-msgstr "Diese Datei ist Teil von Projekt \"%s”"
-
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Gehe zu Fußnotendefinition"
-
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Generiere Linkvorschau…"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Fett"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursiv"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Bild"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Kommentar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Codeblock"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Kein Fußnotentext gefunden."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Datei %s existiert nicht."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Wörter"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Bearbeitet"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Öffnen…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr "In neuem Tab öffnen"
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Keine Syntax"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Eigenschaften"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr "Link öffnen"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Datei duplizieren"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr "E-Mail-Adresse kopieren"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Dateipfad kopieren"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr "Link kopieren"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Dateinamen kopieren"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr "Link entfernen"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "In Explorer zeigen"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Bild in Zwischenablage kopieren"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "In Dateibrowser zeigen"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Bild öffnen"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Datei schließen"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Im Dateibrowser anzeigen"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Verzeichnis umbenennen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Keine Vorschläge"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Verzeichnis löschen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Zum Wörterbuch hinzufügen"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Überprüfe Verzeichnis …"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursiv"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Projekt exportieren"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Link einfügen"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
+msgstr "Arbeitsverzeichnis schließen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Ungeordnete Liste einfügen"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
+msgstr "Tab schließen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Numerierte Liste einfügen"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Alle anderen Tabs schließen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr "Aufgabenliste einfügen"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Alle Tabs schließen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr "Blockzitat einfügen"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Tab lösen"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr "Tabelle einfügen"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Tab anheften"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Formel-Code kopieren"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Lesbarkeitsmodus (%s)"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Charts"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Bild konnte nicht geladen werden: %s"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "FSAL-Statistiken"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "Bild extern öffnen"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Schreibstatistiken"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Lade Mermaid-Graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Januar"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Konnte Graph nicht darstellen:"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Februar"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Dem Link mit Cmd/Strg+Klick folgen"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "März"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Updates"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "April"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Neue Version verfügbar"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Mai"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Deine Version"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Juni"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Juli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "August"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "September"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Oktober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "November"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Dezember"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Unter dem monatlichen Durchschnitt"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Über dem monatlichen Durchschnitt"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Mehr als das Doppelte des monatlichen Durchschnitts"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Exportiere Projekt nach:"
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Aktiv"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Profil"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Transformation"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Dateien für den Exportvorgang"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Bitte wähle mindestens ein Profil aus, um das Projekt zu exportieren."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Projekt-Titel"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "CSL Stylesheet"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "LaTeX-Template"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "HTML-Template"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Entferne Datei aus Exportliste"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Füge Datei zur Exportliste hinzu"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Nach oben"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Nach unten"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Du hast keine Dateien für den Export bestimmt."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Eine neue Version von Zettlr steht zum Download bereit. Bitte lies die "
-"Änderungsdatei unten."
+"Einige Dateien wurden zum Export ausgewählt, sind aber nicht mehr auffindbar."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Lade Update herunter"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Allgemein"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Keine Updates verfügbar. Du nutzt die aktuelle Version."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Update starten"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "nie"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Zuletzt überprüft: %s"
+msgid "No results for \"%s\""
+msgstr "Keine Ergebnisse für “%s“"
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Aktualisiere …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Suchen"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Farbe zuweisen"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Dateimanager"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Farbe entfernen"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Editor"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Schlagwort"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Farbe"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Import und Export"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Anzahl"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Erweitert"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Kurzbeschreibung"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Suche: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
-"In diesem Dialog kannst du Schlagwörter Farben zuweisen. Wenn ein "
-"Schlagwortin einer Datei enthalten ist, erhält die Datei an verschiedenen "
-"Stelleneinen farblichen Marker. Die Beschreibung wird beim Hovern angezeigt."
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Schlagworte filtern…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Ordner auswählen…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr "Neues Schlagwort"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Datei auswählen…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr "Umbenennen"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Neu"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr "Umbenennen…"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Aktionen"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Löschen"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Bild von Zwischenablage einfügen"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Bildgröße"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1857,10 +2880,6 @@ msgstr "Dateiname"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Ein einzigartiger Dateiname"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Lade…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1928,46 +2947,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr nutzt auch die folgenden Projekte:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Hier kannst du verschiedene Stile von Zettlr überschreiben und damit die App "
-"noch weiter anpassen. <strong>Achtung: Diese Datei überschreibt sämtliche "
-"CSS-Direktiven! Ändere daher niemals die Geometrie von Elementen, "
-"anderenfalls könnte Zettlr unerwartetes Verhalten zeigen!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Snippet umbenennen"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Snippets sind wiederverwendbare Textbausteine mit Variablen."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Öffne Snippets-Ordner"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Speichere …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Fehler beim Speichern"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Exportieren"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Importieren"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Benutzerdefiniertes CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Gespeichert!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1993,39 +2994,81 @@ msgstr "Öffne Profilordner"
 msgid "Edit the default settings for imports or exports here."
 msgstr "Bearbeite die Standardeinstellungen für Importe oder Exporte hier."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Gespeichert!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Exportieren"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Snippet umbenennen"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Importieren"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Snippets sind wiederverwendbare Textbausteine mit Variablen."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Hier kannst du verschiedene Stile von Zettlr überschreiben und damit die App "
+"noch weiter anpassen. <strong>Achtung: Diese Datei überschreibt sämtliche "
+"CSS-Direktiven! Ändere daher niemals die Geometrie von Elementen, "
+"anderenfalls könnte Zettlr unerwartetes Verhalten zeigen!</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Öffne Snippets-Ordner"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Fehler beim Speichern"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "Wörter"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Farbe zuweisen"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "Zeichen"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Farbe entfernen"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Kein offenes Dokument"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Schlagwort"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Farbe"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Anzahl"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Kurzbeschreibung"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"In diesem Dialog kannst du Schlagwörter Farben zuweisen. Wenn ein "
+"Schlagwortin einer Datei enthalten ist, erhält die Datei an verschiedenen "
+"Stelleneinen farblichen Marker. Die Beschreibung wird beim Hovern angezeigt."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Schlagworte filtern…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr "Neues Schlagwort"
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr "Umbenennen"
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr "Umbenennen…"
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2051,76 +3094,114 @@ msgstr "Ton"
 msgid "Volume"
 msgstr "Lautstärke"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr "Inhaltsverzeichnis"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "Wörter (Monat)"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Verwandte Dateien"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "durchschnittlich"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Keine verwandten Dateien"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "Wörter heute"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Verwandt aufgrund gegenseitiger Verlinkung."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Weiter so!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Verwandt aufgrund ausgehendem Link."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Fast geschafft!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Verwandt aufgrund eingehendem Link."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Schreibe, um deinen Durchschnitt zu übertreffen."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Mehr Statistiken …"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Verwandt basierend auf %s gemeinsamen Schlagworten: %s"
+msgid "%s selected"
+msgstr "%s ausgewählt"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Andere Dateien"
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s Selektionen"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Öffne Verzeichnis"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr "In allen Dateien suchen"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Keine anderen Dateien"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr "Schreibstatistiken anzeigen"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr "Schlagwortwolke anzeigen"
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr "Einstellungen öffnen"
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr "Aktuelle Datei exportieren"
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Lesbarkeitsmodus umschalten"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr "Kommentar einfügen"
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr "Bild einfügen"
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr "Fußnote einfügen"
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr "Pomodoro-Uhr"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr "Temporärer Ordner"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
 msgstr "Aktueller Ordner"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Literatur"
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr "Ordner auswählen"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "In diesem Dokument wurden keine Zitationen gefunden."
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Exportiere…"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
-msgstr "circa %s Wörter"
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exportieren"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Name"
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "Befehl"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Schlagwortwolke"
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr "Filtern…"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2130,8 +3211,8 @@ msgstr "Verzeichnisse"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Dateien"
 
@@ -2145,10 +3226,26 @@ msgstr "Zeichen"
 msgid "Words"
 msgstr "Wörter"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr "Filtern…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Arbeitsverzeichnisse"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Keine offenen Dateien oder Ordner"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Keine Ergebnisse"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Kein Verzeichnis ausgewählt"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Leeres Verzeichnis"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2178,15 +3275,6 @@ msgstr "aufsteigend"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr "absteigend"
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Zurücksetzen"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2247,13 +3335,6 @@ msgstr "Auge"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr "Auge (gestrichen)"
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2463,130 +3544,10 @@ msgstr "CD/DVD"
 msgid "Set writing target…"
 msgstr "Schreibziel setzen…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Keine Ergebnisse"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Kein Verzeichnis ausgewählt"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Leeres Verzeichnis"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Arbeitsverzeichnisse"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Keine offenen Dateien oder Ordner"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "Wörter (Monat)"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "durchschnittlich"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "Wörter heute"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Weiter so!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Fast geschafft!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Schreibe, um deinen Durchschnitt zu übertreffen."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Mehr Statistiken …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s ausgewählt"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s Selektionen"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr "In allen Dateien suchen"
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr "Schreibstatistiken anzeigen"
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr "Schlagwortwolke anzeigen"
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr "Einstellungen öffnen"
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr "Aktuelle Datei exportieren"
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Lesbarkeitsmodus umschalten"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr "Kommentar einfügen"
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr "Bild einfügen"
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr "Fußnote einfügen"
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr "Pomodoro-Uhr"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr "Temporärer Ordner"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr "Aktueller Ordner"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr "Ordner auswählen"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Exportiere…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exportieren"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "Befehl"
+msgid "Table size: %s &times; %s"
+msgstr "Tabellengröße: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2608,11 +3569,6 @@ msgstr "Begrenze Suche auf ein Verzeichnis"
 msgid "Choose directory…"
 msgstr "Verzeichnis wählen…"
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Suchen"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Neue Suche"
@@ -2626,1087 +3582,137 @@ msgstr "Ergebnisse umschalten"
 msgid "%s matches across %s files"
 msgstr "%s Treffer in %s Dateien"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Name"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Schlagwortwolke"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "Wörter"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "Zeichen"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Kein offenes Dokument"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Verwandte Dateien"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Keine verwandten Dateien"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Verwandt aufgrund gegenseitiger Verlinkung."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Verwandt aufgrund ausgehendem Link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Verwandt aufgrund eingehendem Link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Tabellengröße: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Verwandt basierend auf %s gemeinsamen Schlagworten: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Neu"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Andere Dateien"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Aktionen"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Öffne Verzeichnis"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Löschen"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Keine anderen Dateien"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Ordner auswählen…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Aktueller Ordner"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Datei auswählen…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr "Inhaltsverzeichnis"
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Exportiere Projekt nach:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Literatur"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Aktiv"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "In diesem Dokument wurden keine Zitationen gefunden."
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Profil"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Transformation"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Dateien für den Exportvorgang"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Bitte wähle mindestens ein Profil aus, um das Projekt zu exportieren."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Projekt-Titel"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "CSL Stylesheet"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "LaTeX-Template"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "HTML-Template"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Entferne Datei aus Exportliste"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Füge Datei zur Exportliste hinzu"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Nach oben"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Nach unten"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Du hast keine Dateien für den Export bestimmt."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-"Einige Dateien wurden zum Export ausgewählt, sind aber nicht mehr auffindbar."
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Allgemein"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "Keine Ergebnisse für “%s“"
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Erscheinungsbild"
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Dateimanager"
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Editor"
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Rechtschreibprüfung"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "AutoCorrect"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Zitationen"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Import und Export"
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Erweitert"
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr "Suche: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Januar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Februar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "März"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "April"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Mai"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Juni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Juli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "August"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "September"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Oktober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "November"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Dezember"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Unter dem monatlichen Durchschnitt"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Über dem monatlichen Durchschnitt"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Mehr als das Doppelte des monatlichen Durchschnitts"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Charts"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "FSAL-Statistiken"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Schreibstatistiken"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten-IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Muster für Zettelkasten-IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Nutzt ECMAScript für Reguläre Ausdrücke"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Muster für neue IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Verfügbare Variablen: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Interne Verlinkungen"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Nur mit Dateinamen verlinken"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "Beim Verlinken von Dateien, füge den Dateititel ein …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Immer an"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Nur, wenn mit ID verlinkt wird"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Niemals"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Format für interne Links"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Du kannst optionale Titel zu internen Links hinzufügen, separiert durch "
-"einen vertikalen Strich. Hier kannst du bestimmen, was zuerst kommt."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Titel]]: Link zuerst (empfohlen)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Titel|Link]]: Titel zuerst"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Starte eine Suche beim Klick auf einen Zettelkasten-Link"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "Die Suche entspricht dem Inhalt zwischen den Klammern: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Erstelle nicht existierende Dateien automatisch beim Klick auf interne Links"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Das funktioniert nur, wenn der Ordner als Arbeitsverzeichnis in Zettlr "
-"geöffnet ist."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Pfad zu Ordner"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Typographische Anführungszeichen"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Normale Anführungszeichen"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Magic Quotes ausschalten"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Einfache Anführungszeichen"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Automatischer Textersatz"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Ersetze nur ganze Wörter"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-"AutoCorrect ersetzt niemals Teile von Wörtern, wenn diese Option aktiv ist"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Ersetzen"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "Mit"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filter"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Eingabemodus"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Der Eingabemodus bestimmt deine Interaktion mit dem Editor. Wir empfehlen "
-"die Einstellung “Normal“. Wähle “Vim“ oder “Emacs“ nur, wenn du weißt, was "
-"das bedeutet."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Schreibrichtung"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown-Darstellung"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Aktiviert die formatierte Live-Darstellung von verschiedenen Markdown-"
-"Elementen. Das versteckt Formatierungszeichen (wie **Text**) oder stellt "
-"Bilder direkt dar, anstelle ihres Links."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr "Zitate rendern"
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr "iframes rendern"
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr "Bilder rendern"
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr "Links rendern"
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr "Formeln rendern"
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr "Aufgaben rendern"
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Überschrift-Zeichen verstecken"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Hervorhebungen darstellen"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr "Formatierungszeichen für fett und kursiv"
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Überprüfe Markdown auf stilistische Probleme"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Table Editor"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"Der Table Editor ist ein interaktives Bedienelement für das Bearbeiten von "
-"Tabellen. Er stellt generelle Funktionalitäten bereit und formatiert "
-"Markdown-Quellcode."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Blende nicht fokussierte Zeilen im ablenkungsfreien Modus ab"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr "Werkzeugleiste im Ablenkungsfreien Modus ausblenden"
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Wortzähler"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Zeichen statt Wörter zählen (z.B. für Chinesisch)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Lesbarkeitsmodus"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algorithmus"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Maximale Bildbreite (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Maximale Bildhöhe (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Andere Einstellungen"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Schriftgröße"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Einrückungsgröße (Anzahl Leerzeichen)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Mit Tab-Zeichen einrücken"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr "Zeige Formatierungsleiste für Textauswahl"
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Leerzeichen anzeigen"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Empfehle Emojis während der Autovervollständigung"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Link-Vorschauen anzeigen"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Schließe Zeichenpaare automatisch"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Zeitplan"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Aus"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Folge Betriebssystem"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Ein"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Ende"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Theme"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Toolbar-Einstellungen"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr "Linker Bereich"
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr "Zeige “Einstellungen öffnen“"
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr "Zeige “Neue Datei“"
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr "Zeige “Vorherige Datei“"
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr "Zeige “Nächste Datei“"
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr "Mittlerer Bereich"
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr "Zeige “Lesbarkeitsmodus“"
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr "Zeige “Kommentar einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr "Zeige “Link einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr "Zeige “Bild einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr "Zeige “Aufgabenliste einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr "Zeige “Tabelle einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr "Zeige “Fußnote einfügen“"
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr "Rechter Bereich"
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr "Zeige Wort/Zeichenanzahl"
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr "Zeige Pomodoro-Uhr"
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Statusleiste"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr "Statusleiste einblenden"
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Öffne CSS-Editor"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Strenge der Empfehlungen"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Standard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Akribisch"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Muttersprache"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Nicht eingestellt"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Bevorzugte Sprachvarianten"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"Klicke “Ordner auswählen…” oder füge einen relativen oder absoluten Pfad in "
-"das Feld ein."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Interpretiere Englisch als"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Interpretiere Deutsch als"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Interpretiere Portugiesisch als"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Interpretiere Katalanisch als"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageTool-Anbieter"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Benutzerdefinierter Server"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Benutzerdefinierter Server"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr ignoriert die “LanguageTool-Anbieter”-Einstellungen, wenn du hier "
-"Zugangsdaten eingibst."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool-Benutzername"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool API key"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Aktiv"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Sprache"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Wähle die Sprachen aus, für welche du die Rechtschreibprüfung einschalten "
-"möchtest."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Benutzerdefiniertes Wörterbuch. Entferne Wörter mittels Klick."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Wörterbucheintrag"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Nach Einträgen suchen …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Darstellungsmodus"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Dünn"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Erweitert"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Kombiniert"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"Der dünne Darstellungsmodus zeigt Ordner und Dateien separat an. Wähle einen "
-"Ordner aus, um seinen Inhalt in der Dateiliste anzuzeigen. Wechsle zwischen "
-"Dateiliste und Verzeichnisbaum durch Klicken auf Verzeichnisse oder den "
-"Pfeil-Button, der in der linken oberen Ecke der Dateiliste angezeigt wird."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Zusätzliche Dateiinformationen"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Zeige Ordner vor Dateien"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Anzeige von Dokumentnamen"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Nur Dateiname"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Titel falls vorhanden"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Erste Überschrift falls vorhanden"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Titel oder erste Überschrift falls vorhanden"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Zeige Markdown Dateierweiterungen an"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Zeitanzeige"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Letzter Bearbeitungszeitpunkt"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Dateierstellungszeitpunkt"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Sortierung"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Beim Sortieren von Dokumenten…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Nutze die Natürliche Reihenfolge (2 kommt vor 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Nutze die ASCII-Reihenfolge (2 kommt nach 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Import- und Export-Profile"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Importprofil-Editor öffnen"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Exportprofil-Editor öffnen"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Einstellungen für Export"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Nutze die interne Pandoc-Bibliothek für Exporte"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Entferne Schlagwörter aus den Dateien"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Entferne interne Links komplett"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Entferne interne Links"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Lasse interne Links unverändert"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Zielordner für exportierte Dateien"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Temporäres Verzeichnis"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Wie Dateiort"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Frage nach Ordner beim Export"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Achtung! Dateien im temporären Verzeichnis werden regelmäßig gelöscht. "
-"Exportieren zum Dateiort wird Dateien mit demselben Dateinamen überschreiben."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Benutzerdefinierte Export-Befehle"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Anzeigename"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Befehl"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Definiere benutzerdefinierte Befehle für den Exporter. Jeder Befehl erhält "
-"als erstes Argument die Datei oder den Projektordner, welche(r) exportiert "
-"werden soll."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Muster für neue Dateinamen"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Bestimme ein Muster für neue Dateinamen"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Verfügbare Variablen: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Dateinamen bei Dateierstellung nicht abfragen"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Nutze natives Fensterdesign"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-"Nur verfügbar für Linux; das ist die Standardeinstellung für macOS und "
-"Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Aktiviere Fenster-vibrancy"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Nur verfügbar für macOS; macht den Fensterhintergrund undurchsichtig."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "App-Icon in der Menüleiste anzeigen"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "App in der Statusleiste anzeigen"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoom-Verhalten"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Skaliert die gesamte GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Ändert nur die Editor-Schriftgröße"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Anhänge"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "Dateinamenerweiterungen, die in den Anhängen angezeigt werden"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Whitelist für iFrames"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Watchdog-Polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr "Watchdog-Polling aktivieren"
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Wartezeit, bis das Schreiben einer Datei als beendet erachtet wird (in "
-"Millisekunden)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Dateien löschen"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-"Dateien unwiderruflich löschen, wenn Verschieben in den Papierkorb "
-"fehlschlägt"
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Entwicklermodus"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Entwicklermodus aktivieren"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta-Versionen"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Informiere mich über Beta-Releases"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Öffne Vorlagen-Editor"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Sprache"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automatisches Speichern"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Änderungen speichern"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Sofort"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Mit Verzögerung"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Standard-Bildordner"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Klicke “Ordner auswählen…” oder füge einen relativen oder absoluten Pfad in "
-"das Feld ein."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Verhalten"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Vermeide neue Tabs für Dokumente, falls möglich"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+msgid "circa %s words"
+msgstr "circa %s Wörter"
+
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Lade…"
+
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Updates"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Automatisch auf Updates überprüfen"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Neue Version verfügbar"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Wie soll Autocomplete Zitate einfügen?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Deine Version"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr "Zitationsdatenbank (CSL JSON oder BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Eine neue Version von Zettlr steht zum Download bereit. Bitte lies die "
+"Änderungsdatei unten."
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Dateipfad"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Lade Update herunter"
 
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr "CSL-Stil (optional)"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Keine Updates verfügbar. Du nutzt die aktuelle Version."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Update starten"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "nie"
+
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
+msgstr "Zuletzt überprüft: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Aktualisiere …"
 
 #~ msgid "Open Link"
 #~ msgstr "Link öffnen"

--- a/static/lang/en-GB.po
+++ b/static/lang/en-GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-03-18 08:35+0100\n"
 "Last-Translator: Hendrik Erz <info@zettlr.com>\n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "The citation database could not be loaded"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Changes to the library file detected. Reloading …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Loading workspace %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,141 +81,6 @@ msgstr "Option %s must be at least %s (characters long)."
 msgid "Option %s is required."
 msgstr "Option %s is required."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Show Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Quit"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "An update to version %s is available!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Could not check for updates: Server Error (Status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Could not check for updates: Client Error (Status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Could not check for updates: Could not establish connection"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Could not check for updates. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Could not check for updates: Server hasn't sent any data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Document too long"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Could not create file"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "The reference with key %s does not appear to have attachments."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Could not open attachment. Is Zotero running?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +98,96 @@ msgstr "Yes"
 msgid "No"
 msgstr "No"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Replace tag “%s” with “%s” across %s files?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancel"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Really delete?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Do you really want to remove %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "The reference with key %s does not appear to have attachments."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Could not open attachment. Is Zotero running?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Malformed Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Select import profile"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "There are multiple profiles that can import %s. Please choose one."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Cannot export project"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Project \"%s\" successfully exported. Click to show."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Project Export"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -292,46 +243,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Import failed"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Cannot export project"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Project \"%s\" successfully exported. Click to show."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Project Export"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Cannot move directory"
@@ -349,28 +260,49 @@ msgstr "Cannot move directory or file"
 msgid "The file/directory %s already exists in target."
 msgstr "The file/directory %s already exists in target."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Untitled"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "The provided name did not contain any allowed letters."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Could not create directory"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "The requested directory was not found."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Really delete?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Export failed"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Do you really want to remove %s?"
+msgid "An error occurred during export: %s"
+msgstr "An error occurred during export: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Choose export destination"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Save"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Exporting to %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "An error occurred on export: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -395,11 +327,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Document too long"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -412,125 +346,34 @@ msgstr "Language file imported: %s"
 msgid "Could not import language file %s!"
 msgstr "Could not import language file %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Export failed"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Could not create file"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "An error occurred during export: %s"
+msgid "Copy of %s"
+msgstr "Copy of %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Choose export destination"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Untitled"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Save"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Could not create directory"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exporting to %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "An error occurred on export: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "The provided name did not contain any allowed letters."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "The requested directory was not found."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Select import profile"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "There are multiple profiles that can import %s. Please choose one."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Malformed Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Always load remote changes to the current file"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Overwrite existing file"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "The file %s already exists in this directory. Overwrite?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Open file"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Unsaved changes"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "There are unsaved changes. Do you want to save them first?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Save file"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Open project folder"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "The citation database could not be loaded"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Replace tag “%s” with “%s” across %s files?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -642,6 +485,12 @@ msgstr "Rename file"
 msgid "Delete file"
 msgstr "Delete file"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Quit"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -660,15 +509,15 @@ msgstr "Redo"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Cut"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copy"
 
@@ -680,8 +529,8 @@ msgstr "Copy as HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Paste"
 
@@ -693,8 +542,8 @@ msgstr "Paste without style"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Select all"
 
@@ -937,10 +786,161 @@ msgstr "Stop speaking"
 msgid "Bring All to Front"
 msgstr "Bring All to Front"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Open project folder"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Always load remote changes to the current file"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Unsaved changes"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "There are unsaved changes. Do you want to save them first?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Open file"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Save file"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Overwrite existing file"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "The file %s already exists in this directory. Overwrite?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Show Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "An update to version %s is available!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Could not check for updates: Server Error (Status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Could not check for updates: Client Error (Status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Could not check for updates: Could not establish connection"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Could not check for updates. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Could not check for updates: Server hasn't sent any data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -954,16 +954,16 @@ msgstr "Discard changes"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "There are unsaved changes. Do you want to save or discard them?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "File changed on disk"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s changed on disk"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -972,127 +972,1143 @@ msgstr ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Do you want to keep the current editor contents or load the file from disk?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Keep editor contents"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Load changes from disk"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Autocorrect"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Smart quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Double Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Disable Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Single Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Text-replacement patterns"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Match whole words"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "When checked, AutoCorrect will never replace parts of words"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Replace"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "With"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filter"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Schedule"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Off"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Follow Operating System"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "On"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "End"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Theme"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Toolbar options"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Properties"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicate file"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copy path"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copy filename"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Status bar"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Custom CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Open CSS editor"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Import and export profiles"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Open import profiles editor"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Open export profiles editor"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Export settings"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Use Zettlr's internal Pandoc for exports"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Remove tags from files when exporting"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Internal links"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Remove internal links completely"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Unlink internal links"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Don't touch internal links"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Destination folder for exported files"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Temporary folder"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Same as file location"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Ask for folder when exporting"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Custom export commands"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Display name"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Command"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Pattern for new file names"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Define a pattern for new file names"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Available variables: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Do not prompt for filename when creating new files"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Appearance"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Use native window appearance"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "Only available on Linux; this is the default for macOS and Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Enable window vibrancy"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Only available on macOS; makes the window background opaque."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Show app in the notification area"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Leave app running in the notification area"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoom behavior"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Resizes the whole GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Changes the editor font size"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Attachments sidebar"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "File extensions to be visible in the Attachments sidebar"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Iframe rendering whitelist"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Time to wait before writing a file is considered done (in ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Deleting items"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Debug mode"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Enable debug mode"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta releases"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notify me about beta releases"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Input mode"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Writing direction"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown rendering"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Hide heading characters"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Render emphasis"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Bold"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Italics"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Check Markdown for style issues"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Table Editor"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Mute non-focused lines in distraction-free mode"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Word counter"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Count characters instead of words (e.g., for Chinese)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Readability mode"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algorithm"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Image size"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Maximum width of images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Maximum height of images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Other settings"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Font size"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Indentation size (number of spaces)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Indent using tabs instead of spaces"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Suggest emojis during autocompletion"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Show link previews"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Automatically close matching character pairs"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Display mode"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Thin"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Expanded"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Combined"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Show file information"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Show folders above files"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Markdown document name display"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Filename only"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Title if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "First heading level 1 if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Title or first heading level 1 if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Display Markdown file extensions"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Time display"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Last modification time"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "File creation time"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Sorting"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "When sorting documents…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Use natural order (2 comes before 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Use ASCII order (2 comes after 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Citations"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "How would you like autocomplete to insert your citations?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Path to file"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Pattern for Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Uses ECMAScript regular expressions"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Pattern used to generate new IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Available Variables: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Link with filename only"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "When linking files, add the document name …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Always"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Only when linking using the ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Never"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Start a full-text search when following internal links"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "The search string will match the content between the brackets: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr "For this to work, the folder must be open as a Workspace in Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Path to folder"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Snippets"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Open snippets editor"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Strictness"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Standard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Picky"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Mother language"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Not set"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageTool Provider"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Custom server"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Custom server address"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool Username"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool API key"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Spellchecking"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Active"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Language"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Code"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Select the languages for which you want to enable automatic spell checking."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "User dictionary. Remove words by clicking them."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Dictionary entry"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Search for entries …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Application language"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Autosave"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Save modifications"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Immediately"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "After a short delay"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Default image folder"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Behaviour"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Avoid opening files in new tabs if possible"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Updates"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Automatically check for updates"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s characters"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s words"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Go to footnote reference"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "No highlighting"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Open diagnostics panel"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Disabled"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Custom"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Detect automatically"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Rendering mermaid graph …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Could not render Graph:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Readability mode (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Image not found: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Spelling mistake"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "File %s does not exist."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Word count"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modified"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Open…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Open in a new tab"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Image"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comment"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "No footnote text found."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copy equation code"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copy image to clipboard"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Open image"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Reveal in Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Open in File Browser"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "No suggestions"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Close file"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Add to dictionary"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Rename directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Italic"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Delete directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Insert link"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Check for directory …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Insert unordered list"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Export Project"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Insert numbered list"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Close other tabs"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Close all tabs"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Unpin tab"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Pin tab"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-click to follow this link"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1500,322 +2516,318 @@ msgstr "Chinese (Taiwan)"
 msgid "Chinese"
 msgstr "Chinese"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Disabled"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Custom"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s words"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s characters"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Open diagnostics panel"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Spelling mistake"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Properties"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicate file"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copy path"
+
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copy filename"
+
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Reveal in Explorer"
+
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Reveal in File Browser"
+
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Close file"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Rename directory"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Delete directory"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Check for directory …"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Export Project"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Bold"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Italics"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Image"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comment"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Code"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "No footnote text found."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "File %s does not exist."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Word count"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modified"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Open…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Open in a new tab"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "No highlighting"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Close other tabs"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Close all tabs"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Unpin tab"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Pin tab"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendar"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Charts"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "January"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "February"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "March"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "April"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "May"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "June"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "July"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "August"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "September"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "October"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "November"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "December"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Below the monthly average"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Over the monthly average"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "More than twice the monthly average"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copy image to clipboard"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Open image"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Open in File Browser"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "No suggestions"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Add to dictionary"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Italic"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Insert link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Insert unordered list"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Insert numbered list"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copy equation code"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Readability mode (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Image not found: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Could not render Graph:"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "New update available"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Your version"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Downloading your update"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "No update available. You have the most recent version."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Click to start update"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Search"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Count"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filter tags…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Select folder…"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Select file…"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Add"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Actions"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Delete"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Image size"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1832,10 +2844,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1902,46 +2910,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr also makes use of these projects:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Rename snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Snippets let you define reusable pieces of text with variables."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Saving …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Saving failed"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Custom CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Saved!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1967,39 +2957,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Edit the default settings for imports or exports here."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Saved!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Rename snippet"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Snippets let you define reusable pieces of text with variables."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "words"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "characters"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "No open document"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Saving failed"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Count"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filter tags…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2025,76 +3054,114 @@ msgstr "Sound Effect"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "words last month"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "daily average"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "No related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "words today"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "This relation is based on a bidirectional link."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 You're on fire!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "This relation is based on an outbound link."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 You're close to hitting your daily average!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "This relation is based on a backlink."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Get writing to surpass your daily average."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "More statistics …"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "This relation is based on %s shared tags: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Other files"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Open directory"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "No other files"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "References"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "There are no citations in this document."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Tag Cloud"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Exporting…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Export"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "command"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2104,8 +3171,8 @@ msgstr "Directories"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Files"
 
@@ -2119,10 +3186,26 @@ msgstr "Characters"
 msgid "Words"
 msgstr "Words"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
 msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "No results"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "No directory selected"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Empty directory"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2152,15 +3235,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2221,13 +3295,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendar"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2437,130 +3504,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Set writing target…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "No results"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "No directory selected"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Empty directory"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "words last month"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "daily average"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "words today"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 You're on fire!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 You're close to hitting your daily average!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Get writing to surpass your daily average."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "More statistics …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Exporting…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Export"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "command"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2582,11 +3529,6 @@ msgstr "Restrict search to directory"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Search"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Clear search"
@@ -2600,1073 +3542,137 @@ msgstr "Toggle results"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Name"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Tag Cloud"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "words"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "characters"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "No open document"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Related files"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "No related files"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "This relation is based on a bidirectional link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "This relation is based on an outbound link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "This relation is based on a backlink."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "This relation is based on %s shared tags: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Other files"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Open directory"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "No other files"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Add"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Actions"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Delete"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Select folder…"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Select file…"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "References"
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "There are no citations in this document."
 
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Appearance"
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Updater"
+
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "New update available"
+
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Your version"
+
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Downloading your update"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "No update available. You have the most recent version."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Click to start update"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Spellchecking"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Autocorrect"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Citations"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "January"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "February"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "March"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "April"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "May"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "June"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "July"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "August"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "September"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "October"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "November"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "December"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Below the monthly average"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Over the monthly average"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "More than twice the monthly average"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Charts"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Pattern for Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Uses ECMAScript regular expressions"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Pattern used to generate new IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Available Variables: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Link with filename only"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "When linking files, add the document name …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Always"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Only when linking using the ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Never"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Start a full-text search when following internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "The search string will match the content between the brackets: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr "For this to work, the folder must be open as a Workspace in Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Path to folder"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Smart quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Double Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Disable Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Single Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Text-replacement patterns"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Match whole words"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "When checked, AutoCorrect will never replace parts of words"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Replace"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "With"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filter"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Input mode"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Writing direction"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown rendering"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Hide heading characters"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Render emphasis"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Check Markdown for style issues"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Table Editor"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Mute non-focused lines in distraction-free mode"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Word counter"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Count characters instead of words (e.g., for Chinese)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Readability mode"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algorithm"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Maximum width of images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Maximum height of images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Other settings"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Font size"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Indentation size (number of spaces)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Indent using tabs instead of spaces"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Suggest emojis during autocompletion"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Show link previews"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Automatically close matching character pairs"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Schedule"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Off"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Follow Operating System"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "On"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "End"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Theme"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Toolbar options"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Status bar"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Open CSS editor"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Strictness"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Standard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Picky"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Mother language"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Not set"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageTool Provider"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Custom server"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Custom server address"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool Username"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool API key"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Active"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Language"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Select the languages for which you want to enable automatic spell checking."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "User dictionary. Remove words by clicking them."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Dictionary entry"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Search for entries …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Display mode"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Thin"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Expanded"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Combined"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Show file information"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Show folders above files"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Markdown document name display"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Filename only"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Title if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "First heading level 1 if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Title or first heading level 1 if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Display Markdown file extensions"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Time display"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Last modification time"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "File creation time"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Sorting"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "When sorting documents…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Use natural order (2 comes before 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Use ASCII order (2 comes after 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Import and export profiles"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Open import profiles editor"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Open export profiles editor"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Export settings"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Use Zettlr's internal Pandoc for exports"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Remove tags from files when exporting"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Remove internal links completely"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Unlink internal links"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Don't touch internal links"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Destination folder for exported files"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Temporary folder"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Same as file location"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Ask for folder when exporting"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Custom export commands"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Display name"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Command"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Pattern for new file names"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Define a pattern for new file names"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Available variables: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Do not prompt for filename when creating new files"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Use native window appearance"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "Only available on Linux; this is the default for macOS and Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Enable window vibrancy"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Only available on macOS; makes the window background opaque."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Show app in the notification area"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Leave app running in the notification area"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoom behavior"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Resizes the whole GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Changes the editor font size"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Attachments sidebar"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "File extensions to be visible in the Attachments sidebar"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Iframe rendering whitelist"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Time to wait before writing a file is considered done (in ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Deleting items"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Debug mode"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Enable debug mode"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta releases"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notify me about beta releases"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Open snippets editor"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Application language"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Autosave"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Save modifications"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Immediately"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "After a short delay"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Default image folder"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Behaviour"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Avoid opening files in new tabs if possible"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Updates"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Automatically check for updates"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "How would you like autocomplete to insert your citations?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Path to file"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Starting update …"
 
 #~ msgid "Open Link"
 #~ msgstr "Open Link"

--- a/static/lang/en-US.po
+++ b/static/lang/en-US.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Zettlr 3.4.3\n"
+"Project-Id-Version: Zettlr 3.4.4\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-16 09:47+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "The citation database could not be loaded"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Changes to the library file detected. Reloading …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Loading workspace %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,147 +81,6 @@ msgstr "Option %s must be at least %s (characters long)."
 msgid "Option %s is required."
 msgstr "Option %s is required."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Show Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Quit"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr "Cannot check for update"
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr "There was an error while checking for updates. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Update available"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "An update to version %s is available!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr "Open updater"
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr "Not now"
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Could not check for updates: Server Error (Status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Could not check for updates: Client Error (Status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Could not check for updates: Could not establish connection"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Could not check for updates. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Could not check for updates: Server hasn't sent any data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr "The SHA256 checksums file seems to be missing for this release."
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr "Cannot retrieve SHA256 checksums: %s"
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr "Could not accept data for application update: Write stream is gone."
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr "Could not start update. Please retry or update manually. Error was: %s"
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Document too long"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Could not create file"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "The reference with key %s does not appear to have attachments."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Could not open attachment. Is Zotero running?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -225,24 +98,101 @@ msgstr "Yes"
 msgid "No"
 msgstr "No"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Replace tag \"%s\" with \"%s\" across %s files?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancel"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Really delete?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Do you really want to remove %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "The reference with key %s does not appear to have attachments."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Could not open attachment. Is Zotero running?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Malformed Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Select import profile"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "There are multiple profiles that can import %s. Please choose one."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Cannot export project"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Project File Mismatch"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Project \"%s\" successfully exported. Click to show."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Project Export"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -298,51 +248,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Import failed"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Cannot export project"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Project File Mismatch"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Project \"%s\" successfully exported. Click to show."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Project Export"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Cannot move directory"
@@ -360,28 +265,49 @@ msgstr "Cannot move directory or file"
 msgid "The file/directory %s already exists in target."
 msgstr "The file/directory %s already exists in target."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Untitled"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "The provided name did not contain any allowed letters."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Could not create directory"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "The requested directory was not found."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Really delete?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Export failed"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Do you really want to remove %s?"
+msgid "An error occurred during export: %s"
+msgstr "An error occurred during export: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Choose export destination"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Save"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Exporting to %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "An error occurred on export: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -406,11 +332,13 @@ msgstr "Cannot open workpace"
 msgid "Cannot open workspace \"%s\"."
 msgstr "Cannot open workspace \"%s\"."
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Document too long"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -423,127 +351,34 @@ msgstr "Language file imported: %s"
 msgid "Could not import language file %s!"
 msgstr "Could not import language file %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Export failed"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Could not create file"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "An error occurred during export: %s"
+msgid "Copy of %s"
+msgstr "Copy of %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Choose export destination"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Untitled"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Save"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Could not create directory"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exporting to %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "An error occurred on export: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "The provided name did not contain any allowed letters."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "The requested directory was not found."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Select import profile"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "There are multiple profiles that can import %s. Please choose one."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Malformed Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Replace file"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Always load remote changes to the current file"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Overwrite existing file"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "The file %s already exists in this directory. Overwrite?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Open file"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Unsaved changes"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "There are unsaved changes. Do you want to save them first?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Save file"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Open project folder"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "The citation database could not be loaded"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Replace tag \"%s\" with \"%s\" across %s files?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -655,6 +490,12 @@ msgstr "Rename file"
 msgid "Delete file"
 msgstr "Delete file"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Quit"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -673,15 +514,15 @@ msgstr "Redo"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Cut"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copy"
 
@@ -693,8 +534,8 @@ msgstr "Copy as HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Paste"
 
@@ -706,8 +547,8 @@ msgstr "Paste without style"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Select all"
 
@@ -950,10 +791,169 @@ msgstr "Stop speaking"
 msgid "Bring All to Front"
 msgstr "Bring All to Front"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Open project folder"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Replace file"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Always load remote changes to the current file"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Unsaved changes"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "There are unsaved changes. Do you want to save them first?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Open file"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Save file"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Overwrite existing file"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "The file %s already exists in this directory. Overwrite?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Show Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr "Cannot check for update"
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr "There was an error while checking for updates. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Update available"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "An update to version %s is available!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr "Open updater"
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr "Not now"
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Could not check for updates: Server Error (Status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Could not check for updates: Client Error (Status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Could not check for updates: Could not establish connection"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Could not check for updates. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Could not check for updates: Server hasn't sent any data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr "The SHA256 checksums file seems to be missing for this release."
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr "Cannot retrieve SHA256 checksums: %s"
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr "Could not accept data for application update: Write stream is gone."
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr "Could not start update. Please retry or update manually. Error was: %s"
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -967,16 +967,16 @@ msgstr "Discard changes"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "There are unsaved changes. Do you want to save or discard them?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "File changed on disk"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s changed on disk"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -985,127 +985,1149 @@ msgstr ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Do you want to keep the current editor contents or load the file from disk?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Keep editor contents"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Load changes from disk"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Could not save file"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Could not save file %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
-msgstr "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Autocorrect"
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Properties"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Smart quotes"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicate file"
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Double Quotes"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copy path"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Disable Magic Quotes"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copy filename"
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Single Quotes"
 
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Text-replacement patterns"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Match whole words"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "When checked, AutoCorrect will never replace parts of words"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Replace"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "With"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filter"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Schedule"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Off"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Follow system"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "On"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "End"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Theme"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Toolbar options"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr "Left section"
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr "Display \"Open settings\" button"
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr "Display \"New file\" button"
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr "Display \"Previous file\" button"
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr "Display \"Next file\" button"
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr "Center section"
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr "Display \"Readability mode\" button"
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr "Display \"Insert comment\" button"
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr "Display \"Insert link\" button"
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr "Display \"Insert image\" button"
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr "Display \"Insert task list\" button"
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr "Display \"Insert table\" button"
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr "Display \"Insert footnote\" button"
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr "Right section"
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr "Display word/character counter"
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr "Display Pomodoro timer"
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Status bar"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr "Show status bar"
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Custom CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Open CSS editor"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Import and export profiles"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Open import profiles editor"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Open export profiles editor"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Export settings"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Use Zettlr's internal Pandoc for exports"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Remove tags from files when exporting"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Internal links"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Remove internal links completely"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Unlink internal links"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Don't touch internal links"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Destination folder for exported files"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Temporary folder"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Same as file location"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Ask for folder when exporting"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Custom export commands"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Display name"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Command"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Pattern for new file names"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Define a pattern for new file names"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Available variables: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Do not prompt for filename when creating new files"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Appearance"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Use native window appearance"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "Only available on Linux; this is the default for macOS and Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Enable window vibrancy"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Only available on macOS; makes the window background opaque."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Show app in the notification area"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Leave app running in the notification area"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoom behavior"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Resizes the whole GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Changes the editor font size"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Attachments sidebar"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "File extensions to be visible in the Attachments sidebar"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Iframe rendering whitelist"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr "Activate watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Time to wait before writing a file is considered done (in ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Deleting items"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr "Delete items irreversibly if moving them to trash fails"
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Debug mode"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Enable debug mode"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta releases"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notify me about beta releases"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Input mode"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Writing direction"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown rendering"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr "Render citations"
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr "Render iframes"
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr "Render images"
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr "Render links"
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr "Render formulae"
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr "Render tasks"
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Hide heading characters"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Render emphasis"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr "Formatting characters for bold and italics"
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Bold"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Italics"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Check Markdown for style issues"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Table Editor"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Mute non-focused lines in distraction-free mode"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr "Hide toolbar in distraction-free mode"
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Word counter"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Count characters instead of words (e.g., for Chinese)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Readability mode"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algorithm"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Image size"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Maximum width of images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Maximum height of images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Other settings"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Font size"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Indentation size (number of spaces)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Indent using tabs instead of spaces"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr "Show formatting toolbar when text is selected"
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Highlight whitespace"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Suggest emojis during autocompletion"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Show link previews"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Automatically close matching character pairs"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Display mode"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Thin"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Expanded"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Combined"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Show file information"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Show folders above files"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Markdown document name display"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Filename only"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Title if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "First heading level 1 if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Title or first heading level 1 if applicable"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Display Markdown file extensions"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Time display"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Last modification time"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "File creation time"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Sorting"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "When sorting documents…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Use natural order (2 comes before 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Use ASCII order (2 comes after 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Citations"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "How would you like autocomplete to insert your citations?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr "Citation database (CSL JSON or BibTex)"
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Path to file"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr "CSL style (optional)"
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Pattern for Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Uses ECMAScript regular expressions"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Pattern used to generate new IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Available Variables: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Link with filename only"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "When linking files, add the document name …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Always"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Only when linking using the ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Never"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Link format"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Title]]: Link first (recommended)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Title|Link]]: Title first"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Start a full-text search when following internal links"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "The search string will match the content between the brackets: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr "For this to work, the folder must be open as a Workspace in Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Path to folder"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Snippets"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Open snippets editor"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Strictness"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Standard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Picky"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Mother language"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Not set"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Preferred Variants"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Interpret English as"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Interpret German as"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Interpret Portuguese as"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Interpret Catalan as"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageTool Provider"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Custom server"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Custom server address"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool Username"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool API key"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Spellchecking"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Active"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Language"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Code"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Select the languages for which you want to enable automatic spell checking."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "User dictionary. Remove words by clicking them."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Dictionary entry"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Search for entries …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Application language"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Autosave"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Save modifications"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Immediately"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "After a short delay"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Default image folder"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Behavior"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Avoid opening files in new tabs if possible"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Updates"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Automatically check for updates"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s characters"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s words"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr "This file is part of project \"%s\""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Go to footnote reference"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "No highlighting"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Open diagnostics panel"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Disabled"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Custom"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Detect automatically"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Rendering mermaid graph …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Could not render Graph:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Readability mode (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Image not found: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "Open image externally"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Spelling mistake"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "File %s does not exist."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Word count"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modified"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Open…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Open in a new tab"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Fetching link preview…"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Image"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comment"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "No footnote text found."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copy equation code"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr "Open link"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr "Copy email address"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr "Copy link"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr "Remove link"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copy image to clipboard"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Open image"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Reveal in Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Open in File Browser"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "No suggestions"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Close file"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Add to dictionary"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Rename directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Italic"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Delete directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Insert link"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Check for directory …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Insert unordered list"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Export Project"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Insert numbered list"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
-msgstr "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
+msgstr "Insert task list"
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
-msgstr "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
+msgstr "Insert blockquote"
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Close other tabs"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr "Insert table"
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Close all tabs"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Unpin tab"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Pin tab"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-click to follow this link"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1513,325 +2535,319 @@ msgstr "Chinese (Taiwan)"
 msgid "Chinese"
 msgstr "Chinese"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Disabled"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Custom"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
+msgstr "Open in new tab"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s words"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Properties"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicate file"
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copy path"
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copy filename"
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
-msgstr "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Reveal in Explorer"
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Reveal in File Browser"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Fetching link preview…"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Close file"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Bold"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Rename directory"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Italics"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Delete directory"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Check for directory …"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Image"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Export Project"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comment"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
+msgstr "Close workspace"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Code"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
+msgstr "Close tab"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "No footnote text found."
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Close other tabs"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "File %s does not exist."
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Close all tabs"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Word count"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Unpin tab"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modified"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Pin tab"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Open…"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendar"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Open in a new tab"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Charts"
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "FSAL Stats"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr "Open link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Writing statistics"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "January"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "February"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "March"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "April"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Open image"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "May"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "June"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "No suggestions"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "July"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Add to dictionary"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "August"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Italic"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "September"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Insert link"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "October"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Insert unordered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "November"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Insert numbered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "December"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Below the monthly average"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Over the monthly average"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "More than twice the monthly average"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copy equation code"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Export project to:"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Use"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Format"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Conversion"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Files to be included in the export"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Could not render Graph:"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Please select at least one profile to build this project."
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Project Title"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "CSL Stylesheet"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "New update available"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "LaTeX Template"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Your version"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "HTML Template"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Remove file from export"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Add file to export"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Move file up"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Move file down"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "You have not selected any files for export."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Downloading your update"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "General"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "No update available. You have the most recent version."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Click to start update"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "never"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Last checked: %s"
+msgid "No results for \"%s\""
+msgstr "No results for \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Search"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "File Manager"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Editor"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Import and Export"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Advanced"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Searching: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Preferences"
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filter tags…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
+msgstr "Click to set your shortcut"
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr "Rename"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Select folder…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Select file…"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Add"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Actions"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Delete"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Insert Image from Clipboard"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Image size"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1849,10 +2865,6 @@ msgstr "Filename"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "A unique filename"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Loading…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1918,46 +2930,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr also makes use of these projects:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Rename snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Snippets let you define reusable pieces of text with variables."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Open snippets folder"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Saving …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Saving failed"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Exporting"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Importing"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Custom CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Saved!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1983,39 +2977,81 @@ msgstr "Open defaults folder"
 msgid "Edit the default settings for imports or exports here."
 msgstr "Edit the default settings for imports or exports here."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Exporting"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Importing"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Open snippets folder"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Saving failed"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "words"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Assign color"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "characters"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Remove color"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Tag name"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Color"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Count"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "A short description"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filter tags…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr "New tag"
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr "Rename"
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr "Rename tag…"
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2041,76 +3077,114 @@ msgstr "Sound Effect"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "words last month"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "daily average"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "No related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "words today"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "This relation is based on a bidirectional link."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 You're on fire!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "This relation is based on an outbound link."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 You're close to hitting your daily average!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "This relation is based on a backlink."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Get writing to surpass your daily average."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "More statistics …"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "This relation is based on %s shared tags: %s"
+msgid "%s selected"
+msgstr "%s selected"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Other files"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Open directory"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "No other files"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "Current folder"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "References"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "There are no citations in this document."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
-msgstr "circa %s words"
+msgid "%s selections"
+msgstr "%s selections"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr "Search across all files"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Tag Cloud"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr "View writing statistics"
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr "View Tag Cloud"
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr "Open settings"
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr "Export current file"
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Toggle readability mode"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr "Insert comment"
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr "Insert image"
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr "Insert footnote"
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr "Pomodoro timer"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr "Temporary directory"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr "Current directory"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr "Select directory"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Exporting…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Export"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "command"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr "Filter…"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2120,8 +3194,8 @@ msgstr "Directories"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Files"
 
@@ -2135,10 +3209,26 @@ msgstr "Characters"
 msgid "Words"
 msgstr "Words"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Workspaces"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "No open files or folders"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "No results"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "No directory selected"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Empty directory"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2168,15 +3258,6 @@ msgstr "ascending"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr "descending"
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2237,13 +3318,6 @@ msgstr "Eye"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr "Eye (crossed)"
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendar"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2453,130 +3527,10 @@ msgstr "CD/DVD"
 msgid "Set writing target…"
 msgstr "Set writing target…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "No results"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "No directory selected"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Empty directory"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Workspaces"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "No open files or folders"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "words last month"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "daily average"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "words today"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 You're on fire!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 You're close to hitting your daily average!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Get writing to surpass your daily average."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "More statistics …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s selected"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s selections"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr "Search across all files"
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr "View writing statistics"
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr "View Tag Cloud"
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr "Open settings"
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr "Export current file"
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Toggle readability mode"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr "Insert comment"
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr "Insert image"
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr "Insert footnote"
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr "Pomodoro timer"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr "Temporary directory"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr "Current directory"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr "Select directory"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Exporting…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Export"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "command"
+msgid "Table size: %s &times; %s"
+msgstr "Table size: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2598,11 +3552,6 @@ msgstr "Restrict search to directory"
 msgid "Choose directory…"
 msgstr "Choose directory…"
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Search"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Clear search"
@@ -2616,1077 +3565,134 @@ msgstr "Toggle results"
 msgid "%s matches across %s files"
 msgstr "%s matches across %s files"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Name"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Tag Cloud"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "words"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "characters"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "No open document"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Related files"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "No related files"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "This relation is based on a bidirectional link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "This relation is based on an outbound link."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "This relation is based on a backlink."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "This relation is based on %s shared tags: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Other files"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Actions"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Open directory"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Delete"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "No other files"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Select folder…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Current folder"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Select file…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr "Table of contents"
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "References"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Use"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "There are no citations in this document."
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Format"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Conversion"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Files to be included in the export"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Please select at least one profile to build this project."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Project Title"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "CSL Stylesheet"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "LaTeX Template"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "HTML Template"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Remove file from export"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Add file to export"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Move file up"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Move file down"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "You have not selected any files for export."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-"Some files are selected for export but no longer exist in the directory."
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "General"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "No results for \"%s\""
+msgid "circa %s words"
+msgstr "circa %s words"
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Appearance"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Loading…"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "File Manager"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Updater"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Editor"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "New update available"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Spellchecking"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Your version"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Autocorrect"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Citations"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Downloading your update"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "No update available. You have the most recent version."
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Import and Export"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Click to start update"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Advanced"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "never"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "Searching: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Preferences"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "January"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "February"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "March"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "April"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "May"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "June"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "July"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "August"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "September"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "October"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "November"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "December"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Below the monthly average"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Over the monthly average"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "More than twice the monthly average"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Charts"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "FSAL Stats"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Writing statistics"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Pattern for Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Uses ECMAScript regular expressions"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Pattern used to generate new IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Available Variables: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Link with filename only"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "When linking files, add the document name …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Always"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Only when linking using the ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Never"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Link format"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Title]]: Link first (recommended)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Title|Link]]: Title first"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Start a full-text search when following internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "The search string will match the content between the brackets: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr "For this to work, the folder must be open as a Workspace in Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Path to folder"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Smart quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Double Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Disable Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Single Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Text-replacement patterns"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Match whole words"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "When checked, AutoCorrect will never replace parts of words"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Replace"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "With"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filter"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Input mode"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Writing direction"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown rendering"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr "Render citations"
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr "Render iframes"
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr "Render images"
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr "Render links"
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr "Render formulae"
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr "Render tasks"
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Hide heading characters"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Render emphasis"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr "Formatting characters for bold and italics"
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Check Markdown for style issues"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Table Editor"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Mute non-focused lines in distraction-free mode"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr "Hide toolbar in distraction-free mode"
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Word counter"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Count characters instead of words (e.g., for Chinese)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Readability mode"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algorithm"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Maximum width of images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Maximum height of images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Other settings"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Font size"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Indentation size (number of spaces)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Indent using tabs instead of spaces"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr "Show formatting toolbar when text is selected"
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Highlight whitespace"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Suggest emojis during autocompletion"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Show link previews"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Automatically close matching character pairs"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Schedule"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Off"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Follow system"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "On"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "End"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Theme"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Toolbar options"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr "Left section"
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr "Display \"Open settings\" button"
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr "Display \"New file\" button"
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr "Display \"Previous file\" button"
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr "Display \"Next file\" button"
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr "Center section"
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr "Display \"Readability mode\" button"
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr "Display \"Insert comment\" button"
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr "Display \"Insert link\" button"
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr "Display \"Insert image\" button"
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr "Display \"Insert task list\" button"
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr "Display \"Insert table\" button"
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr "Display \"Insert footnote\" button"
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr "Right section"
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr "Display word/character counter"
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr "Display Pomodoro timer"
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Status bar"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr "Show status bar"
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Open CSS editor"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Strictness"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Standard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Picky"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Mother language"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Not set"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Preferred Variants"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Interpret English as"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Interpret German as"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Interpret Portuguese as"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Interpret Catalan as"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageTool Provider"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Custom server"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Custom server address"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool Username"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool API key"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Active"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Language"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Select the languages for which you want to enable automatic spell checking."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "User dictionary. Remove words by clicking them."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Dictionary entry"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Search for entries …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Display mode"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Thin"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Expanded"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Combined"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Show file information"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Show folders above files"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Markdown document name display"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Filename only"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Title if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "First heading level 1 if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Title or first heading level 1 if applicable"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Display Markdown file extensions"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Time display"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Last modification time"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "File creation time"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Sorting"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "When sorting documents…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Use natural order (2 comes before 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Use ASCII order (2 comes after 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Import and export profiles"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Open import profiles editor"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Open export profiles editor"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Export settings"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Use Zettlr's internal Pandoc for exports"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Remove tags from files when exporting"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Remove internal links completely"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Unlink internal links"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Don't touch internal links"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Destination folder for exported files"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Temporary folder"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Same as file location"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Ask for folder when exporting"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Custom export commands"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Display name"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Command"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Pattern for new file names"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Define a pattern for new file names"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Available variables: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Do not prompt for filename when creating new files"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Use native window appearance"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "Only available on Linux; this is the default for macOS and Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Enable window vibrancy"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Only available on macOS; makes the window background opaque."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Show app in the notification area"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Leave app running in the notification area"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoom behavior"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Resizes the whole GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Changes the editor font size"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Attachments sidebar"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "File extensions to be visible in the Attachments sidebar"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Iframe rendering whitelist"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr "Activate watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Time to wait before writing a file is considered done (in ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Deleting items"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr "Delete items irreversibly if moving them to trash fails"
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Debug mode"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Enable debug mode"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta releases"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notify me about beta releases"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Open snippets editor"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Application language"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Autosave"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Save modifications"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Immediately"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "After a short delay"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Default image folder"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Behavior"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Avoid opening files in new tabs if possible"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Updates"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Automatically check for updates"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "How would you like autocomplete to insert your citations?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr "Citation database (CSL JSON or BibTex)"
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Path to file"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr "CSL style (optional)"
+msgid "Last checked: %s"
+msgstr "Last checked: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Starting update …"

--- a/static/lang/eo-EO.po
+++ b/static/lang/eo-EO.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr ""
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr ""
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,140 +81,6 @@ msgstr "Opcio %s devas esti almenaŭ %s (karaktroj longa)."
 msgid "Option %s is required."
 msgstr "Opcio %s estas bezonata."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr ""
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr ""
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr ""
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -218,24 +98,96 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
 msgstr ""
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Nuligi"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr ""
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr ""
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr ""
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr ""
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -289,46 +241,6 @@ msgstr ""
 msgid "Import failed"
 msgstr ""
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr ""
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr ""
@@ -346,27 +258,48 @@ msgstr ""
 msgid "The file/directory %s already exists in target."
 msgstr ""
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sentitola"
-
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
 msgstr ""
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
 msgstr ""
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
+msgid "An error occurred during export: %s"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Konservi"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr ""
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
 msgstr ""
 
 #: source/app/service-providers/commands/root-open.ts:59
@@ -392,10 +325,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -409,124 +344,33 @@ msgstr ""
 msgid "Could not import language file %s!"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
+msgid "Copy of %s"
 msgstr ""
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sentitola"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Konservi"
-
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr ""
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr ""
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Ĉiam ŝarĝu forajn ŝanĝojn al la aktuala dosiero"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr ""
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:44
@@ -639,6 +483,12 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr ""
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -657,15 +507,15 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr ""
 
@@ -677,8 +527,8 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr ""
 
@@ -690,8 +540,8 @@ msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr ""
 
@@ -931,9 +781,159 @@ msgstr ""
 msgid "Bring All to Front"
 msgstr ""
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Ĉiam ŝarĝu forajn ŝanĝojn al la aktuala dosiero"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
 msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
@@ -948,141 +948,1177 @@ msgstr ""
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Modo de dosier-administrilo"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Ŝaltu aŭtomatan korektadon"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Malŝalti Magiajn Citaĵojn"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Malŝalti Magiajn Citaĵojn"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Malŝalti Magiajn Citaĵojn"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "anstataŭigi per"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
 msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtri etikedojn ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Horaro"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Malŝalti"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Sekvu Operaciumon"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Propra CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr ""
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Uzu la internan Pandoc por eksportado"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Forigi etikedojn de dosieroj"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Malligi internajn ligojn"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Forigu internajn ligojn tute"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Malligi internajn ligojn"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Ne tuŝu internajn ligojn"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Montri dosierajn informojn"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Skemo por novaj dosiernomoj"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Skemo por novaj dosiernomoj"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Ne petu dosiernomon kiam vi kreas novajn dosierojn"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Uzu denaskan fenestran aspekton"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Uzu denaskan fenestran aspekton"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Montru programon en la sciiga areo"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Lasu programon funkcii en la sciiga areo"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Tekstoredaktilo tipara grandeco"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "iFrame-bildigo de blanka listo"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Gastiganta nomo"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktivigu voĉdonadon de Gardhundo"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Tempo por atendi antaŭ ol verki dosieron estas konsiderata finita (en ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Ebligu elpurigan reĝimon"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Ebligu elpurigan reĝimon"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Sciigu min pri beta-eldonoj"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Redaktila eniga reĝimo"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Kaŝi titolajn karaktrojn"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Enable Table Editor"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Mutaj ne-fokusitaj linioj en sen distra reĝimo"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Kalkulu karaktrojn anstataŭ vortoj (ekz. Por la ĉina)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Maksimuma larĝo de bildoj (procento)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Maksimuma alteco de bildoj (procento)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Tekstoredaktilo tipara grandeco"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Deŝovu per la sekva nombro da spacoj"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Deŝovu per la sekva nombro da spacoj"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Akceptu spacojn dum aŭtokompletigo"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Aŭtomate fermu kongruajn karaktrojn parojn"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Montri dosierajn informojn"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Lasta modifa tempo"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Tempo de kreo de dosieroj"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Natura ordo (10 post 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII-ordo (2 post 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Reprodukti citaĵojn"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Aldonu al dosiero"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Skemo uzata por generi novajn identigilojn"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Identiga regula esprimo"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Skemo uzata por generi novajn identigilojn"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Kiam vi ligas dosierojn, aldonu la dosiernomon ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "ĉiam"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "nur dum ligado per la ID (identigilo)"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "neniam"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Komencu serĉon sekvante Zettelkasten-ligojn"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Aŭtomate kreu neekzistantajn dosierojn kiam vi sekvas internajn ligojn"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalendaro"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Propra CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Propra CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Elektu la lingvojn, por kiuj vi volas ebligi aŭtomatan literumkontrolon."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Uzanta vortaro. Forigu vortojn alklakante ilin."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Vortara eniro"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Aŭtomate konservi"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Lasta modifa tempo"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Tuj"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Post mallonga prokrasto"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Evitu malfermi dosierojn en novaj langetoj, se eblas"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Propra CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Reprodukti bildojn"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
 msgstr ""
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ""
-
-#: source/common/util/localise-number.ts:29
-msgid "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
 
 #: source/common/util/format-date.ts:33
@@ -1515,321 +2551,317 @@ msgstr "Ĉina (Ĉinio)"
 msgid "Chinese"
 msgstr "Ĉina (Ĉinio)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
+#: source/common/util/localise-number.ts:29
+msgid "."
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-#, fuzzy
-msgid "Custom"
-msgstr "Propra CSS"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalendaro"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Diagramoj"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Reprodukti bildojn"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtri etikedojn ..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
 msgstr ""
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
-msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
 msgstr ""
 
 #: source/tmp/win-paste-image/App.vue.ts:59
@@ -1847,10 +2879,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1912,45 +2940,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr ankaŭ uzas ĉi tiujn projektojn:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Ĉi tie vi povas anstataŭigi la stilojn de Zettlr por agordi ĝin eĉ pli. "
-"<strong> Atentu: Ĉi tiu dosiero anstataŭas ĉiujn CSS-direktivojn! Neniam "
-"ŝanĝu la geometrion de elementoj, alie la programo povus elmontri "
-"nedeziratan konduton! </strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Renomi fragmenton"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Fragmentoj permesas vin difini reuzeblajn tekstopecojn kun variabloj."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Propra CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1973,38 +2983,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Redaktu la defaŭltajn agordojn por importado aŭ eksportado ĉi tie."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Renomi fragmenton"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Fragmentoj permesas vin difini reuzeblajn tekstopecojn kun variabloj."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Ĉi tie vi povas anstataŭigi la stilojn de Zettlr por agordi ĝin eĉ pli. "
+"<strong> Atentu: Ĉi tiu dosiero anstataŭas ĉiujn CSS-direktivojn! Neniam "
+"ŝanĝu la geometrion de elementoj, alie la programo povus elmontri "
+"nedeziratan konduton! </strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtri etikedojn ..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
 msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
@@ -2031,76 +3080,114 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Etikeda Nubo"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2110,8 +3197,8 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr ""
 
@@ -2125,9 +3212,25 @@ msgstr ""
 msgid "Words"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
@@ -2157,15 +3260,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2227,13 +3321,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalendaro"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2443,129 +3530,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2588,11 +3555,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2606,1090 +3568,134 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Etikeda Nubo"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr ""
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr ""
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Ŝaltu aŭtomatan korektadon"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Reprodukti citaĵojn"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Diagramoj"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Skemo uzata por generi novajn identigilojn"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Identiga regula esprimo"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Skemo uzata por generi novajn identigilojn"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Malligi internajn ligojn"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Kiam vi ligas dosierojn, aldonu la dosiernomon ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "ĉiam"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "nur dum ligado per la ID (identigilo)"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "neniam"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Komencu serĉon sekvante Zettelkasten-ligojn"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Aŭtomate kreu neekzistantajn dosierojn kiam vi sekvas internajn ligojn"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Malŝalti Magiajn Citaĵojn"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Malŝalti Magiajn Citaĵojn"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Malŝalti Magiajn Citaĵojn"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "anstataŭigi per"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtri etikedojn ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Redaktila eniga reĝimo"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Kaŝi titolajn karaktrojn"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Enable Table Editor"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Mutaj ne-fokusitaj linioj en sen distra reĝimo"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Kalkulu karaktrojn anstataŭ vortoj (ekz. Por la ĉina)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Maksimuma larĝo de bildoj (procento)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Maksimuma alteco de bildoj (procento)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Tekstoredaktilo tipara grandeco"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Deŝovu per la sekva nombro da spacoj"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Deŝovu per la sekva nombro da spacoj"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Akceptu spacojn dum aŭtokompletigo"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Aŭtomate fermu kongruajn karaktrojn parojn"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Horaro"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Malŝalti"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Sekvu Operaciumon"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalendaro"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Propra CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Propra CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Elektu la lingvojn, por kiuj vi volas ebligi aŭtomatan literumkontrolon."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Uzanta vortaro. Forigu vortojn alklakante ilin."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Vortara eniro"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Montri dosierajn informojn"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Lasta modifa tempo"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Tempo de kreo de dosieroj"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Natura ordo (10 post 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII-ordo (2 post 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr ""
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Uzu la internan Pandoc por eksportado"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Forigi etikedojn de dosieroj"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Forigu internajn ligojn tute"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Malligi internajn ligojn"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Ne tuŝu internajn ligojn"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Montri dosierajn informojn"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Skemo por novaj dosiernomoj"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Skemo por novaj dosiernomoj"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Ne petu dosiernomon kiam vi kreas novajn dosierojn"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Uzu denaskan fenestran aspekton"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Uzu denaskan fenestran aspekton"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Montru programon en la sciiga areo"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Lasu programon funkcii en la sciiga areo"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Tekstoredaktilo tipara grandeco"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "iFrame-bildigo de blanka listo"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Gastiganta nomo"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktivigu voĉdonadon de Gardhundo"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Tempo por atendi antaŭ ol verki dosieron estas konsiderata finita (en ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Ebligu elpurigan reĝimon"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Ebligu elpurigan reĝimon"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Sciigu min pri beta-eldonoj"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Aŭtomate konservi"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Lasta modifa tempo"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Tuj"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Post mallonga prokrasto"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Evitu malfermi dosierojn en novaj langetoj, se eblas"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Aldonu al dosiero"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Find in file"

--- a/static/lang/es-ES.po
+++ b/static/lang/es-ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,21 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "No se pudo cargar la base de datos de citas"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Se han detectado cambios en el archivo de la biblioteca. Recargando…"
+
+# javascript-format
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Cargando espacio de trabajo %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -66,148 +81,6 @@ msgstr "La opción %s debe tener al menos %s caracteres."
 msgid "Option %s is required."
 msgstr "La opción %s es requerida."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Mostrar Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Salir"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Actualización disponible"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "¡Una actualización a la versión %s está disponible!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"No se pudo comprobar si hay actualizaciones: Error del servidor (Código de "
-"estado: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"No se pudo comprobar si hay actualizaciones: Error del cliente (Código de "
-"estado: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"No se pudo comprobar si hay actualizaciones: El servidor intentó redirigir "
-"(Código de estado: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"No se pudo comprobar si hay actualizaciones: No se pudo establecer conexión"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "No se pudo comprobar si hay actualizaciones. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"No se pudo comprobar si hay actualizaciones: El servidor no ha enviado datos"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Documento demasiado largo"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "fuera de linea"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "No se pudo crear el archivo"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "La referencia con clave %s no parece tener adjuntos."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "No se pudo abrir el adjunto. ¿Está en ejecución Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -225,24 +98,101 @@ msgstr "Sí"
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "¿Reemplazar la etiqueta \"%s\" con \"%s\" en %s archivos?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "¿Realmente eliminar?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "¿Realmente deseas eliminar %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "La referencia con clave %s no parece tener adjuntos."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "No se pudo abrir el adjunto. ¿Está en ejecución Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Paquete de texto malformado: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Seleccionar perfil de importación"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "Hay múltiples perfiles que pueden importar %s. Por favor, elige uno."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "No se puede exportar el proyecto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"No se han seleccionado archivos para exportar. Por favor, selecciona "
+"archivos para incluir en la configuración del proyecto."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Incompatibilidad de archivo del proyecto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Uno o más archivos especificados en la configuración del proyecto no se han "
+"encontrado. Pueden haber sido movidos o eliminados. Por favor, verifica que "
+"todos los archivos que deseas exportar estén incluidos."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Proyecto \"%s\" exportado exitosamente. Haz clic para mostrar."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Exportar proyecto"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -298,51 +248,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Fallo de importación"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "No se puede exportar el proyecto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"No se han seleccionado archivos para exportar. Por favor, selecciona "
-"archivos para incluir en la configuración del proyecto."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Incompatibilidad de archivo del proyecto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Uno o más archivos especificados en la configuración del proyecto no se han "
-"encontrado. Pueden haber sido movidos o eliminados. Por favor, verifica que "
-"todos los archivos que deseas exportar estén incluidos."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Proyecto \"%s\" exportado exitosamente. Haz clic para mostrar."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Exportar proyecto"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "No se puede mover la carpeta"
@@ -360,28 +265,49 @@ msgstr "No se puede mover la carpeta o el archivo"
 msgid "The file/directory %s already exists in target."
 msgstr "El archivo/la carpeta %s ya existe en el destino."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sin título"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "El nombre proporcionado no contenía ninguna letra permitida."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "No se pudo crear la carpeta"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "No se encontró la carpeta solicitada."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "¿Realmente eliminar?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Error de exportación"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "¿Realmente deseas eliminar %s?"
+msgid "An error occurred during export: %s"
+msgstr "Se produjo un error durante la exportación: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Elegir destino de exportación"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Guardar"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Exportando a %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Se produjo un error en la exportación: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -406,11 +332,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Copia de %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Documento demasiado largo"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "fuera de linea"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -423,127 +351,34 @@ msgstr "Archivo de idioma importado: %s"
 msgid "Could not import language file %s!"
 msgstr "No se ha podido importar el archivo de idioma %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Error de exportación"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "No se pudo crear el archivo"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Se produjo un error durante la exportación: %s"
+msgid "Copy of %s"
+msgstr "Copia de %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Elegir destino de exportación"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sin título"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Guardar"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "No se pudo crear la carpeta"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exportando a %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Se produjo un error en la exportación: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "El nombre proporcionado no contenía ninguna letra permitida."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "No se encontró la carpeta solicitada."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Seleccionar perfil de importación"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "Hay múltiples perfiles que pueden importar %s. Por favor, elige uno."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Paquete de texto malformado: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Reemplazar archivo"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"El archivo %s ha sido modificado de forma remota. ¿Reemplazar la versión "
-"cargada con la más reciente del disco?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Siempre recargar el archivo actual cuando hay cambios remotos"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Sobrescribir archivo existente"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "El archivo %s ya existe en este directorio. ¿Sobreescribir?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Abrir archivo"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Cambios sin guardar"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Hay cambios no guardados. ¿Deseas guardarlos primero?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Guardar archivo"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Abrir carpeta de proyecto"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "No se pudo cargar la base de datos de citas"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Se han detectado cambios en el archivo de la biblioteca. Recargando…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "¿Reemplazar la etiqueta \"%s\" con \"%s\" en %s archivos?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -655,6 +490,12 @@ msgstr "Renombrar archivo"
 msgid "Delete file"
 msgstr "Eliminar archivo"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Salir"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -673,15 +514,15 @@ msgstr "Rehacer"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Cortar"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copiar"
 
@@ -693,8 +534,8 @@ msgstr "Copiar como HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Pegar"
 
@@ -706,8 +547,8 @@ msgstr "Pegar sin formato"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Seleccionar todo"
 
@@ -950,11 +791,170 @@ msgstr "Deja de hablar"
 msgid "Bring All to Front"
 msgstr "Traer todo al frente"
 
-# javascript-format
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Abrir carpeta de proyecto"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Reemplazar archivo"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Cargando espacio de trabajo %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"El archivo %s ha sido modificado de forma remota. ¿Reemplazar la versión "
+"cargada con la más reciente del disco?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Siempre recargar el archivo actual cuando hay cambios remotos"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Cambios sin guardar"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Hay cambios no guardados. ¿Deseas guardarlos primero?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Abrir archivo"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Guardar archivo"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Sobrescribir archivo existente"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "El archivo %s ya existe en este directorio. ¿Sobreescribir?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Mostrar Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Actualización disponible"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "¡Una actualización a la versión %s está disponible!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"No se pudo comprobar si hay actualizaciones: Error del servidor (Código de "
+"estado: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"No se pudo comprobar si hay actualizaciones: Error del cliente (Código de "
+"estado: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"No se pudo comprobar si hay actualizaciones: El servidor intentó redirigir "
+"(Código de estado: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"No se pudo comprobar si hay actualizaciones: No se pudo establecer conexión"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "No se pudo comprobar si hay actualizaciones. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"No se pudo comprobar si hay actualizaciones: El servidor no ha enviado datos"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -968,16 +968,16 @@ msgstr "Descartar cambios"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Hay cambios no guardados. ¿Deseas guardarlos o descartarlos?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "Archivo modificado en disco"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s cambió en el disco"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -987,129 +987,1163 @@ msgstr ""
 "¿Deseas mantener el contenido actual del editor o cargar el archivo desde el "
 "disco?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "¿Deseas mantener el contenido actual del editor o cargar el archivo desde el "
 "disco?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Mantener el contenido del editor"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Cargar cambios desde el disco"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Cargar siempre cambios desde el disco si no hay cambios no guardados en el "
 "editor"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "No se pudo guardar el archivo"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "No se pudo guardar el archivo %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Autocorrección"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Comillas inteligentes"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Comillas dobles"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Deshabilitar comillas mágicas"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Comillas simples"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Patrones de sustitución de texto"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Coincidir palabras completas"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+"Cuando esté marcado, la autocorrección nunca reemplazará partes de palabras"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Reemplazar"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "Con"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filtro"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Horario"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Apagar"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Seguir el sistema"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Encendido"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Iniciar"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Fin"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Tema"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Opciones de la barra de herramientas"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Propiedades"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicar archivo"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copiar ruta"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copiar nombre de archivo"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Barra de estado"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personalizado"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Abrir editor de CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Importar y exportar perfiles"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Abrir el editor de perfiles de importación"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Abrir el editor de perfiles de exportación"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Configuraciones de exportación"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Usar el Pandoc interno de Zettlr para exportar"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Eliminar etiquetas de los archivos al exportar"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Vínculos internos"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Eliminar completamente los enlaces internos"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Desvincular enlaces internos"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "No modificar los enlaces internos"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Carpeta de destino para los archivos exportados"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Carpeta temporal"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Misma ubicación que el archivo"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Preguntar por la carpeta al exportar"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"¡Advertencia! Los archivos en la carpeta temporal se eliminan regularmente. "
+"Elegir la misma ubicación que el archivo sobrescribirá archivos con nombres "
+"idénticos si ya existen."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Comandos de exportación personalizados"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Nombre para mostrar"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Comando"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Introduce comandos personalizados para ejecutar el exportador. Cada comando "
+"recibe como primer argumento el archivo o la carpeta del proyecto que se va "
+"a exportar."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Patrón para nombres de archivo nuevos"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Define un patrón para nombres de archivo nuevos"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Variables disponibles: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "No pedir nombre al crear nuevos archivos"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Utilizar la apariencia nativa de ventanas"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+"Solo disponible en Linux; este es el valor predeterminado para macOS y "
+"Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Activar la vibración de la ventana"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Solo disponible en macOS; hace que el fondo de la ventana sea opaco."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Mostrar la aplicación en el área de notificación"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Dejar la aplicación en ejecución en el área de notificación"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportamiento del zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Redimensiona toda la interfaz gráfica"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Cambia el tamaño de la fuente del editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Barra lateral de archivos adjuntos"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+"Extensiones de archivo visibles en la barra lateral de archivos adjuntos"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Lista blanca de renderizado de iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nombre del host"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Monitorización de vigilancia"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Tiempo de espera antes de que la escritura de un archivo se considere "
+"finalizada (en ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Eliminar elementos"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Modo de depuración"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Habilitar el modo de depuración"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Lanzamientos beta"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notificarme sobre las versiones beta"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Modo de entrada"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"El modo de entrada determina cómo interactúas con el editor. Recomendamos "
+"mantener esta configuración en \"Normal\". Solo elige \"Vim\" o \"Emacs\" si "
+"sabes lo que implica."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Dirección de escritura"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Renderización de Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Marca para habilitar la renderización en vivo de varios elementos de "
+"Markdown a su apariencia formateada. Esto oculta los caracteres de formato "
+"(como **texto**) o renderiza imágenes en lugar de su enlace."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ocultar caracteres de encabezado"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Renderizar énfasis"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Negrita"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Cursiva"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Revisar Markdown en busca de problemas de estilo"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Editor de tablas"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"El Editor de Tablas es una interfaz interactiva que simplifica la creación y "
+"edición de tablas. Proporciona botones para funcionalidades comunes y se "
+"encarga de la formateo de Markdown."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Silenciar líneas no enfocadas en el modo libre de distracciones"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Contador de palabras"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Contar caracteres en lugar de palabras (p. ej., para chino)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Modo de legibilidad"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algoritmo"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Tamaño de imagen"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Anchura máxima de las imágenes (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Altura máxima de las imágenes (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Otras configuraciones"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Tamaño de la fuente"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Tamaño de la sangría (número de espacios)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Identar utilizando tabulaciones en lugar de espacios"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Resaltar espacios en blanco"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Sugerir emojis durante la autocompletación"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Mostrar vistas previas de enlaces"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Cerrar automáticamente pares de caracteres coincidentes"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Modo de visualización"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Delgado"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Expandido"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Combinado"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"El modo Delgado muestra tus directorios y archivos por separado. Selecciona "
+"un directorio para que su contenido se muestre en la lista de archivos. "
+"Cambia entre la lista de archivos y el árbol de directorios haciendo clic en "
+"los directorios o en el botón de flecha que aparece en la esquina superior "
+"izquierda de la lista de archivos."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Mostrar información del archivo"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Mostrar carpetas encima de los archivos"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Mostrar nombre del documento Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Solo el nombre del archivo"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Título, si procede"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Primera cabecera de nivel 1, si procede"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Título o primera cabecera de nivel 1, si procede"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Mostrar extensiones de archivos Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Visualización del tiempo"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Hora de la última modificación"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Hora de creación del archivo"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Ordenar"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Al ordenar documentos…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Usar orden natural (2 viene antes de 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Usar orden ASCII (2 viene después de 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Renderizar citas"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "¿Cómo te gustaría que la autocompletación insertara tus citas?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Ruta al archivo"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "IDs de Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Patrón para los IDs de Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Usa expresiones regulares de ECMAScript"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Patrón utilizado para generar nuevos IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Variables disponibles: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Vincular solo con el nombre del archivo"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "Al vincular archivos, agregar el nombre del documento..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Siempre"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Solo al vincular usando el ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Nunca"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Formato de vínculo"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Los vínculos internos te permiten agregar un título opcional, separado por "
+"un carácter de barra vertical del objetivo del vínculo real. Aquí puedes "
+"definir el orden de los dos."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Title]]: Vínculo primero (recomendado)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Title|Link]]: Título primero"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Iniciar una búsqueda de texto completo al seguir los vínculos internos"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+"La cadena de búsqueda coincidirá con el contenido entre los corchetes: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Crear automáticamente archivos no existentes en esta carpeta al seguir "
+"vínculos internos"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Para que esto funcione, la carpeta debe estar abierta como un Espacio de "
+"trabajo en Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Ruta a la carpeta"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Fragmentos (Snippets)"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Abrir el editor de fragmentos"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Rigor"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Estándar"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Exigente"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Idioma materno"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "No establecido"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Variantes preferidas"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool no puede distinguir ciertas variantes del idioma. Estas "
+"configuraciones ajustarán LanguageTool para detectar automáticamente tu "
+"variante preferida de estos idiomas."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Interpretar el inglés como"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Interpretar el alemán como"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Interpretar el portugués como"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Interpretar el catalán como"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Proveedor de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Servidor personalizado"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Dirección del servidor personalizado"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr ignorará los ajustes del \"proveedor de LanguageTool\" si introduces "
+"alguna credencial aquí."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Nombre de usuario de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "Clave API de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Revisión ortográfica"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Activo"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Código"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Selecciona los idiomas para los que deseas habilitar la corrección "
+"ortográfica automática."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Diccionario del usuario. Elimina las palabras haciendo clic en ellas."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Entrada del diccionario"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Buscar entradas…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Idioma de la aplicación"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Autoguardado"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Guardar modificaciones"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Inmediatamente"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Después de un breve retraso"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Carpeta de imágenes predeterminada"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Haz clic en \"Seleccionar carpeta…\" o escribe una ruta absoluta o relativa "
+"directamente en el campo de entrada."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Comportamiento"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Evitar abrir archivos en nuevas pestañas si es posible"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Actualizaciones"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Comprobar automáticamente si hay actualizaciones"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caracteres"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s palabras"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Ir a la referencia de la nota al pie"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Sin resaltado"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Abrir panel de diagnóstico"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Personalizado"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Detectar automáticamente"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Renderizando gráfico de mermaid …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "No se pudo renderizar el gráfico:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Modo de legibilidad (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Imagen no encontrada: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Error de ortografía"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "El archivo %s no existe."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Recuento de palabras"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificado"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Abrir..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Abrir en una pestaña nueva"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Cargando vista previa del enlace…"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Enlace"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Imagen"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comentario"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "No se encontró texto de nota al pie."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copiar código de la ecuación"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copiar imagen al portapapeles"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Abrir imagen"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Revelar en Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Revelar en el Explorador"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Abrir en el explorador de archivos"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Revelar en el navegador de archivos"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Sin sugerencias"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Cerrar archivo"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Añadir al diccionario"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Renombrar carpeta"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Cursiva"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Eliminar carpeta"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Insertar enlace"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Comprobar la carpeta…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Insertar lista no ordenada"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportar proyecto"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Insertar lista numerada"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Cerrar otras pestañas"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Cerrar todas las pestañas"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Desanclar pestaña"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Anclar pestaña"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-clic para seguir este enlace"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1517,325 +2551,320 @@ msgstr "Chino (Taiwán)"
 msgid "Chinese"
 msgstr "Chino"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Detectar automáticamente"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Desactivado"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Personalizado"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s palabras"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caracteres"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Abrir panel de diagnóstico"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Error de ortografía"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Ir a la referencia de la nota al pie"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Propiedades"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Cargando vista previa del enlace…"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicar archivo"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Negrita"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copiar ruta"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Cursiva"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copiar nombre de archivo"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Enlace"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Revelar en el Explorador"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Imagen"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Revelar en el navegador de archivos"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comentario"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Cerrar archivo"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Código"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Renombrar carpeta"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "No se encontró texto de nota al pie."
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Eliminar carpeta"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "El archivo %s no existe."
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Comprobar la carpeta…"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Recuento de palabras"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportar proyecto"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificado"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Abrir..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Abrir en una pestaña nueva"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Sin resaltado"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Cerrar otras pestañas"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Cerrar todas las pestañas"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copiar imagen al portapapeles"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Desanclar pestaña"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Abrir imagen"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Anclar pestaña"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Abrir en el explorador de archivos"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendario"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Sin sugerencias"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Gráficos"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Añadir al diccionario"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "Estadísticas FSAL"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Cursiva"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Estadísticas de escritura"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Insertar enlace"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Enero"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Insertar lista no ordenada"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Febrero"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Insertar lista numerada"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Marzo"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Abril"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Mayo"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Junio"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copiar código de la ecuación"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Julio"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Modo de legibilidad (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agosto"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Imagen no encontrada: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Septiembre"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Octubre"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Renderizando gráfico de mermaid …"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Noviembre"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "No se pudo renderizar el gráfico:"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Diciembre"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-clic para seguir este enlace"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Por debajo de la media mensual"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Actualizador"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Por encima de la media mensual"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Nueva actualización disponible"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Más del doble de la media mensual"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Tu versión"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Exportar proyecto a:"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Usar"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Formatear"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Conversión"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Archivos a incluir en la exportación"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Por favor, selecciona al menos un perfil para crear este proyecto."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Título del proyecto"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "Hoja de estilo CSL"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "Plantilla LaTeX"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "Plantilla HTML"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Eliminar archivo de la exportación"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Agregar archivo a la exportación"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Mover archivo hacia arriba"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Mover archivo hacia abajo"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "No has seleccionado ningun archivo para exportar."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Hay una nueva versión de Zettlr disponible para descargar. Por favor, lee el "
-"changelog (registro de cambios) a continuación."
+"Algunos archivos están seleccionados para la exportación pero ya no existen "
+"en el directorio."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Descargando la actualización"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "General"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "No hay actualizaciones disponibles. Esta es la versión más reciente"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Clica para empezar la actualización"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "Nunca"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Última comprobación: %s"
+msgid "No results for \"%s\""
+msgstr "Sin resultados para \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Empezando la actualización..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Búsqueda"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Asignar color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Administrador de archivos"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Eliminar color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Editor"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Nombre de etiqueta"
-
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Color"
-
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Contar"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Una breve descripción"
-
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-"Aquí puedes asignar colores a diferentes etiquetas. Si se encuentra una "
-"etiqueta en un archivo, su recuadro en la lista de vista previa recibirá un "
-"indicador de color. La descripción se mostrará al pasar el ratón."
-
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrar etiquetas…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Importar y Exportar"
+
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Buscando: %s"
+
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reinicia"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Seleccionar carpeta…"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Seleccionar archivo"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Añadir"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Acciones"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Eliminar"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Insertar imagen desde el portapapeles"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Tamaño de imagen"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1853,10 +2882,6 @@ msgstr "Nombre de archivo"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Un nombre de archivo único"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Cargando..."
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1923,46 +2948,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr también utiliza estos proyectos:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Aquí puedes sobreescribir los estilos de Zettlr para personalizarlo aún más. "
-"<strong>Atención: Este archivo sobrescribe todas las directivas CSS! Nunca "
-"altere la geometría de los elementos, de lo contrario la aplicación puede "
-"tener comportamientos no deseados!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Renombrar fragmento"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Los fragmentos te permiten definir trozos de texto reutilizables con "
+"variables."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Abrir carpeta de Fragmentos (Snippets)"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Guardando..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Fallo al guardar"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Exportando"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Importando"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personalizado"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Fragmentos (Snippets)"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "¡Guardado!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1987,41 +2996,81 @@ msgid "Edit the default settings for imports or exports here."
 msgstr ""
 "Editar aquí la configuración por defecto para importaciones o exportaciones."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "¡Guardado!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Exportando"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Renombrar fragmento"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Importando"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Los fragmentos te permiten definir trozos de texto reutilizables con "
-"variables."
+"Aquí puedes sobreescribir los estilos de Zettlr para personalizarlo aún más. "
+"<strong>Atención: Este archivo sobrescribe todas las directivas CSS! Nunca "
+"altere la geometría de los elementos, de lo contrario la aplicación puede "
+"tener comportamientos no deseados!</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Abrir carpeta de Fragmentos (Snippets)"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Fallo al guardar"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "palabras"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Asignar color"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "carácteres"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Eliminar color"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "No hay ningún documento abierto"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Nombre de etiqueta"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Iniciar"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Color"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Contar"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Una breve descripción"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Aquí puedes asignar colores a diferentes etiquetas. Si se encuentra una "
+"etiqueta en un archivo, su recuadro en la lista de vista previa recibirá un "
+"indicador de color. La descripción se mostrará al pasar el ratón."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrar etiquetas…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2047,76 +3096,114 @@ msgstr "Efecto de sonido"
 msgid "Volume"
 msgstr "Volumen"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "palabras el mes pasado"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "promedio diario"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "palabras hoy"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 ¡No hay quien te detenga!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 ¡Estás cerca de llegar a tu promedio diario!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 ¡A escribir para superar tu promedio diario!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Más estadísticas..."
+
+#: source/tmp/win-main/App.vue.ts:221
+#, javascript-format
+msgid "%s selected"
+msgstr "%s seleccionado(s)"
+
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s selecciones"
+
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Archivos relacionados"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Sin archivos relacionados"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Esta relación se basa en un enlace bidireccional."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Esta relación se basa en un enlace saliente."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Esta relación se basa en un enlace de retroceso."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
-#, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Esta relación se basa en %s etiquetas compartidas: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Otros archivos"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Abrir directorio"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "No hay otros archivos"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "Carpeta actual"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referencias"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "No hay citas en este documento."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Nombre"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Nube de etiquetas (Tags)"
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Alternar modo de legibilidad"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Exportando…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exportar"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "comando"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2126,8 +3213,8 @@ msgstr "Directorios"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Archivos"
 
@@ -2141,10 +3228,26 @@ msgstr "Caracteres"
 msgid "Words"
 msgstr "Palabras"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Áreas de trabajo"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "No hay archivos o carpetas abiertas"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Sin resultados"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Ningún directorio seleccionado"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Directorio vacío"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2174,15 +3277,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reinicia"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2243,13 +3337,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendario"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2459,130 +3546,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Establece un objetivo de escritura...."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Sin resultados"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Ningún directorio seleccionado"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Directorio vacío"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Áreas de trabajo"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "No hay archivos o carpetas abiertas"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "palabras el mes pasado"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "promedio diario"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "palabras hoy"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 ¡No hay quien te detenga!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 ¡Estás cerca de llegar a tu promedio diario!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 ¡A escribir para superar tu promedio diario!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Más estadísticas..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s seleccionado(s)"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s selecciones"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Alternar modo de legibilidad"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Exportando…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exportar"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "comando"
+msgid "Table size: %s &times; %s"
+msgstr "Tamaño de la tabla: %s × %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2604,11 +3571,6 @@ msgstr "Restringir búsqueda al directorio"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Búsqueda"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Limpiar búsqueda"
@@ -2622,1093 +3584,137 @@ msgstr "Alternar resultados"
 msgid "%s matches across %s files"
 msgstr "%s coincidencias en %s archivos"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Nombre"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Nube de etiquetas (Tags)"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "palabras"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "carácteres"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "No hay ningún documento abierto"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Archivos relacionados"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Sin archivos relacionados"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Esta relación se basa en un enlace bidireccional."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Esta relación se basa en un enlace saliente."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Esta relación se basa en un enlace de retroceso."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Tamaño de la tabla: %s × %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Esta relación se basa en %s etiquetas compartidas: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Añadir"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Otros archivos"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Acciones"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Abrir directorio"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Eliminar"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "No hay otros archivos"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Seleccionar carpeta…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Carpeta actual"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Seleccionar archivo"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Exportar proyecto a:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referencias"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Usar"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "No hay citas en este documento."
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Formatear"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#, javascript-format
+msgid "circa %s words"
+msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Conversión"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Cargando..."
 
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Archivos a incluir en la exportación"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Actualizador"
 
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Por favor, selecciona al menos un perfil para crear este proyecto."
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Nueva actualización disponible"
 
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Título del proyecto"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Tu versión"
 
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "Hoja de estilo CSL"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "Plantilla LaTeX"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "Plantilla HTML"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Eliminar archivo de la exportación"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Agregar archivo a la exportación"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Mover archivo hacia arriba"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Mover archivo hacia abajo"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "No has seleccionado ningun archivo para exportar."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Some files are selected for export but no longer exist in the directory."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
-"Algunos archivos están seleccionados para la exportación pero ya no existen "
-"en el directorio."
+"Hay una nueva versión de Zettlr disponible para descargar. Por favor, lee el "
+"changelog (registro de cambios) a continuación."
 
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "General"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Descargando la actualización"
 
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr "Sin resultados para \"%s\""
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "No hay actualizaciones disponibles. Esta es la versión más reciente"
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Apariencia"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Clica para empezar la actualización"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Administrador de archivos"
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Editor"
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Revisión ortográfica"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Autocorrección"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Renderizar citas"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Importar y Exportar"
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr "Buscando: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Enero"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Febrero"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Marzo"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Abril"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Mayo"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Junio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Julio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agosto"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Septiembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Octubre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Noviembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Diciembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Por debajo de la media mensual"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Por encima de la media mensual"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Más del doble de la media mensual"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Gráficos"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "Estadísticas FSAL"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Estadísticas de escritura"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "IDs de Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Patrón para los IDs de Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Usa expresiones regulares de ECMAScript"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Patrón utilizado para generar nuevos IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Variables disponibles: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Vínculos internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Vincular solo con el nombre del archivo"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "Al vincular archivos, agregar el nombre del documento..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Siempre"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Solo al vincular usando el ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr "Nunca"
 
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Formato de vínculo"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Los vínculos internos te permiten agregar un título opcional, separado por "
-"un carácter de barra vertical del objetivo del vínculo real. Aquí puedes "
-"definir el orden de los dos."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Title]]: Vínculo primero (recomendado)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Title|Link]]: Título primero"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Iniciar una búsqueda de texto completo al seguir los vínculos internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-"La cadena de búsqueda coincidirá con el contenido entre los corchetes: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Crear automáticamente archivos no existentes en esta carpeta al seguir "
-"vínculos internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Para que esto funcione, la carpeta debe estar abierta como un Espacio de "
-"trabajo en Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Ruta a la carpeta"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Comillas inteligentes"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Comillas dobles"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Deshabilitar comillas mágicas"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Comillas simples"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Patrones de sustitución de texto"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Coincidir palabras completas"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-"Cuando esté marcado, la autocorrección nunca reemplazará partes de palabras"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Reemplazar"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "Con"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filtro"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Modo de entrada"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"El modo de entrada determina cómo interactúas con el editor. Recomendamos "
-"mantener esta configuración en \"Normal\". Solo elige \"Vim\" o \"Emacs\" si "
-"sabes lo que implica."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Dirección de escritura"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Renderización de Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Marca para habilitar la renderización en vivo de varios elementos de "
-"Markdown a su apariencia formateada. Esto oculta los caracteres de formato "
-"(como **texto**) o renderiza imágenes en lugar de su enlace."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ocultar caracteres de encabezado"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Renderizar énfasis"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Revisar Markdown en busca de problemas de estilo"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Editor de tablas"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"El Editor de Tablas es una interfaz interactiva que simplifica la creación y "
-"edición de tablas. Proporciona botones para funcionalidades comunes y se "
-"encarga de la formateo de Markdown."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Silenciar líneas no enfocadas en el modo libre de distracciones"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Contador de palabras"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Contar caracteres en lugar de palabras (p. ej., para chino)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Modo de legibilidad"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algoritmo"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Anchura máxima de las imágenes (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Altura máxima de las imágenes (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Otras configuraciones"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Tamaño de la fuente"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Tamaño de la sangría (número de espacios)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Identar utilizando tabulaciones en lugar de espacios"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Resaltar espacios en blanco"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Sugerir emojis durante la autocompletación"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Mostrar vistas previas de enlaces"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Cerrar automáticamente pares de caracteres coincidentes"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Horario"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Apagar"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Seguir el sistema"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Encendido"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Fin"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Tema"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Opciones de la barra de herramientas"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Barra de estado"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Abrir editor de CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Rigor"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Estándar"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Exigente"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Idioma materno"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "No establecido"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Variantes preferidas"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool no puede distinguir ciertas variantes del idioma. Estas "
-"configuraciones ajustarán LanguageTool para detectar automáticamente tu "
-"variante preferida de estos idiomas."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Interpretar el inglés como"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Interpretar el alemán como"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Interpretar el portugués como"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Interpretar el catalán como"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Proveedor de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Servidor personalizado"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Dirección del servidor personalizado"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr ignorará los ajustes del \"proveedor de LanguageTool\" si introduces "
-"alguna credencial aquí."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Nombre de usuario de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "Clave API de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Activo"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Selecciona los idiomas para los que deseas habilitar la corrección "
-"ortográfica automática."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Diccionario del usuario. Elimina las palabras haciendo clic en ellas."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Entrada del diccionario"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Buscar entradas…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Modo de visualización"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Delgado"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Expandido"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Combinado"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"El modo Delgado muestra tus directorios y archivos por separado. Selecciona "
-"un directorio para que su contenido se muestre en la lista de archivos. "
-"Cambia entre la lista de archivos y el árbol de directorios haciendo clic en "
-"los directorios o en el botón de flecha que aparece en la esquina superior "
-"izquierda de la lista de archivos."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Mostrar información del archivo"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Mostrar carpetas encima de los archivos"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Mostrar nombre del documento Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Solo el nombre del archivo"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Título, si procede"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Primera cabecera de nivel 1, si procede"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Título o primera cabecera de nivel 1, si procede"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Mostrar extensiones de archivos Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Visualización del tiempo"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Hora de la última modificación"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Hora de creación del archivo"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Ordenar"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Al ordenar documentos…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Usar orden natural (2 viene antes de 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Usar orden ASCII (2 viene después de 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Importar y exportar perfiles"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Abrir el editor de perfiles de importación"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Abrir el editor de perfiles de exportación"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Configuraciones de exportación"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Usar el Pandoc interno de Zettlr para exportar"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Eliminar etiquetas de los archivos al exportar"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Eliminar completamente los enlaces internos"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Desvincular enlaces internos"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "No modificar los enlaces internos"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Carpeta de destino para los archivos exportados"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Carpeta temporal"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Misma ubicación que el archivo"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Preguntar por la carpeta al exportar"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"¡Advertencia! Los archivos en la carpeta temporal se eliminan regularmente. "
-"Elegir la misma ubicación que el archivo sobrescribirá archivos con nombres "
-"idénticos si ya existen."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Comandos de exportación personalizados"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Nombre para mostrar"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Comando"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Introduce comandos personalizados para ejecutar el exportador. Cada comando "
-"recibe como primer argumento el archivo o la carpeta del proyecto que se va "
-"a exportar."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Patrón para nombres de archivo nuevos"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Define un patrón para nombres de archivo nuevos"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Available variables: %s"
-msgstr "Variables disponibles: %s"
+msgid "Last checked: %s"
+msgstr "Última comprobación: %s"
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "No pedir nombre al crear nuevos archivos"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Utilizar la apariencia nativa de ventanas"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-"Solo disponible en Linux; este es el valor predeterminado para macOS y "
-"Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Activar la vibración de la ventana"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Solo disponible en macOS; hace que el fondo de la ventana sea opaco."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Mostrar la aplicación en el área de notificación"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Dejar la aplicación en ejecución en el área de notificación"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportamiento del zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Redimensiona toda la interfaz gráfica"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Cambia el tamaño de la fuente del editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Barra lateral de archivos adjuntos"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-"Extensiones de archivo visibles en la barra lateral de archivos adjuntos"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Lista blanca de renderizado de iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nombre del host"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Monitorización de vigilancia"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Tiempo de espera antes de que la escritura de un archivo se considere "
-"finalizada (en ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Eliminar elementos"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Modo de depuración"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Habilitar el modo de depuración"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Lanzamientos beta"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notificarme sobre las versiones beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Abrir el editor de fragmentos"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Idioma de la aplicación"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Autoguardado"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Guardar modificaciones"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Inmediatamente"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Después de un breve retraso"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Carpeta de imágenes predeterminada"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Haz clic en \"Seleccionar carpeta…\" o escribe una ruta absoluta o relativa "
-"directamente en el campo de entrada."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Comportamiento"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Evitar abrir archivos en nuevas pestañas si es posible"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Actualizaciones"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Comprobar automáticamente si hay actualizaciones"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "¿Cómo te gustaría que la autocompletación insertara tus citas?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Ruta al archivo"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Empezando la actualización..."
 
 #~ msgid "Open Link"
 #~ msgstr "Abrir enlace"

--- a/static/lang/et-ET.po
+++ b/static/lang/et-ET.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr ""
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Töölauad"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,140 +82,6 @@ msgstr ""
 msgid "Option %s is required."
 msgstr ""
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Näita Zettlrit"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Lahku"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "%s on uuendamiseks saadaval!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Faili polnud võimalik luua"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr ""
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Manust ei olnud võimalik avada. Kas Zotero töötab?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Olgu"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Tühista"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Kustuta?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Kas soovite tõesti %s eemaldada?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr ""
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Manust ei olnud võimalik avada. Kas Zotero töötab?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Moondunud Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Ekspordi Projekt"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Ekspordi..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -291,48 +245,6 @@ msgstr "%s faile pole võimalik importida, kuna nende failitüüp pole teada: %s
 msgid "Import failed"
 msgstr "Eksportimine ebaõnnestus"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Ekspordi Projekt"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Olgu"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Ekspordi..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Nimistut pole võimalik liigutada"
@@ -350,28 +262,49 @@ msgstr "Nimistut või faili pole võimalik liigutada."
 msgid "The file/directory %s already exists in target."
 msgstr "Fail või nimistu %s juba eksisteerib sihtkohas."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Nimetu"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "See nimi ei sisaldanud ühtki lubatud tähtedest."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Nimistut polnud võimalik luua"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Otsitud nimistut ei leitud."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Kustuta?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Eksportimine ebaõnnestus"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Eksportimisel tekkis viga: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Salvesta"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Kas soovite tõesti %s eemaldada?"
+msgid "Exporting to %s"
+msgstr "Eksportimine %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Eksportimisel tekkis viga: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -396,10 +329,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -413,127 +348,33 @@ msgstr "Keelefail imporditud: %s"
 msgid "Could not import language file %s!"
 msgstr "Keelefaili %s polnud võimalik importida!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Eksportimine ebaõnnestus"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Faili polnud võimalik luua"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Eksportimisel tekkis viga: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Salvesta"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Eksportimine %s"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Nimetu"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Nimistut polnud võimalik luua"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Eksportimisel tekkis viga: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "See nimi ei sisaldanud ühtki lubatud tähtedest."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Otsitud nimistut ei leitud."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Moondunud Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Asenda fail"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr "Faili %s on natukene muudetud. Asenda see versioon uuemaga kettalt?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Kirjuta olemasolev fail üle"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Fail %s on nimistus juba olemas. Kirjuta üle?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Ava fail"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Salvestamata muudatused"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Selles failis on salvestamata muudatusi. Kas soovid need hüljata või "
-"salvestada?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Ava porjekti kaust"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:44
@@ -646,6 +487,12 @@ msgstr "Nimeta fail ümber"
 msgid "Delete file"
 msgstr "Kustuta fail"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Lahku"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -664,15 +511,15 @@ msgstr "Tee uuesti"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Lõika"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopeeri"
 
@@ -684,8 +531,8 @@ msgstr "Kopeeri HTML-ina"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Kleebi"
 
@@ -697,8 +544,8 @@ msgstr "Kleebi ainult tekst"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Vali kõik"
 
@@ -941,10 +788,163 @@ msgstr "Lõpeta rääkimine"
 msgid "Bring All to Front"
 msgstr "Too kõik esiplaanile"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Töölauad"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Ava porjekti kaust"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Asenda fail"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr "Faili %s on natukene muudetud. Asenda see versioon uuemaga kettalt?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr ""
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Salvestamata muudatused"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Selles failis on salvestamata muudatusi. Kas soovid need hüljata või "
+"salvestada?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Ava fail"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Kirjuta olemasolev fail üle"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Fail %s on nimistus juba olemas. Kirjuta üle?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Näita Zettlrit"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "%s on uuendamiseks saadaval!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -963,143 +963,1182 @@ msgstr ""
 "Selles failis on salvestamata muudatusi. Kas soovid need hüljata või "
 "salvestada?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Failihalduri režiim"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Lülita automaatparandus välja"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Atribuudid"
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Paljunda faili"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
 #, fuzzy
-msgid "Copy path"
-msgstr "Kopeeri täispikk rada"
+msgid "Replace"
+msgstr "Asenda fail"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopeeri failinimi"
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filter ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Ajakava"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Väljas"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Jälgi operatsioonisüsteemi"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Alustamine"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Näita Zettlrit"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Kohandatud CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Ava nimistu"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Eksportimine %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Kasuta eksportimiseks sisemist Pandoci"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Eemalda failidelt märksõnad"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Sisesta link"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Eemalda kõik sisemised lingid"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Ära puutu sisemisi linke"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Näita faili infot"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Kuva pildi nupp"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Kommentaar"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Muster uute failinimede jaoks"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Muster uute failinimede jaoks"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Suumi käitumine"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Suum muutab terve GUI (graafilise kasutajaliigese) suurust"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Suum muudab toimetaja kirjasuurust"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Kustuta fail"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Tume režiim"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Teavita mind beta väljaannetest"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Otsi nimistust"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Paks"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursiiv"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr ""
+"Muuda segajatevabas režiimis ollas fookusest väljas olevad read häguseks"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Sõnade arv"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Loe sõnade asemel tähemärke (nt hiina keele puhul)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Pilt"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Fotode maksimaalne laius (protsentides)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Fotode maksimaalne kõrgus (protsentides)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Teised failid"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Toimetaja kirjasuurus"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Luba tühikud automaattäitmise ajal"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Kuva pildi nupp"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Näita faili infot"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Näita kaustu üle failide"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Ainult failinimi"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Nimi, kui võimalik"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Esimese pealkirja tase 1, kui võimalik"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Nimi või esimese pealkirja tase 1, kui võimalik"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Faili loomisaeg"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Ekspordi..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Hiljutised dokumendid"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Tegevused"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Lisa faili"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Muster uute failinimede jaoks"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Ainult failinimi"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "alati"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "ainult siis, kui linkides ID-d kasutada"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "mitte kunagi"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Järgidel Zettelkasteni linke, alusta otsingut"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalender"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Kohandatud CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Kohandatud CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Tegevused"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kood"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Vali keeled, mille puhul automaatparandust kasutada."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Kasuta sõnaraamatut. Eemalda sõnad neile vajutades."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Sõnaraamatu sissekanne"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Otsi sissekandeid ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automaatsalvestus"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Kohe"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Väikese viivitusega"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Suumi käitumine"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Kui võimalik, hoidu failide avamisest uues aknas"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Uuendaja"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Kontrolli uuendusi automaatselt"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s tähemärki"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s sõna"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Kohandatud CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Faili polnud võimalik luua"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Sõnade arv"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Muudetud"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Ava..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Ava uues aknas"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Pilt"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Kommentaar"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Kopeeri võrrandikood"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Kopeeri pilt lõikelauale"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Ava fail"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Ava brauseris"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Soovitusi pole"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Lisa sõnaraamatusse"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursiiv"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Sisesta link"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Sisesta järjestamata nimekiri"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Sisesta nummerdatud nimekiri"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Sulge fail"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Nimeta nimistu ümber"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Kustuta nimistu"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Kontrolli nimistut ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Ekspordi Projekt"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Sulge teised vaheaknad"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Sulge kõik vaheaknad"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1531,325 +2570,322 @@ msgstr "hiina (Hiina)"
 msgid "Chinese"
 msgstr "hiina (Hiina)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Atribuudid"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Paljunda faili"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Kohandatud CSS"
+msgid "Copy path"
+msgstr "Kopeeri täispikk rada"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s sõna"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopeeri failinimi"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s tähemärki"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Sulge fail"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Nimeta nimistu ümber"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Kustuta nimistu"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Kontrolli nimistut ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Ekspordi Projekt"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Sulge teised vaheaknad"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Sulge kõik vaheaknad"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Paks"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursiiv"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Pilt"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Kommentaar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kood"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Sõnade arv"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Muudetud"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Ava..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Ava uues aknas"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "jaanuar"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "veerbuar"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "märts"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "aprill"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "mai"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "juuni"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "juuli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "august"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "september"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "oktoober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "november"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "detsember"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Alla kuu keskmise"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Üle kuu keskmise"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Kopeeri pilt lõikelauale"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Ava fail"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Ava brauseris"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Soovitusi pole"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Lisa sõnaraamatusse"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursiiv"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Sisesta link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Sisesta järjestamata nimekiri"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Sisesta nummerdatud nimekiri"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Kopeeri võrrandikood"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Faili polnud võimalik luua"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Uuendaja"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Uuendus saadaval"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Sinu versioon"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Uuenduse allalaadimine"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Uuendus pole saadaval. Sul on olemas kõige hilisem versioon."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klõpsa uuenduse alustamiseks"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Uuenduse alustamine ..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Otsi"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtreeri märksõnu..."
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Lähtesta"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Ava porjekti kaust"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Kustuta fail"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Lisa"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Tegevused"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Kustuta fail"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Pilt"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1866,10 +2902,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1920,42 +2952,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Salvestamine ..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Salvestamine nurjus"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Kohandatud CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Salvestatud!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1977,39 +2995,74 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Muuda importimise ja eksportimise vaikimisi sätteid siin."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Salvestatud!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "sõnad"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Salvestamine nurjus"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "tähemärke"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Avatud dokumenti pole"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Alustamine"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtreeri märksõnu..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2035,76 +3088,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "sõnu see kuu"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "Päevane keskmine"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "sõnu täna"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Sa oled leegitsemas!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Seotud failid"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Seotud faile pole"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Rohkem statistikat ..."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Teised failid"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Ava nimistu"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Teisi faile pole"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Viited"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Selles dokumendis pole ühtegi tsitaati."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Märksõnade pilv"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Ekspordi..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Ekspordi..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2114,8 +3207,8 @@ msgstr "Nimistud"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Failid"
 
@@ -2129,10 +3222,26 @@ msgstr "Tähemärgid"
 msgid "Words"
 msgstr "Sõnad"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Töölauad"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Avatud failid või kaustad puuduvad"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Tulemused puuduvad"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nimistut pole valitud"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Tühi nimistu"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2162,15 +3271,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Lähtesta"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2231,13 +3331,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2447,131 +3540,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Sea kirjutamiseesmärk..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Tulemused puuduvad"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nimistut pole valitud"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Tühi nimistu"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Töölauad"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Avatud failid või kaustad puuduvad"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "sõnu see kuu"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "Päevane keskmine"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "sõnu täna"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Sa oled leegitsemas!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr ""
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Rohkem statistikat ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Ekspordi..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Ekspordi..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2594,11 +3565,6 @@ msgstr "Piira otsing nimistule."
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Otsi"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Tühjenda otsing"
@@ -2612,1095 +3578,135 @@ msgstr "Tulemuste lüliti"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Märksõnade pilv"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "sõnad"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "tähemärke"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Avatud dokumenti pole"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Seotud failid"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Seotud faile pole"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Lisa"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Tegevused"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Kustuta fail"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Ava porjekti kaust"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Kustuta fail"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Lülita automaatparandus välja"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Tegevused"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "jaanuar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "veerbuar"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "märts"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "aprill"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "mai"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "juuni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "juuli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "august"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "september"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "oktoober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "november"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "detsember"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Alla kuu keskmise"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Üle kuu keskmise"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Muster uute failinimede jaoks"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Sisesta link"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Ainult failinimi"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "alati"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "ainult siis, kui linkides ID-d kasutada"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "mitte kunagi"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Järgidel Zettelkasteni linke, alusta otsingut"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Asenda fail"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filter ..."
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Otsi nimistust"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr ""
-"Muuda segajatevabas režiimis ollas fookusest väljas olevad read häguseks"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Sõnade arv"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Loe sõnade asemel tähemärke (nt hiina keele puhul)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Fotode maksimaalne laius (protsentides)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Fotode maksimaalne kõrgus (protsentides)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Teised failid"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Toimetaja kirjasuurus"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Luba tühikud automaattäitmise ajal"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Ajakava"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Väljas"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Jälgi operatsioonisüsteemi"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Näita Zettlrit"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Ava nimistu"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Teisi faile pole"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalender"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Viited"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Selles dokumendis pole ühtegi tsitaati."
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Kohandatud CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Kohandatud CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Tegevused"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Vali keeled, mille puhul automaatparandust kasutada."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Kasuta sõnaraamatut. Eemalda sõnad neile vajutades."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Sõnaraamatu sissekanne"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Otsi sissekandeid ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Kuva pildi nupp"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Näita faili infot"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Näita kaustu üle failide"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Ainult failinimi"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Nimi, kui võimalik"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Esimese pealkirja tase 1, kui võimalik"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Nimi või esimese pealkirja tase 1, kui võimalik"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Faili loomisaeg"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Ekspordi..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Hiljutised dokumendid"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Eksportimine %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Kasuta eksportimiseks sisemist Pandoci"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Eemalda failidelt märksõnad"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Eemalda kõik sisemised lingid"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Ära puutu sisemisi linke"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Näita faili infot"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Kuva pildi nupp"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Kommentaar"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Muster uute failinimede jaoks"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Muster uute failinimede jaoks"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Suumi käitumine"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Suum muutab terve GUI (graafilise kasutajaliigese) suurust"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Suum muudab toimetaja kirjasuurust"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Kustuta fail"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Tume režiim"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Teavita mind beta väljaannetest"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automaatsalvestus"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Kohe"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Väikese viivitusega"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Suumi käitumine"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Kui võimalik, hoidu failide avamisest uues aknas"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Uuendaja"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Kontrolli uuendusi automaatselt"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Uuendus saadaval"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Sinu versioon"
+
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Uuenduse allalaadimine"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Uuendus pole saadaval. Sul on olemas kõige hilisem versioon."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klõpsa uuenduse alustamiseks"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Lisa faili"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Uuenduse alustamine ..."
 
 #~ msgid "Open Link"
 #~ msgstr "Ava link"

--- a/static/lang/eu-EU.po
+++ b/static/lang/eu-EU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Aipuen datubasea ezin izan da kargatu"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Fitxategien liburutegiak aldaketak hauteman dira. Birkargatzen..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Lan eremuak"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,144 +81,6 @@ msgstr "%s aukerak %s (karaktereko luzera) izan behar du gutxienez."
 msgid "Option %s is required."
 msgstr "%s aukera derrigorrezkoa da."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Irten"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Ezin izan dira eguneraketak bilatu: Zerbitzariaren Errorea (egoera kodea: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Ezin izan dira eguneraketak bilatu: Bezeroaren Errorea (egoera kodea: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Ezin izan dira eguneraketak bilatu: Zerbitzaria birbideratzen saiatu da "
-"(egoera kodea: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Ezin izan dira eguneraketak bilatu: Ezin izan da konexioa ezarri"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Ezin izan dira eguneraketak bilatu: Zerbitzariak ez du daturik bidali"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Ezin izan da fitxategia sortu"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Ez dirudi %s gakoa duen erreferentziak eranskinik duenik."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Ezin izan da eranskina ireki. Zotero martxan al dago?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -222,24 +98,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Ezeztatu"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Ezabatu, ziur?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Ziur al zaude %s ezabatu nahi duzula?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Ez dirudi %s gakoa duen erreferentziak eranskinik duenik."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Ezin izan da eranskina ireki. Zotero martxan al dago?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Gaizki osatutako testu multzoa: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Proiektua esportatu"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Esportatu..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -296,48 +246,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Esportazioak huts egin du"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Proiektua esportatu"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Esportatu..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Ezin da direktorioa mugitu"
@@ -355,28 +263,49 @@ msgstr "Ezin da direktorioa edo fitxategia mugitu"
 msgid "The file/directory %s already exists in target."
 msgstr "%s fitxategia/direktorioa badago dagoeneko helburuan."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Izenburu gabea"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Emandako izenak ez zuen baimendutako hizkirik."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Ezin izan da direktorioa sortu"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Eskatutako direktorioa ez da aurkitu."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Ezabatu, ziur?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Esportazioak huts egin du"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Errore bat gertatu da esportatzerakoan: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Gorde"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Ziur al zaude %s ezabatu nahi duzula?"
+msgid "Exporting to %s"
+msgstr "%s-ra esportatzen."
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Errore bat gertatu da esportatzerakoan: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -401,10 +330,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -418,128 +349,34 @@ msgstr "Hizkuntza fitxategia inportatu da: %s"
 msgid "Could not import language file %s!"
 msgstr "Ezin izan da %s hizkuntza fitxategia inportatu!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Esportazioak huts egin du"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Ezin izan da fitxategia sortu"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Errore bat gertatu da esportatzerakoan: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Gorde"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "%s-ra esportatzen."
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Izenburu gabea"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Ezin izan da direktorioa sortu"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Errore bat gertatu da esportatzerakoan: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Emandako izenak ez zuen baimendutako hizkirik."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Eskatutako direktorioa ez da aurkitu."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Gaizki osatutako testu multzoa: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Urruneko aldaketak beti kargatu uneko fitxategian"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Gainidatzi aurrez badagoen fitxategia"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "%s fitxategia badago dagoeneko direktorio honetan. Gainidatzi?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Fitxategia ireki"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Gorde gabeko aldaketak daude uneko fitxategian. Baztertu nahi dituzu, ala "
-"gorde?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Proiektu karpeta ireki"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Aipuen datubasea ezin izan da kargatu"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Fitxategien liburutegiak aldaketak hauteman dira. Birkargatzen..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -651,6 +488,12 @@ msgstr "Fitxategia berrizendatu"
 msgid "Delete file"
 msgstr "Fitxategia ezabatu"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Irten"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -669,15 +512,15 @@ msgstr "Berriro egin"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Moztu"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopiatu"
 
@@ -689,8 +532,8 @@ msgstr "HTML bezala kopiatu"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Itsasi"
 
@@ -702,8 +545,8 @@ msgstr "Estilorik gane itsatsi"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Hautatu guztiak"
 
@@ -945,10 +788,167 @@ msgstr "Utzi hitz egiteari"
 msgid "Bring All to Front"
 msgstr "Ekarri denak aurrera"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Lan eremuak"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Proiektu karpeta ireki"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Urruneko aldaketak beti kargatu uneko fitxategian"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Gorde gabeko aldaketak daude uneko fitxategian. Baztertu nahi dituzu, ala "
+"gorde?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Fitxategia ireki"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Gainidatzi aurrez badagoen fitxategia"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "%s fitxategia badago dagoeneko direktorio honetan. Gainidatzi?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Ezin izan dira eguneraketak bilatu: Zerbitzariaren Errorea (egoera kodea: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Ezin izan dira eguneraketak bilatu: Bezeroaren Errorea (egoera kodea: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Ezin izan dira eguneraketak bilatu: Zerbitzaria birbideratzen saiatu da "
+"(egoera kodea: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Ezin izan dira eguneraketak bilatu: Ezin izan da konexioa ezarri"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Ezin izan dira eguneraketak bilatu: Zerbitzariak ez du daturik bidali"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -967,143 +967,1182 @@ msgstr ""
 "Gorde gabeko aldaketak daude uneko fitxategian. Baztertu nahi dituzu, ala "
 "gorde?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Fitxategi kudeatzailearen modua"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
-msgstr ""
-
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr ""
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Fitxategia bikoiztu"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
 #, fuzzy
-msgid "Copy path"
-msgstr "IDa kopiatu"
+msgid "Autocorrect"
+msgstr "Zuzenketa automatikoa aktibatu"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Fitxategiaren izena kopiatu"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Bat ere ez"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Bat ere ez"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Bat ere ez"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Fitxategia ordezkatu"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Etiketak iragazi..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Planifikatu"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Desaktibatuta"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Sistema eragilea jarraitu"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Hasi"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS pertsonalizatua"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Direktorioa ireki"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "%s-ra esportatzen."
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Fitxategietatik etiketak kendu"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Barne esteken estekak kendu"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Barne estekak ezabatu erabat"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Barne esteken estekak kendu"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Ez ukitu barne estekak"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Fitxategiaren informazioa erakutsi"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Iruzkina"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Fitxategi berriak izendatzeko eredua"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Fitxategi berriak izendatzeko eredua"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Ez galdetu fitxategiaren izena fitxategi berriak sortzerakoan"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Leihoen itxura jatorrizkoa erabili"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Leihoen itxura jatorrizkoa erabili"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Watchdog galdeketak aktibatu"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Fitxategin batean idaztea egintzat emateko itxoin beharreko denbora (ms-tan)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Fitxategia ezabatu"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Arazketa modua gaitu"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Arazketa modua gaitu"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Beta bertsioak jakinarazi"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Editorearen sarrera modua"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Direktorioan bilatu"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ezkutatu izenburu karaktereak"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Letra lodia"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Letra etzana"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Taulen editorea gaitu"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Mututu fokoz kanpoko lerroak distraziorik gabeko moduan"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Karaktereak zenbatu hitzen ordez (adibidez, txineraz)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Irudia"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Honako zuriune kopuruarekin koskatu"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Honako zuriune kopuruarekin koskatu"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Automatikoki itxi bat datozen karaktere pareak"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Fitxategiaren informazioa erakutsi"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Azken aldaketaren data"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Fitxategiaren sorrera data"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Esportatu..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Duela gutxi erabilitako dokumentuak"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordena naturala (10a 2a eta gero)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII ordena (2a 10a eta gero)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Aipuak errendatu"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Erakutsi fitxategia"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "IDak sortzeko erabilitako eredua"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID adierazpen erregularra"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "IDak sortzeko erabilitako eredua"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Fitxategiak estekatzerakoan, fitxategiaren izena gehitu..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "beti"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "IDa erabiliz estekatzerakoan bakarrik"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "inoiz ez"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr ""
+"Existitzen ez duten fitxategiak automatikoki sortu barne estekak jarraitzean"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Existitzen ez duten fitxategiak automatikoki sortu barne estekak jarraitzean"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "CSS pertsonalizatua"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "CSS pertsonalizatua"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kodea"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Aukeratu zein hizkuntzatan gaitu nahi duzun ortografiaren egiaztatze "
+"automatikoa."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Erabiltzailearen hiztegia. Ezabatu hitzak haietan klik eginda."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Azken aldaketaren data"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s hitz"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "CSS pertsonalizatua"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Ezin izan da fitxategia sortu"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Ireki..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Esteka"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Irudia"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Iruzkina"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Fitxategia ireki"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Iradokizunik ez"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Hiztegira gehitu"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Letra etzana"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Txertatu esteka"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Ordenaron gabeko zerrenda gehitu"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Txertatu zenbakitutako zerrenda"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Fitxategia itxi"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Direktorioaren izena aldatu"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Direktorioa ezabatu"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Bilatu direktorioa..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Proiektua esportatu"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Fitxa guztiak itxi"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1535,326 +2574,322 @@ msgstr "Txinera"
 msgid "Chinese"
 msgstr "Txinera"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Fitxategia bikoiztu"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "CSS pertsonalizatua"
+msgid "Copy path"
+msgstr "IDa kopiatu"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s hitz"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Fitxategiaren izena kopiatu"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Fitxategia itxi"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Direktorioaren izena aldatu"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Direktorioa ezabatu"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Bilatu direktorioa..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Proiektua esportatu"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Fitxa guztiak itxi"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Letra lodia"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Letra etzana"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Esteka"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Irudia"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Iruzkina"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kodea"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Ireki..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Fitxategia ireki"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Iradokizunik ez"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Hiztegira gehitu"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Letra etzana"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Txertatu esteka"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Ordenaron gabeko zerrenda gehitu"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Txertatu zenbakitutako zerrenda"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Ezin izan da fitxategia sortu"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Eguneraketa berria eskuragarri"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Zure bertsioa"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Zettlr-en bertsio berri bat dago deskargatzeko eskuragarri. Mesedez irakurri "
-"aldaketen erregistroa azpian."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Etiketak iragazi..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Proiektu karpeta ireki"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Fitxategia ezabatu"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Fitxategia ezabatu"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Irudia"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1871,10 +2906,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1938,45 +2969,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr-ek honako proiektuak erabiltzen ditu:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"Zettlr-en estiloak gainidatzi ditzakezu hemen, itxura are gehiago "
-"pertsonalizatzeko. <strong>Adi: Fitxategi honek CSS direktiba guztiak "
-"gainidatziko ditu! Ez eraldatu inoiz elementuen gemoetria, bestela "
-"aplikazioak nahi ez den portaera izan dezake!</strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS pertsonalizatua"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1999,39 +3012,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr ""
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Zettlr-en estiloak gainidatzi ditzakezu hemen, itxura are gehiago "
+"pertsonalizatzeko. <strong>Adi: Fitxategi honek CSS direktiba guztiak "
+"gainidatziko ditu! Ez eraldatu inoiz elementuen gemoetria, bestela "
+"aplikazioak nahi ez den portaera izan dezake!</strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "hitz"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "karaktere"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Hasi"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Etiketak iragazi..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2057,76 +3109,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "hitz joan den hilabetean"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "eguneko batazbestekoa"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "hitz gaur"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Sutan zaude!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Zure eguneko batazbestetik gertu zaude!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Ekin idazteari zure eguneko batazbestekoa gainditzeko."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Estatistika gehiago..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Direktorioa ireki"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Erreferentziak"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Ez dago aipurik dokumentu honetan."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Etiketa-hodeia"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Esportatu..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Esportatu..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2136,8 +3228,8 @@ msgstr "Direktorioak"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Fitxategiak"
 
@@ -2151,10 +3243,26 @@ msgstr "Karaktereak"
 msgid "Words"
 msgstr "Hitzak"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Lan eremuak"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Ez dago fitxategi edo direktoriorik irekita"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Ez dago emaitzarik"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Ez dago direktoriorik hautatuta"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Direktorioa hutsik"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2183,15 +3291,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2252,13 +3351,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2469,131 +3561,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Idazteko helburua ezarri..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Ez dago emaitzarik"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Ez dago direktoriorik hautatuta"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Direktorioa hutsik"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Lan eremuak"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Ez dago fitxategi edo direktoriorik irekita"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "hitz joan den hilabetean"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "eguneko batazbestekoa"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "hitz gaur"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Sutan zaude!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Zure eguneko batazbestetik gertu zaude!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Ekin idazteari zure eguneko batazbestekoa gainditzeko."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Estatistika gehiago..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Esportatu..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Esportatu..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2616,11 +3586,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2634,1095 +3599,136 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Etiketa-hodeia"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "hitz"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "karaktere"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Fitxategia ezabatu"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Proiektu karpeta ireki"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Fitxategia ezabatu"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Zuzenketa automatikoa aktibatu"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Aipuak errendatu"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "IDak sortzeko erabilitako eredua"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID adierazpen erregularra"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "IDak sortzeko erabilitako eredua"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Barne esteken estekak kendu"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Fitxategiak estekatzerakoan, fitxategiaren izena gehitu..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "beti"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "IDa erabiliz estekatzerakoan bakarrik"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "inoiz ez"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr ""
-"Existitzen ez duten fitxategiak automatikoki sortu barne estekak jarraitzean"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Existitzen ez duten fitxategiak automatikoki sortu barne estekak jarraitzean"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Bat ere ez"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Bat ere ez"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Bat ere ez"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Fitxategia ordezkatu"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Etiketak iragazi..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Editorearen sarrera modua"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Direktorioan bilatu"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ezkutatu izenburu karaktereak"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Taulen editorea gaitu"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Mututu fokoz kanpoko lerroak distraziorik gabeko moduan"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Karaktereak zenbatu hitzen ordez (adibidez, txineraz)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Honako zuriune kopuruarekin koskatu"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Honako zuriune kopuruarekin koskatu"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Automatikoki itxi bat datozen karaktere pareak"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Planifikatu"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Desaktibatuta"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Sistema eragilea jarraitu"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Direktorioa ireki"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Erreferentziak"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Ez dago aipurik dokumentu honetan."
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "CSS pertsonalizatua"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "CSS pertsonalizatua"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Aukeratu zein hizkuntzatan gaitu nahi duzun ortografiaren egiaztatze "
-"automatikoa."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Erabiltzailearen hiztegia. Ezabatu hitzak haietan klik eginda."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Fitxategiaren informazioa erakutsi"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Azken aldaketaren data"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Fitxategiaren sorrera data"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Esportatu..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Duela gutxi erabilitako dokumentuak"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordena naturala (10a 2a eta gero)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII ordena (2a 10a eta gero)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "%s-ra esportatzen."
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Fitxategietatik etiketak kendu"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Barne estekak ezabatu erabat"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Barne esteken estekak kendu"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Ez ukitu barne estekak"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Fitxategiaren informazioa erakutsi"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Iruzkina"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Fitxategi berriak izendatzeko eredua"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Fitxategi berriak izendatzeko eredua"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Ez galdetu fitxategiaren izena fitxategi berriak sortzerakoan"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Leihoen itxura jatorrizkoa erabili"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Leihoen itxura jatorrizkoa erabili"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Eguneraketa berria eskuragarri"
 
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Zure bertsioa"
 
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Watchdog galdeketak aktibatu"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Fitxategin batean idaztea egintzat emateko itxoin beharreko denbora (ms-tan)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Fitxategia ezabatu"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Arazketa modua gaitu"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Arazketa modua gaitu"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Beta bertsioak jakinarazi"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Azken aldaketaren data"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Zettlr-en bertsio berri bat dago deskargatzeko eskuragarri. Mesedez irakurri "
+"aldaketen erregistroa azpian."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Erakutsi fitxategia"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Open Link"

--- a/static/lang/fi-FI.po
+++ b/static/lang/fi-FI.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "citeproc: Viittaustietokantaa ei voitu ladata"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+"citeproc: Havaittiin kirjastotiedostoon tehtyjä muutoksia. Ladataan "
+"uudelleen…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Työtilat"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,143 +84,6 @@ msgstr "Valinnan %s on oltava vähintään %s merkkiä."
 msgid "Option %s is required."
 msgstr "Valinta %s on pakollinen."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Näytä Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Lopeta"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Päivitys versioon %s on saatavilla!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Päivitysten tarkistaminen ei onnistunut: palvelinvirhe (status %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Päivitysten tarkistaminen ei onnistunut: asiakasohjelman virhe (status %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Päivitysten tarkistaminen ei onnistunut: palvelimen uudelleenohjaus (status "
-"%s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Päivitysten tarkistaminen ei onnistunut: yhteyttä ei voitu muodostaa"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Ei voitu tarkistaa päivityksiä: %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Päivitysten tarkistaminen ei onnistunut: tyhjä vastaus palvelimelta"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Tiedostoa ei voitu luoda"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Viiteavaimeen %s ei näytä liittyvän liitetiedostoja."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Liitettä ei voitu avata. Onko Zotero käynnissä?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -222,24 +101,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Peruuta"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Vahvista poisto"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Haluatko varmasti poistaa: %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Viiteavaimeen %s ei näytä liittyvän liitetiedostoja."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Liitettä ei voitu avata. Onko Zotero käynnissä?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Epäkelpo Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Vie projekti"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Vie…"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -295,48 +248,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Vienti epäonnistui"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Vie projekti"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Vie…"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Hakemistoa ei voi siirtää"
@@ -354,28 +265,49 @@ msgstr "Ei voitu siirtää"
 msgid "The file/directory %s already exists in target."
 msgstr "Tiedosto tai hakemisto %s on jo olemassa."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Uusi hakemisto"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Annetussa nimessä ei ollut sallittuja kirjaimia (no_allowed_chars)."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Hakemistoa ei voitu luoda"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Pyydettyä hakemistoa ei löydy."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Vahvista poisto"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Vienti epäonnistui"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Viennissä tapahtui virhe: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Valitse vientikohde"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Tallenna"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Haluatko varmasti poistaa: %s?"
+msgid "Exporting to %s"
+msgstr "Viedään: %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Viennissä tapahtui virhe: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -400,10 +332,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -417,131 +351,34 @@ msgstr "Käännöstiedosto tuotu: %s"
 msgid "Could not import language file %s!"
 msgstr "Ei voitu tuoda käännöstiedostoa %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Vienti epäonnistui"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Tiedostoa ei voitu luoda"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Viennissä tapahtui virhe: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Valitse vientikohde"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Tallenna"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Viedään: %s"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Uusi hakemisto"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Hakemistoa ei voitu luoda"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Viennissä tapahtui virhe: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Annetussa nimessä ei ollut sallittuja kirjaimia (no_allowed_chars)."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Pyydettyä hakemistoa ei löydy."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Epäkelpo Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr ""
-"Päivitä tiedosto aina, jos ulkoisia muutoksia nykyiseen tiedostoon havaitaan"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Päällekirjoita olemassaoleva tiedosto"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr ""
-"Tiedosto %s on jo olemassa tässä hakemistossa. Kirjoitetaanko sen päälle?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Avaa tiedosto"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Tallentamattomia muutoksia"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Nykyistä tiedostoa on muutettu. Haluatko hylätä vai tallentaa muutokset?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Avaa hakemisto"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "citeproc: Viittaustietokantaa ei voitu ladata"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr ""
-"citeproc: Havaittiin kirjastotiedostoon tehtyjä muutoksia. Ladataan "
-"uudelleen…"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -653,6 +490,12 @@ msgstr "Nimeä tiedosto uudelleen"
 msgid "Delete file"
 msgstr "Poista tiedosto"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Lopeta"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -671,15 +514,15 @@ msgstr "Tee sittenkin"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Leikkaa"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopioi"
 
@@ -691,8 +534,8 @@ msgstr "Kopioi HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Liitä"
 
@@ -704,8 +547,8 @@ msgstr "Liitä ilman muotoiluja"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Valitse kaikki"
 
@@ -948,10 +791,167 @@ msgstr "Lopeta puhuminen"
 msgid "Bring All to Front"
 msgstr "Tuo kaikki eteen"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Työtilat"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Avaa hakemisto"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr ""
+"Päivitä tiedosto aina, jos ulkoisia muutoksia nykyiseen tiedostoon havaitaan"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Tallentamattomia muutoksia"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Nykyistä tiedostoa on muutettu. Haluatko hylätä vai tallentaa muutokset?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Avaa tiedosto"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Päällekirjoita olemassaoleva tiedosto"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr ""
+"Tiedosto %s on jo olemassa tässä hakemistossa. Kirjoitetaanko sen päälle?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Näytä Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Päivitys versioon %s on saatavilla!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Päivitysten tarkistaminen ei onnistunut: palvelinvirhe (status %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Päivitysten tarkistaminen ei onnistunut: asiakasohjelman virhe (status %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Päivitysten tarkistaminen ei onnistunut: palvelimen uudelleenohjaus (status "
+"%s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Päivitysten tarkistaminen ei onnistunut: yhteyttä ei voitu muodostaa"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Ei voitu tarkistaa päivityksiä: %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Päivitysten tarkistaminen ei onnistunut: tyhjä vastaus palvelimelta"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -969,143 +969,1199 @@ msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr ""
 "Nykyistä tiedostoa on muutettu. Haluatko hylätä vai tallentaa muutokset?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Tiedostoselaimen muoto"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Laita AutoCorrect päälle"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Ominaisuudet"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Monista tiedosto"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Kopioi koko polku"
+msgid "Double Quotes"
+msgstr "Ei mikään"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopioi tiedostonnimi"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Ei mikään"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Ei mikään"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Korvaa tiedosto"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Suodatin..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Aikataulun mukaan, kello&nbsp;"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Pois päältä"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Käyttöjärjestelmän mukaan"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Aloita"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Näytä Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Mukautettu CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Avaa hakemisto"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Viedään: %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Käytä sisäistä Pandoc-asennusta dokumenttien vientiin"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Poista tunnisteet tiedostoista"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Poista linkitys (ei kuitenkaan linkkitekstejä) sisäisiin tiedostoihin"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Poista sisäiset linkit (myös linkkitekstit) kokonaan"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Poista linkitys (ei kuitenkaan linkkitekstejä) sisäisiin tiedostoihin"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Älä kajoa sisäisiin linkkeihin"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Näytä sivupalkissa tiedostojen lisätiedot"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Näytä kuvapainike"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Kommentti"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Uusien tiedostonimien muoto"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Uusien tiedostonimien muoto"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Älä kysy tiedostonimeä uusia tiedostoja luotaessa"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Käytä alkuperäistä ikkunoiden ulkonäköä"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Käytä alkuperäistä ikkunoiden ulkonäköä"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Näytä sovellus ilmoitusalueella"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Jätä sovellus päälle ilmoitusalueelle"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoomaus-käyttäytyminen"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Zoom muuttaa koko käyttöliittymän kokoa"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Zoom muuttaa editorin fonttikokoa"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "iFrame-renderöinti valkoinen lista"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Isäntänimi"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktivoi Watchdog kysely"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Odotusaika ennen kuin tiedoston kirjoittaminen on todettu valmiiksi (ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Poista tiedosto"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Vianmääritystila (debug)"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Vianmääritystila (debug)"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Ilmoita betaversioista"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Tekstieditorin syöttötila"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Etsi hakemistosta"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Piilota otsakemerkit"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Hahmonna korostukset"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Lihavoitu"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursivoitu"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Käytä taulukkomuokkainta"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Häiriöttömän tilan ollessa käytössä, mykistä muut rivit"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Sanamäärä"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Laske merkkejä sanojen sijaan (esim. kiinalle)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Kuva"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Kuvien maksimileveys (prosenttia)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Kuvien maksimikorkeus (prosenttia)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Muut tiedostot"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Editorin fonttikoko"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Sisennyksessä käytettävien välilyöntien määrä"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Sisennä käyttämällä sarkainta"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Hyväksy välilyöntejä automaattisen täydennyksen aikana"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Sulje automaattisesti yhtenevät merkkiparit"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Näytä kuvapainike"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Näytä sivupalkissa tiedostojen lisätiedot"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Näytä kansiot ennen tiedostoja"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Vain tiedostonimeä"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Otsikkoa (jos saatavilla)"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "1. tason otsikkoa (jos saatavilla)"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Otsikkoa tai 1. tason otsikkoa (jos saatavilla)"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Näytä Markdown-tiedostopääte"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Viimeksi muokattu"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Tiedoston luontiaika"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Vie…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Viimeaikaiset tiedostot"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Luonnollinen järjestys (10 näytetään 2:n jälkeen)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII:n mukainen järjestys (2 näytetään 10:n jälkeen)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Näytä lainaukset"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Kuinka haluat automaattisen täydennyksen lisäävän viitteesi?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Lisää tiedostoon"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Generoitavien ID-numeroiden muoto"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID-numeron säännöllinen lauseke (regex)"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Generoitavien ID-numeroiden muoto"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Vain tiedostonimeä"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Linkitettäessä tiedostoja lisää tiedostonimi..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "aina"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "vain linkitettäessä ID:n avulla"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "ei koskaan"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Aloita haku Zettelkasten-linkkejä seurattaessa"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Luo puuttuvat tiedostot automaattisesti sisäisiä linkkejä luotaessa"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalenteri"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Mukautettu CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Mukautettu CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Toiminnot"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Koodi"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Valitse kielet, joille automaattinen oikeinkirjoituksen tarkistus otetaan "
+"käyttöön."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Mukautettu sanakirja. Poista sanoja klikkaamalla."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Sanakirjan merkintä"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Etsi..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automaattinen tallennus"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Viimeksi muokattu"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Välittömästi"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Lyhyen viiveen jälkeen"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Zoomaus-käyttäytyminen"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Vältä tiedostojen avaamista uusissa välilehdissä, jos mahdollista"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Päivittäjä"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Tarkista päivitykset automaattisesti"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s merkkiä"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s sanaa"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Mukautettu CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Tiedostoa ei voitu luoda"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Sanamäärä"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Muokattu"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Avaa…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Avaa uudessa välilehdessä"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Linkki"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Kuva"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Kommentti"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Kopioi yhtälön koodi"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Kopioi kuva leikepöydälle"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Avaa tiedosto"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Avaa selaimessa"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Ei ehdotuksia"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Lisää sanakirjaan"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursivoitu"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Lisää linkki"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Lisää lista"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Lisää järjestetty lista"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Sulje tiedosto"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Nimeä hakemisto uudelleen"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Poista hakemisto"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Etsi uudelleen hakemistosta…"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Vie projekti"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Sulje muut välilehdet"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Sulje kaikki välilehdet"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Poista kiinnitys"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Kiinnitä välilehti"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "&nbsp;"
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1537,325 +2593,322 @@ msgstr "kiina [汉语]"
 msgid "Chinese"
 msgstr "kiina [汉语]"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "&nbsp;"
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Ominaisuudet"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Monista tiedosto"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Mukautettu CSS"
+msgid "Copy path"
+msgstr "Kopioi koko polku"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s sanaa"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopioi tiedostonnimi"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s merkkiä"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Sulje tiedosto"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Nimeä hakemisto uudelleen"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Poista hakemisto"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Etsi uudelleen hakemistosta…"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Vie projekti"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Sulje muut välilehdet"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Sulje kaikki välilehdet"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Poista kiinnitys"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Kiinnitä välilehti"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalenteri"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Kaaviot"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Lihavoitu"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursivoitu"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Linkki"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Kuva"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Kommentti"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Koodi"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Tammikuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Helmikuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Maaliskuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Huhtikuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Toukokuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Kesäkuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Heinäkuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Elokuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Syyskuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Lokakuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Marraskuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Joulukuu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Alle kuukauden keskiarvon"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Yli kuukauden keskiarvon"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Enemmän kuin kaksi kertaa yli kuukauden keskiarvon"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Sanamäärä"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Muokattu"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Avaa…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Avaa uudessa välilehdessä"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Kopioi kuva leikepöydälle"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Avaa tiedosto"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Avaa selaimessa"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Ei ehdotuksia"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Lisää sanakirjaan"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursivoitu"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Lisää linkki"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Lisää lista"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Lisää järjestetty lista"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Kopioi yhtälön koodi"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Tiedostoa ei voitu luoda"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Päivittäjä"
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Päivitys saatavilla"
-
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Käyttämäsi versio"
-
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Uusi versio Zettlristä on saatavilla. Katso muutoshistoria alta."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Ladataan päivitystä"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Ei päivityksiä saatavilla. Sinulla on viimeisin version."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klikkaa päivityksen käynnistämiseksi"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Aloitetaan päivitystä..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Etsi"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Suodata tunnisteet…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Nollaa"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Avaa hakemisto"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Poista tiedosto"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Lisää"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Toiminnot"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Poista tiedosto"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Kuva"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1872,10 +2925,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1936,45 +2985,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr hyödyntää myös seuraavia projekteja:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Tässä voit ohittaa ohjelman vakiotyylit mukauttaaksesi käyttöliittymää. "
-"<strong>Huomio: Tämä tiedosto ohittaa kaikki CSS-direktiivit! Älä vaihda "
-"elementtien muotoa, tai ohjelma voi toimia väärin.</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Uudelleennimeä katkelma"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Katkelmat antavat sinun määrittää uudelleenkäytettäviä tekstipätkiä, "
+"muuttujien avulla."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Tallennetaan..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Tallennus epäonnistui"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Mukautettu CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Tallennettu!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1998,41 +3032,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Muokkaa tuonnin ja viennin oletusasetuksia täällä."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Tallennettu!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Uudelleennimeä katkelma"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-"Katkelmat antavat sinun määrittää uudelleenkäytettäviä tekstipätkiä, "
-"muuttujien avulla."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "sanaa"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "merkkiä"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Tässä voit ohittaa ohjelman vakiotyylit mukauttaaksesi käyttöliittymää. "
+"<strong>Huomio: Tämä tiedosto ohittaa kaikki CSS-direktiivit! Älä vaihda "
+"elementtien muotoa, tai ohjelma voi toimia väärin.</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Ei avoimia tiedostoja"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Tallennus epäonnistui"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Aloita"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Suodata tunnisteet…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2058,76 +3128,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "sanaa viime kuussa"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Liittyvät tiedostot"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "päivittäinen keskiarvo"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Ei liittyviä tiedostoja"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "sanaa tänään"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Olet liekeissä!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Olet lähellä päivittäistä keskiarvoasi!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Aloita kirjoittaminen parantaaksesi keskiarvoasi."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Lisää tilastoja..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Muut tiedostot"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Avaa hakemisto"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Ei muita tiedostoja"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Viitteet"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Tässä tiedostossa ei ole viitteitä"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Tunnistepilvi"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Vie…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Vie…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2137,8 +3247,8 @@ msgstr "Hakemistot"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Tiedostot"
 
@@ -2152,10 +3262,26 @@ msgstr "merkkiä"
 msgid "Words"
 msgstr "sanaa"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Työtilat"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Ei avoimia tiedostoja tai hakemistoja"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Ei tuloksia"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Hakemistoa ei ole valittu"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Tyhjä hakemisto"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2185,15 +3311,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Nollaa"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2254,13 +3371,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalenteri"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2470,131 +3580,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Aseta kirjoitustavoite…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Ei tuloksia"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Hakemistoa ei ole valittu"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Tyhjä hakemisto"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Työtilat"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Ei avoimia tiedostoja tai hakemistoja"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "sanaa viime kuussa"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "päivittäinen keskiarvo"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "sanaa tänään"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Olet liekeissä!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Olet lähellä päivittäistä keskiarvoasi!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Aloita kirjoittaminen parantaaksesi keskiarvoasi."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Lisää tilastoja..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Vie…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Vie…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2617,11 +3605,6 @@ msgstr "Rajaa haku hakemistoon"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Etsi"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Tyhjennä haku"
@@ -2635,1112 +3618,135 @@ msgstr "Vaihtele tulokset"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Tunnistepilvi"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "sanaa"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "merkkiä"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Ei avoimia tiedostoja"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Liittyvät tiedostot"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Ei liittyviä tiedostoja"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Lisää"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Toiminnot"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Poista tiedosto"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Avaa hakemisto"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Poista tiedosto"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Laita AutoCorrect päälle"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Näytä lainaukset"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Tammikuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Helmikuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Maaliskuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Huhtikuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Toukokuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Kesäkuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Heinäkuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Elokuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Syyskuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Lokakuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Marraskuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Joulukuu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Alle kuukauden keskiarvon"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Yli kuukauden keskiarvon"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Enemmän kuin kaksi kertaa yli kuukauden keskiarvon"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Kaaviot"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Generoitavien ID-numeroiden muoto"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID-numeron säännöllinen lauseke (regex)"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Generoitavien ID-numeroiden muoto"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Poista linkitys (ei kuitenkaan linkkitekstejä) sisäisiin tiedostoihin"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Vain tiedostonimeä"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Linkitettäessä tiedostoja lisää tiedostonimi..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "aina"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "vain linkitettäessä ID:n avulla"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "ei koskaan"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Aloita haku Zettelkasten-linkkejä seurattaessa"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Luo puuttuvat tiedostot automaattisesti sisäisiä linkkejä luotaessa"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Ei mikään"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Ei mikään"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Ei mikään"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Korvaa tiedosto"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Suodatin..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Tekstieditorin syöttötila"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Etsi hakemistosta"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Piilota otsakemerkit"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Hahmonna korostukset"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Käytä taulukkomuokkainta"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Häiriöttömän tilan ollessa käytössä, mykistä muut rivit"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Sanamäärä"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Laske merkkejä sanojen sijaan (esim. kiinalle)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Kuvien maksimileveys (prosenttia)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Kuvien maksimikorkeus (prosenttia)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Muut tiedostot"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Editorin fonttikoko"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Sisennyksessä käytettävien välilyöntien määrä"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Sisennä käyttämällä sarkainta"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Hyväksy välilyöntejä automaattisen täydennyksen aikana"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Sulje automaattisesti yhtenevät merkkiparit"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Aikataulun mukaan, kello&nbsp;"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Pois päältä"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Käyttöjärjestelmän mukaan"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Näytä Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Avaa hakemisto"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Ei muita tiedostoja"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalenteri"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Viitteet"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Tässä tiedostossa ei ole viitteitä"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Mukautettu CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Mukautettu CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Toiminnot"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Valitse kielet, joille automaattinen oikeinkirjoituksen tarkistus otetaan "
-"käyttöön."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Mukautettu sanakirja. Poista sanoja klikkaamalla."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Sanakirjan merkintä"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Etsi..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Näytä kuvapainike"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Näytä sivupalkissa tiedostojen lisätiedot"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Näytä kansiot ennen tiedostoja"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Vain tiedostonimeä"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Otsikkoa (jos saatavilla)"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "1. tason otsikkoa (jos saatavilla)"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Otsikkoa tai 1. tason otsikkoa (jos saatavilla)"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Näytä Markdown-tiedostopääte"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Viimeksi muokattu"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Tiedoston luontiaika"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Vie…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Viimeaikaiset tiedostot"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Luonnollinen järjestys (10 näytetään 2:n jälkeen)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII:n mukainen järjestys (2 näytetään 10:n jälkeen)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Viedään: %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Käytä sisäistä Pandoc-asennusta dokumenttien vientiin"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Poista tunnisteet tiedostoista"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Poista sisäiset linkit (myös linkkitekstit) kokonaan"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Poista linkitys (ei kuitenkaan linkkitekstejä) sisäisiin tiedostoihin"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Älä kajoa sisäisiin linkkeihin"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Näytä sivupalkissa tiedostojen lisätiedot"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Näytä kuvapainike"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Kommentti"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Uusien tiedostonimien muoto"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Uusien tiedostonimien muoto"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Älä kysy tiedostonimeä uusia tiedostoja luotaessa"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Käytä alkuperäistä ikkunoiden ulkonäköä"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Käytä alkuperäistä ikkunoiden ulkonäköä"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Näytä sovellus ilmoitusalueella"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Jätä sovellus päälle ilmoitusalueelle"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoomaus-käyttäytyminen"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Zoom muuttaa koko käyttöliittymän kokoa"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Zoom muuttaa editorin fonttikokoa"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "iFrame-renderöinti valkoinen lista"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Isäntänimi"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktivoi Watchdog kysely"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Odotusaika ennen kuin tiedoston kirjoittaminen on todettu valmiiksi (ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Poista tiedosto"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Vianmääritystila (debug)"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Vianmääritystila (debug)"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Ilmoita betaversioista"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automaattinen tallennus"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Viimeksi muokattu"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Välittömästi"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Lyhyen viiveen jälkeen"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Zoomaus-käyttäytyminen"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Vältä tiedostojen avaamista uusissa välilehdissä, jos mahdollista"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Päivittäjä"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Tarkista päivitykset automaattisesti"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Päivitys saatavilla"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Kuinka haluat automaattisen täydennyksen lisäävän viitteesi?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Käyttämäsi versio"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Uusi versio Zettlristä on saatavilla. Katso muutoshistoria alta."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Ladataan päivitystä"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Ei päivityksiä saatavilla. Sinulla on viimeisin version."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klikkaa päivityksen käynnistämiseksi"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Lisää tiedostoon"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Aloitetaan päivitystä..."
 
 #~ msgid "Open Link"
 #~ msgstr "Avaa linkki"

--- a/static/lang/fr-FR.po
+++ b/static/lang/fr-FR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-16 09:47+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2025-04-24 20:43+0200\n"
 "Last-Translator: Jules Bouton\n"
 "Language-Team: \n"
@@ -17,6 +17,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Le fichier de bibliographie n'a pas été chargé"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Le fichier de la bibliographie a été modifié. Rechargement…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Chargement de l'espace de travail %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -69,158 +83,6 @@ msgstr "L’option %s doit avoir au moins %s (caractères de longueur)."
 msgid "Option %s is required."
 msgstr "L’option %s est obligatoire."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Afficher Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Quitter"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr "Impossible de vérifier les mises à jour"
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-"Une erreur s'est produite pendant la vérification des mises à jour. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Une mise à jour est disponible"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Une mise à jour vers la version %s est disponible !"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-"Mettez à jour dès que possible. Vous pouvez ouvrir le gestionnaire de mise à "
-"jour maintenant ou plus tard."
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr "Ouvrir le gestionnaire de mise à jour"
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr "Pas maintenant"
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Impossible de vérifier les mises à jour : Erreur Serveur (Code d'état : %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Impossible de vérifier les mises à jour : Erreur Client (Code d'état : %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Impossible de vérifier les mises à jour : le serveur a essayé de rediriger "
-"(Code d'état : %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Impossible de vérifier les mises à jour : pas de connexion"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Impossible de vérifier les mises à jour. %s : %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Impossible de vérifier les mises à jour : le serveur n’a pas envoyé de "
-"données"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-"La fichier de somme de contrôle SHA256 semble manquant pour cette version."
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr "Les sommes de contrôle SHA256 sont introuvables: %s"
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-"Les données n'ont pas pu être réceptionnées pour la mise à jour de "
-"l'application: Le flux d'écriture est terminé."
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-"L'intégrité de la mise à jour téléchargée n'a pu être vérifiée. Vous pouvez "
-"réessayer ou faire une mise à jour manuelle."
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-"Le fichier téléchargé a une somme de contrôle différente de celle du "
-"serveur. Vous pouvez réessayer ou faire une mise à jour manuelle."
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-"Impossible de lancer la mise à jour. Vous pouvez réessayer ou faire une mise "
-"à jour manuelle. Erreur rencontrée: %s"
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Document trop long"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "hors ligne"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Erreur lors de la création du fichier"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "La référence avec la clé %s ne semble pas avoir de pièces jointes."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Impossible d'ouvrir la pièce jointe. Zotero fonctionne-t-il ?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -238,24 +100,101 @@ msgstr "Oui"
 msgid "No"
 msgstr "Non"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Remplacer le tag \"%s\" par \"%s\" à travers les fichiers %s ?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Annuler"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Vraiment supprimer ?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Voulez-vous vraiment supprimer %s ?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "La référence avec la clé %s ne semble pas avoir de pièces jointes."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Impossible d'ouvrir la pièce jointe. Zotero fonctionne-t-il ?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Textbundle incorrect: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Sélectionner le profil d'import"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "%s peut être importé selon plusieurs profils. Choisissez-en un."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Impossible d'exporter le Projet"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"Aucun fichier n'est sélectionné pour l'export. Sélectionnez les fichiers à "
+"inclure dans les paramètres du projet."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Incohérence des fichiers du projet"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Un ou plusieurs fichiers indiqués dans les propriétés du projet n'ont pas pu "
+"être trouvés. Ils ont peut-être été déplacés ou supprimés. Merci de vérifier "
+"que tous les fichiers que vous souhaitez exporter ont été inclus."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Le projet %s a été exporté avec succès. Cliquer pour l'afficher."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Exporter le projet"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -311,51 +250,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "L'importation a échoué"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Impossible d'exporter le Projet"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"Aucun fichier n'est sélectionné pour l'export. Sélectionnez les fichiers à "
-"inclure dans les paramètres du projet."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Incohérence des fichiers du projet"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Un ou plusieurs fichiers indiqués dans les propriétés du projet n'ont pas pu "
-"être trouvés. Ils ont peut-être été déplacés ou supprimés. Merci de vérifier "
-"que tous les fichiers que vous souhaitez exporter ont été inclus."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Le projet %s a été exporté avec succès. Cliquer pour l'afficher."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Exporter le projet"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Impossible de déplacer le dossier"
@@ -373,28 +267,49 @@ msgstr "Impossible de déplacer le dossier ou le fichier"
 msgid "The file/directory %s already exists in target."
 msgstr "Le fichier ou le dossier %s existe déjà."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sans nom"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Le nom fourni ne contenait aucune lettre autorisée."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Erreur lors de la création du dossier"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Le dossier demandé n'a pas été trouvé."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Vraiment supprimer ?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "L'exportation a échoué"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Voulez-vous vraiment supprimer %s ?"
+msgid "An error occurred during export: %s"
+msgstr "Une erreur est survenue lors de l'export : %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Choisissez la destination d'export"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Enregistrer"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Exportation vers %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Une erreur est survenue lors de l'exportation : %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -419,11 +334,13 @@ msgstr "Impossible d'ouvrir un espace de travail"
 msgid "Cannot open workspace \"%s\"."
 msgstr "Impossible d'ouvrir l'espace de travail \"%s\"."
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Copie de %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Document trop long"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "hors ligne"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -436,131 +353,34 @@ msgstr "Le fichier de langue %s a été importé"
 msgid "Could not import language file %s!"
 msgstr "Impossible d'importer le fichier de langue %s !"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "L'exportation a échoué"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Erreur lors de la création du fichier"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Une erreur est survenue lors de l'export : %s"
+msgid "Copy of %s"
+msgstr "Copie de %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Choisissez la destination d'export"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sans nom"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Enregistrer"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Erreur lors de la création du dossier"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exportation vers %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Une erreur est survenue lors de l'exportation : %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Le nom fourni ne contenait aucune lettre autorisée."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Le dossier demandé n'a pas été trouvé."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Sélectionner le profil d'import"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "%s peut être importé selon plusieurs profils. Choisissez-en un."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Textbundle incorrect: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Remplacer le fichier"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Le fichier %s a été modifié à distance. Remplacer la version chargée par la "
-"nouvelle version du disque ?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr ""
-"Toujours actualiser le fichier en cours lorsqu'il est modifié dans un autre "
-"programme"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Écraser le fichier existant"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Le fichier %s existe déjà dans ce répertoire. Écraser ?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Ouvrir un fichier"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Modifications non enregistrées"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Le fichier contient des modifications non enregistrées. Voulez-vous les "
-"enregistrer ?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Enregistrer le fichier"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Ouvrir le dossier de proje"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Le fichier de bibliographie n'a pas été chargé"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Le fichier de la bibliographie a été modifié. Rechargement…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Remplacer le tag \"%s\" par \"%s\" à travers les fichiers %s ?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -672,6 +492,12 @@ msgstr "Renommer le fichier"
 msgid "Delete file"
 msgstr "Supprimer le fichier"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Quitter"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -690,15 +516,15 @@ msgstr "Répéter"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Couper"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copier"
 
@@ -710,8 +536,8 @@ msgstr "Copier en HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Coller"
 
@@ -723,8 +549,8 @@ msgstr "Coller sans le formatage"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Sélectionner tout"
 
@@ -967,10 +793,184 @@ msgstr "Arrêter de parler"
 msgid "Bring All to Front"
 msgstr "Tout au premier plan"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Ouvrir le dossier de proje"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Remplacer le fichier"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Chargement de l'espace de travail %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Le fichier %s a été modifié à distance. Remplacer la version chargée par la "
+"nouvelle version du disque ?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr ""
+"Toujours actualiser le fichier en cours lorsqu'il est modifié dans un autre "
+"programme"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Modifications non enregistrées"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Le fichier contient des modifications non enregistrées. Voulez-vous les "
+"enregistrer ?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Ouvrir un fichier"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Enregistrer le fichier"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Écraser le fichier existant"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Le fichier %s existe déjà dans ce répertoire. Écraser ?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Afficher Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr "Impossible de vérifier les mises à jour"
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+"Une erreur s'est produite pendant la vérification des mises à jour. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Une mise à jour est disponible"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Une mise à jour vers la version %s est disponible !"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+"Mettez à jour dès que possible. Vous pouvez ouvrir le gestionnaire de mise à "
+"jour maintenant ou plus tard."
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr "Ouvrir le gestionnaire de mise à jour"
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr "Pas maintenant"
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Impossible de vérifier les mises à jour : Erreur Serveur (Code d'état : %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Impossible de vérifier les mises à jour : Erreur Client (Code d'état : %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Impossible de vérifier les mises à jour : le serveur a essayé de rediriger "
+"(Code d'état : %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Impossible de vérifier les mises à jour : pas de connexion"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Impossible de vérifier les mises à jour. %s : %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Impossible de vérifier les mises à jour : le serveur n’a pas envoyé de "
+"données"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+"La fichier de somme de contrôle SHA256 semble manquant pour cette version."
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr "Les sommes de contrôle SHA256 sont introuvables: %s"
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+"Les données n'ont pas pu être réceptionnées pour la mise à jour de "
+"l'application: Le flux d'écriture est terminé."
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+"L'intégrité de la mise à jour téléchargée n'a pu être vérifiée. Vous pouvez "
+"réessayer ou faire une mise à jour manuelle."
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+"Le fichier téléchargé a une somme de contrôle différente de celle du "
+"serveur. Vous pouvez réessayer ou faire une mise à jour manuelle."
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
+"Impossible de lancer la mise à jour. Vous pouvez réessayer ou faire une mise "
+"à jour manuelle. Erreur rencontrée: %s"
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -986,16 +986,16 @@ msgstr ""
 "Le fichier contient des modifications non enregistrées. Voulez-vous les "
 "enregistrer ou les abandonner ?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "Fichier modifié sur le disque"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s a été modifié sur le disque"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -1005,128 +1005,1166 @@ msgstr ""
 "non enregistrées. Souhaitez-vous garer la version de l'éditeur ou charger le "
 "fichier du disque ?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Souhaitez-vous conserver la version actuelle ou charger le version du disque?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Conserver la version de l'éditeur"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Charger la version du disque"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Toujours recharger les fichiers du disque s'il n'y a pas de modifications "
 "non enregistrées dans l'éditeur"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Impossible de sauvegarder le fichier"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Impossible de sauvegarder le fichier %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Activer l'autocorrection"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Guillemets intelligents"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Guillemets doubles"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Désactiver Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Guillemets simples"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Schémas de substitution de texte"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Chercher les mots entiers"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+"Si cette option est sélectionnée, l'autocorrection ne remplacera jamais les "
+"parties d'un mot"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Remplacer"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "Avec"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filtrer"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Horaires"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Désactivé"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Suivre le système"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "On"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Démarrer"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Fin"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Thème"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Options de la barre d'outils"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr "Section de gauche"
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr "Afficher le bouton \"Ouvrir les réglages\""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr "Afficher le bouton \"Nouveau fichier\""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr "Afficher le bouton \"Fichier précédent\""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr "Afficher le bouton \"Fichier suivant\""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr "Section centrale"
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr "Afficher le bouton \"Mode de lisibilité\""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr "Afficher le bouton \"Insérer un commentaire\""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr "Afficher le bouton \"Insérer un lien\""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr "Afficher le bouton \"Insérer une image\""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr "Afficher le bouton \"Insérer une liste de tâches\""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr "Afficher le bouton \"Insérer un tableau\""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr "Afficher le bouton \"Insérer une note de bas de page\""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr "Section de droite"
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr "Afficher le compteur de mots/caractères"
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr "Afficher le chronomètre Pomodoro"
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Barre d'état"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr "Afficher la barre d'état"
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personnalisé"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Ouvrir l'éditeur CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Profils d'import et d'export"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Ouvrir l'éditeur de profiles d'import"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Ouvrir l'éditeur de profils d'export"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Paramètres d'export"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Utilisez le Pandoc interne pour les exports"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Supprimer les mot-clés des fichiers lors de l'export"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Liens internes"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Supprimer tous les liens internes"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Supprimer les crochets des liens internes"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Ne pas modifier les liens internes"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Dossier de destination pour les fichiers exportés"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Dossier temporaire"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Même endroit que le fichier"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Demander dans quel dossier exporter"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Attention ! Les fichiers du dossier temporaire sont régulièrement supprimés. "
+"Choisir le même emplacement que le fichiers efface les fichiers portant un "
+"nom identique qui pourraient déjà exister."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Commande d'export personnalisée"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Afficher le nom"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Commande"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Entrer une commande personnalisée pour exporter. Chaque commande reçoit "
+"comme premier argument le fichier ou le dossier de projet à exporter."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Modèle pour les nouveaux noms de fichiers"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Définir un modèle pour les nouveaux noms de fichiers"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Variables disponibles: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Ne pas demander de nom lors de la création de nouveaux fichiers"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Apparence"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Utiliser l'apparence native des fenêtres"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+"Disponible sur Linux uniquement ; réglage par défaut sur macOS et Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Utiliser l'apparence native des fenêtres"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+"Disponible uniquement sur macOS ; rend l'arrière-plan de la fenêtre opaque."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Afficher l'application dans la zone de notification"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+"Laisser l'application en cours d'exécution dans la zone de notification"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportement du zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Redimensionne l'ensemble de l'interface graphique"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Modifie la taille de la police de l'éditeur"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Barre latérale des pièces jointes"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+"Extensions de fichier à afficher dans la Barre latérale des pièces jointes"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Liste blanche des iFrame autorisées"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nom d'hôte"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Décompte du chien de garde"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr "Activer le décompte du chien de garde"
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Temps d'attente avant de considérer l’écriture d’un fichier commeterminée "
+"(en ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Supprimer les éléments"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+"Supprimer les éléments de façon irréversible s'il est impossible de les "
+"mettre dans la corbeille"
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Mode de diagnostic"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Activer le mode de diagnostic"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Versions bêta"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Me prévenir à propos des versions bêta"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Mode de saisie"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Le mode de saisie détermine comment vous interagissez avec l'éditeur. Nous "
+"recommandons de laisser ce paramètre sur \"Normal\". Choisissez \"Vim\" ou "
+"\"Emacs\" uniquement si vous savez ce que cela implique."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Sens d'écriture"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Rendu du Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Active le rendu de différents éléments Markdown en les formatant. Ceci "
+"cachera les caractères de formatage (comme **text**) ou affichera les images "
+"plutôt que leur lien."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr "Rendu des citations"
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr "Rendu des iframe"
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr "Rendu des images"
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr "Rendu des liens"
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr "Rendu des formules"
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr "Rendu des tâches"
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Cacher les \"#\" dans les titres"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Accentuation du rendu"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr "Formattage des caractères en gras et en italique"
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Gras"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Italique"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Vérifier les erreurs de style Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Editeur de tableau"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"L'éditeur de tableau est une interface interactive qui facilite la création "
+"de tableaux. Il fournit des boutons pour la plupart des fonctionnalités "
+"courantes et prend en charge le formatage Markdown."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Masquer les lignes hors focus dans le mode sans distraction"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr "Masquer la barre d'outils dans le mode sans distraction"
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Nombre de mots"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Compter les caractères au lieu des mots (p. ex., pour le chinois)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Mode de lisibilité"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algorithme"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Taille de l'image"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Largeur maximale des images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Hauteur maximale des images (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Autres paramètres"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Taille de police"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Largeur d’indentation en nombre d’espaces"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Indenter à l'aide de tabulations"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+"Afficher la barre d'outil de formatage lorsque du texte est sélectionné"
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Mettre en évidence les espaces blancs"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Suggérer des émojis pendant l'autocomplétion"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Afficher l'aperçu des liens"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Fermer automatiquement les paires de caractères correspondantes"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Mode d'affichage"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Étroit"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Étendu"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Combiné"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"Le mode Étroit affiche les dossiers et les fichiers séparément. Sélectionnez "
+"un dossier pour afficher son contenu dans la liste des fichiers. Vous pouvez "
+"passer de la liste des fichiers à l'arbre des dossiers en cliquant sur les "
+"dossiers ou sur la flèche qui apparaît dans l'angle supérieur de la liste "
+"des fichiers."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Propriétés du fichier"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Afficher les dossiers au-dessus des fichiers"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Affichage du nom des fichiers Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Nom de fichier seulement"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Titre si disponible"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Premier titre de niveau 1 si disponible"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Titre ou premier titre de niveau 1 si disponible"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Afficher les extensions de fichier Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Affichage de la date"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Date de la dernière modification"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Date de création du fichier"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Tri"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Pour trier les documents…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordre naturel (10 après 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Ordre ASCII (2 après 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Citations"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "De quelle manière doivent être insérées vos citations ?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr "Base de données de citations (CSL JSON ou BibTex)"
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Chemin du fichier"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr "Style CSL (optionnel)"
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "IDs Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Modèle des IDs Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Utilise des expressions régulières ECMAScript"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Modèle de création des nouveaux IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Variables disponibles: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Lien avec le nom de fichier seulement"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "Lorsque vous liez des fichiers, ajouter le nom du fichier…"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Toujours"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Uniquement lors de la liaison à l'aide de l'ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Jamais"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Format du lien"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Les liens internes vous permettent d'ajouter un titre optionnel, séparé de "
+"la cible du lien par une barre verticale. Vous pouvez choisir l'ordre entre "
+"ces deux éléments."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Lien|Titre]]: Lien d'abord (recommandé)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Titre|Lien]]: Titre d'abord"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr ""
+"Lancer une recherche plein-texte lorsque vous suivez les liens internes"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "La recherche portera sur le contenu entre crochets: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Créer automatiquement les fichiers manquants dans ce dossier lorsque vous "
+"suivez des liens internes"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Pour que ceci fonctionne, le dossier doit être ouvert comme un Espace de "
+"travail dans Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Chemin vers le dossier"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Fragments"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Ouvrir l'éditeur de fragments"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Sévérité"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Standard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Pointilleux"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Langue maternelle"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Non paramétré"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Variantes préférées"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool n'est pas capable de distinguer certaines variétés de langue. "
+"Ces paramètres permettront à LanguageTool d'automatiquement détecter la "
+"variété que vous préférez pour ces langues."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Interpréter l'anglais comme"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Interpréter l'allemand comme"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Interpréter le portugais comme"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Interpréter le catalan comme"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Fournisseur de LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "CSS personnalisé"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Adresse serveur personnalisée"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr ignorera le paramètre \"Fournisseur de LanguageTool\" si vous entrez "
+"des identifiants ici."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool Username"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool API key"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Correcteur orthographique"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Actif"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Langue"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Code"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Choisir les langues pour lesquelles vous voulez activer le correcteur "
+"orthographique."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Dictionnaire personnalisé. Enlever des mots avec un clic."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Entrée du dictionnaire"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Rechercher des entrées…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Langue de l'application"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Sauvegarde automatique"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Enregistrer les modifications"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Immédiatement"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Après un court délai"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Dossier par défaut pour les images"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Cliquer sur \"Sélectionner un dossier…\" ou entrez un chemin absolu ou "
+"relatif dans le champ de texte."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Comportement"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Éviter d'ouvrir des fichiers dans de nouveaux onglets si possible"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Mises à jour"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Vérifier automatiquement la présence de mises à jour"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caractères"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s mots"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr "Ce fichier fait partie du projet \"%s\""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Aller à la référence de la note de bas de page"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Aucun surlignage"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Ouvrir le panneau de diagnostique"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Détecter automatiquement"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Création du graphe mermaid…"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Erreur lors de la création du graphe:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Mode de lisibilité (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Image non trouvée : %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "Ouvrir l'image dans un outil externe"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Erreur d'orthographe"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Le fichier %s n'existe pas."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Nombre de mots"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modifié"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Ouvrir…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Propriétés"
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Récupération de la prévisualisation du lien…"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Dupliquer le fichier"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Lien"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copier le chemin complet"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Image"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copier le nom de fichier"
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Commentaire"
 
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Aucune note de bas de page trouvée."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copier le code de l'équation"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr "Ouvrir le lien"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr "Copier l'adresse courriel"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr "Copier le lien"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr "Supprimer le lien"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copier l'image dans le presse-papiers"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Ouvrir l'image"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Afficher dans Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Afficher dans Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Ouvrir dans le navigateur de fichiers"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Afficher dans l'explorateur de fichiers"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Pas de suggestions"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Fermer le fichier"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Ajouter au dictionnaire"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Renommer le dossier"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Italique"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Supprimer le dossier"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Insérer un lien"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Vérifier le dossier …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Insérer une liste non ordonnée"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exporter le Projet"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Insérer une liste ordonnée"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
-msgstr "Fermer l'espace de travail"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
+msgstr "Insérer une liste de tâches"
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
-msgstr "Fermer l'onglet"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
+msgstr "Insérer un bloc de citation"
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Fermer les autres onglets"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr "Insérer un tableau"
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Fermer tous les onglets"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Détacher l'onglet"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Épingler l’onglet"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-clic pour suivre ce lien"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1534,325 +2572,320 @@ msgstr "Chinois (Taiwan)"
 msgid "Chinese"
 msgstr "Chine"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Détecter automatiquement"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Désactivé"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Personnalisé"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s mots"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caractères"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Ouvrir le panneau de diagnostique"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Erreur d'orthographe"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
-msgstr "Ce fichier fait partie du projet \"%s\""
-
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Aller à la référence de la note de bas de page"
-
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Récupération de la prévisualisation du lien…"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Gras"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Italique"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Lien"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Image"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Commentaire"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Code"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Aucune note de bas de page trouvée."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Le fichier %s n'existe pas."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Nombre de mots"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modifié"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Ouvrir…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Aucun surlignage"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Propriétés"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr "Ouvrir le lien"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Dupliquer le fichier"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr "Copier l'adresse courriel"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copier le chemin complet"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr "Copier le lien"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copier le nom de fichier"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr "Supprimer le lien"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Afficher dans Explorer"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copier l'image dans le presse-papiers"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Afficher dans l'explorateur de fichiers"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Ouvrir l'image"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Fermer le fichier"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Ouvrir dans le navigateur de fichiers"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Renommer le dossier"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Pas de suggestions"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Supprimer le dossier"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Ajouter au dictionnaire"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Vérifier le dossier …"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Italique"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exporter le Projet"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Insérer un lien"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
+msgstr "Fermer l'espace de travail"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Insérer une liste non ordonnée"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
+msgstr "Fermer l'onglet"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Insérer une liste ordonnée"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Fermer les autres onglets"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr "Insérer une liste de tâches"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Fermer tous les onglets"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr "Insérer un bloc de citation"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Détacher l'onglet"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr "Insérer un tableau"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Épingler l’onglet"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copier le code de l'équation"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendrier"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Mode de lisibilité (%s)"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Graphiques"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Image non trouvée : %s"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "Statistiques FSAL"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "Ouvrir l'image dans un outil externe"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Statistiques d'écriture"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Création du graphe mermaid…"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "janvier"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Erreur lors de la création du graphe:"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "février"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-clic pour suivre ce lien"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "mars"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Mise à jour"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "avril"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Nouvelle version disponible"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "mai"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Votre version"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "juin"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "juillet"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "aout"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "septembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "octobre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "novembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "décembre"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Inférieur à la moyenne mensuelle"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Supérieur à la moyenne mensuelle"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Plus du double de la moyenne mensuelle"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Exporter le projet vers :"
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Utiliser"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Format"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Conversion"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Fichiers à inclure dans l'export"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Vous devez choisir au moins un profile pour construire ce projet."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Titre du projet"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "Feuille de style CSL"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "Modèle LaTeX"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "Modèle HTML"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Retirer le fichier de l'export"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Ajouter le fichier à l'export"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Monter le fichier"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Descendre le fichier"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Vous n'avez sélectionné aucun fichier à exporter."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Une nouvelle version de Zettlr est disponible. La liste des changements est "
-"ci-dessous."
+"Certains fichiers ont été sélectionnés pour l'export mais n'existent plus "
+"dans le dossier."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Téléchargement de votre mise à jour"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Général"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Pas de mise a jour disponible. Vous avez la version la plus récente."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Cliquez pour lancer la mise à jour"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "jamais"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Dernière vérification: %s"
+msgid "No results for \"%s\""
+msgstr "Pas de résultats pour \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Démarrage de la mise à jour…"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Chercher"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Affecter la couleur"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Gestionnaire de fichier"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Supprimer la couleur"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Éditeur"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Nom du mot-clé"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Couleur"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Importer et exporter"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Nombre"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Avancé"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Une description brève"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Recherche: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Préférences"
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
-"Vous pouvez assigner des couleurs aux différents mots-clés. Si un mot-clé "
-"est trouvé dans un fichier, il apparaîtrait en couleur dans la "
-"prévisualisation. La description sera visible au survol de la souris."
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrer les mots-clés…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Sélectionner un dossier…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr "Nouveau mot-clé"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Sélectionner un fichier…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr "Renommer"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Ajouter"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr "Renommer le mot-clé…"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Actions"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Supprimer"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Insérer une image depuis le presse-papier"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Taille de l'image"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1870,10 +2903,6 @@ msgstr "Nom de fichier"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Un nom de fichier unique"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Chargement…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1940,46 +2969,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr utilise également ces logiciels tiers:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Vous pouvez modifier l'apparence de l'application ici. <strong>Attention : "
-"ce fichier peut écraser toutes les directives de CSS ! Ne jamais modifier la "
-"géométrie des éléments, sinon l'application pourrait avoir un comportement "
-"d'affichage indésirable !</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Renommer le fragment"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Les fragments vous permettent de définir des morceaux de texte réutilisables "
+"avec des variables."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Ouvrir le dossier des fragments"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Sauvegarde en cours…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Échec de l'enregistrement"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Export"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Import"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personnalisé"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Fragments"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Enregistré !"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -2005,41 +3018,81 @@ msgstr "Ouvrir le dossier par défaut"
 msgid "Edit the default settings for imports or exports here."
 msgstr "Modifier les paramètres par défaut pour importer ou exporter."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Enregistré !"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Export"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Renommer le fragment"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Import"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Les fragments vous permettent de définir des morceaux de texte réutilisables "
-"avec des variables."
+"Vous pouvez modifier l'apparence de l'application ici. <strong>Attention : "
+"ce fichier peut écraser toutes les directives de CSS ! Ne jamais modifier la "
+"géométrie des éléments, sinon l'application pourrait avoir un comportement "
+"d'affichage indésirable !</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Ouvrir le dossier des fragments"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Échec de l'enregistrement"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "mots"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Affecter la couleur"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caractères"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Supprimer la couleur"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Aucun document ouvert"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Nom du mot-clé"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Démarrer"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Couleur"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Nombre"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Une description brève"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Vous pouvez assigner des couleurs aux différents mots-clés. Si un mot-clé "
+"est trouvé dans un fichier, il apparaîtrait en couleur dans la "
+"prévisualisation. La description sera visible au survol de la souris."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrer les mots-clés…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr "Nouveau mot-clé"
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr "Renommer"
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr "Renommer le mot-clé…"
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2065,76 +3118,114 @@ msgstr "Effet sonore"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr "Table des matières"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "mots au cours du mois"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Fichiers connexes"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "moyenne quotidienne"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Aucun fichier associé"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "mots aujourd'hui"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Cette relation est basée sur un lien bidirectionnel."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Vous êtes en feu !"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Cette relation est basée sur un lien sortant."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Vous avez bientôt atteint votre moyenne journalière !"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Cette relation est basée sur un lien entrant."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Écrire pour dépasser votre moyenne."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Plus de statistiques…"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Cette relation est basée sur %s mots-clés partagés: %s"
+msgid "%s selected"
+msgstr "%s sélectionné"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Autres fichiers"
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s sélections"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Ouvrir le dossier"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr "Chercher dans tous les fichiers"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Pas d'autres fichiers"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr "Voir les statistiques d'écriture"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr "Voir le nuage de mots"
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr "Ouvrir les paramètres"
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr "Exporter le fichier actuel"
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Activer le mod de lisibilité"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr "Insérer un commentaire"
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr "Insérer une image"
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr "Insérer une note de bas de page"
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr "Chronomètre Pomodoro"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr "Dossier temporaire"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
 msgstr "Dossier actuel"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Bibliographie"
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr "Sélectionner un dossier"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Il n'y a pas de citation dans ce document."
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Exporter…"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
-msgstr "environ %s mots"
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Export"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Nom"
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "commande"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Nuage de mots-clés"
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr "Filtrer…"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2144,8 +3235,8 @@ msgstr "Dossiers"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Fichiers"
 
@@ -2159,10 +3250,26 @@ msgstr "Lettres"
 msgid "Words"
 msgstr "Mots"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr "Filtrer…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Espaces de travail"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Aucun fichier ou dossier"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Aucun résultat"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Aucun répertoire sélectionné"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Répertoire vide"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2192,15 +3299,6 @@ msgstr "montant"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr "descendant"
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Réinitialiser"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2261,13 +3359,6 @@ msgstr "Œil"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr "Œil (barré)"
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendrier"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2477,130 +3568,10 @@ msgstr "CD/DVD"
 msgid "Set writing target…"
 msgstr "Définir la cible d'écriture…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Aucun résultat"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Aucun répertoire sélectionné"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Répertoire vide"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Espaces de travail"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Aucun fichier ou dossier"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "mots au cours du mois"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "moyenne quotidienne"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "mots aujourd'hui"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Vous êtes en feu !"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Vous avez bientôt atteint votre moyenne journalière !"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Écrire pour dépasser votre moyenne."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Plus de statistiques…"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s sélectionné"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s sélections"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr "Chercher dans tous les fichiers"
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr "Voir les statistiques d'écriture"
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr "Voir le nuage de mots"
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr "Ouvrir les paramètres"
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr "Exporter le fichier actuel"
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Activer le mod de lisibilité"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr "Insérer un commentaire"
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr "Insérer une image"
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr "Insérer une note de bas de page"
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr "Chronomètre Pomodoro"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr "Dossier temporaire"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr "Dossier actuel"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr "Sélectionner un dossier"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Exporter…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Export"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "commande"
+msgid "Table size: %s &times; %s"
+msgstr "Taille du tableau: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2622,11 +3593,6 @@ msgstr "Restreindre la recherche au répertoire"
 msgid "Choose directory…"
 msgstr "Choisir un dossier…"
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Chercher"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Effacer la recherche"
@@ -2640,1097 +3606,137 @@ msgstr "Plier/Déplier tous les résultats"
 msgid "%s matches across %s files"
 msgstr "%s correspondances dans %s fichiers"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Nom"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Nuage de mots-clés"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "mots"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caractères"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Aucun document ouvert"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Fichiers connexes"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Aucun fichier associé"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Cette relation est basée sur un lien bidirectionnel."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Cette relation est basée sur un lien sortant."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Cette relation est basée sur un lien entrant."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Taille du tableau: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Cette relation est basée sur %s mots-clés partagés: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Ajouter"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Autres fichiers"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Actions"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Ouvrir le dossier"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Supprimer"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Pas d'autres fichiers"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Sélectionner un dossier…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Dossier actuel"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Sélectionner un fichier…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr "Table des matières"
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Exporter le projet vers :"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Bibliographie"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Utiliser"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Il n'y a pas de citation dans ce document."
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Format"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Conversion"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Fichiers à inclure dans l'export"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Vous devez choisir au moins un profile pour construire ce projet."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Titre du projet"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "Feuille de style CSL"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "Modèle LaTeX"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "Modèle HTML"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Retirer le fichier de l'export"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Ajouter le fichier à l'export"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Monter le fichier"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Descendre le fichier"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Vous n'avez sélectionné aucun fichier à exporter."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-"Certains fichiers ont été sélectionnés pour l'export mais n'existent plus "
-"dans le dossier."
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Général"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "Pas de résultats pour \"%s\""
+msgid "circa %s words"
+msgstr "environ %s mots"
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Apparence"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Chargement…"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Gestionnaire de fichier"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Mise à jour"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Éditeur"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Nouvelle version disponible"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Correcteur orthographique"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Votre version"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Activer l'autocorrection"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Une nouvelle version de Zettlr est disponible. La liste des changements est "
+"ci-dessous."
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Citations"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Téléchargement de votre mise à jour"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Pas de mise a jour disponible. Vous avez la version la plus récente."
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Importer et exporter"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Cliquez pour lancer la mise à jour"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Avancé"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "jamais"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "Recherche: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Préférences"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "janvier"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "février"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "mars"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "avril"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "mai"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "juin"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "juillet"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "aout"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "septembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "octobre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "novembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "décembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Inférieur à la moyenne mensuelle"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Supérieur à la moyenne mensuelle"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Plus du double de la moyenne mensuelle"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Graphiques"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "Statistiques FSAL"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Statistiques d'écriture"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "IDs Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Modèle des IDs Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Utilise des expressions régulières ECMAScript"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Modèle de création des nouveaux IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Variables disponibles: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Liens internes"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Lien avec le nom de fichier seulement"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "Lorsque vous liez des fichiers, ajouter le nom du fichier…"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Toujours"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Uniquement lors de la liaison à l'aide de l'ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Jamais"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Format du lien"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Les liens internes vous permettent d'ajouter un titre optionnel, séparé de "
-"la cible du lien par une barre verticale. Vous pouvez choisir l'ordre entre "
-"ces deux éléments."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Lien|Titre]]: Lien d'abord (recommandé)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Titre|Lien]]: Titre d'abord"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr ""
-"Lancer une recherche plein-texte lorsque vous suivez les liens internes"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "La recherche portera sur le contenu entre crochets: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Créer automatiquement les fichiers manquants dans ce dossier lorsque vous "
-"suivez des liens internes"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Pour que ceci fonctionne, le dossier doit être ouvert comme un Espace de "
-"travail dans Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Chemin vers le dossier"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Guillemets intelligents"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Guillemets doubles"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Désactiver Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Guillemets simples"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Schémas de substitution de texte"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Chercher les mots entiers"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-"Si cette option est sélectionnée, l'autocorrection ne remplacera jamais les "
-"parties d'un mot"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Remplacer"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "Avec"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filtrer"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Mode de saisie"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Le mode de saisie détermine comment vous interagissez avec l'éditeur. Nous "
-"recommandons de laisser ce paramètre sur \"Normal\". Choisissez \"Vim\" ou "
-"\"Emacs\" uniquement si vous savez ce que cela implique."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Sens d'écriture"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Rendu du Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Active le rendu de différents éléments Markdown en les formatant. Ceci "
-"cachera les caractères de formatage (comme **text**) ou affichera les images "
-"plutôt que leur lien."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr "Rendu des citations"
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr "Rendu des iframe"
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr "Rendu des images"
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr "Rendu des liens"
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr "Rendu des formules"
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr "Rendu des tâches"
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Cacher les \"#\" dans les titres"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Accentuation du rendu"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr "Formattage des caractères en gras et en italique"
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Vérifier les erreurs de style Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Editeur de tableau"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"L'éditeur de tableau est une interface interactive qui facilite la création "
-"de tableaux. Il fournit des boutons pour la plupart des fonctionnalités "
-"courantes et prend en charge le formatage Markdown."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Masquer les lignes hors focus dans le mode sans distraction"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr "Masquer la barre d'outils dans le mode sans distraction"
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Nombre de mots"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Compter les caractères au lieu des mots (p. ex., pour le chinois)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Mode de lisibilité"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algorithme"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Largeur maximale des images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Hauteur maximale des images (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Autres paramètres"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Taille de police"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Largeur d’indentation en nombre d’espaces"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Indenter à l'aide de tabulations"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-"Afficher la barre d'outil de formatage lorsque du texte est sélectionné"
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Mettre en évidence les espaces blancs"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Suggérer des émojis pendant l'autocomplétion"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Afficher l'aperçu des liens"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Fermer automatiquement les paires de caractères correspondantes"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Horaires"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Désactivé"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Suivre le système"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "On"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Fin"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Thème"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Options de la barre d'outils"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr "Section de gauche"
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr "Afficher le bouton \"Ouvrir les réglages\""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr "Afficher le bouton \"Nouveau fichier\""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr "Afficher le bouton \"Fichier précédent\""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr "Afficher le bouton \"Fichier suivant\""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr "Section centrale"
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr "Afficher le bouton \"Mode de lisibilité\""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr "Afficher le bouton \"Insérer un commentaire\""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr "Afficher le bouton \"Insérer un lien\""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr "Afficher le bouton \"Insérer une image\""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr "Afficher le bouton \"Insérer une liste de tâches\""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr "Afficher le bouton \"Insérer un tableau\""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr "Afficher le bouton \"Insérer une note de bas de page\""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr "Section de droite"
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr "Afficher le compteur de mots/caractères"
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr "Afficher le chronomètre Pomodoro"
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Barre d'état"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr "Afficher la barre d'état"
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Ouvrir l'éditeur CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Sévérité"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Standard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Pointilleux"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Langue maternelle"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Non paramétré"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Variantes préférées"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool n'est pas capable de distinguer certaines variétés de langue. "
-"Ces paramètres permettront à LanguageTool d'automatiquement détecter la "
-"variété que vous préférez pour ces langues."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Interpréter l'anglais comme"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Interpréter l'allemand comme"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Interpréter le portugais comme"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Interpréter le catalan comme"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Fournisseur de LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "CSS personnalisé"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Adresse serveur personnalisée"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr ignorera le paramètre \"Fournisseur de LanguageTool\" si vous entrez "
-"des identifiants ici."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool Username"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool API key"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Actif"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Langue"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Choisir les langues pour lesquelles vous voulez activer le correcteur "
-"orthographique."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Dictionnaire personnalisé. Enlever des mots avec un clic."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Entrée du dictionnaire"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Rechercher des entrées…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Mode d'affichage"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Étroit"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Étendu"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Combiné"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"Le mode Étroit affiche les dossiers et les fichiers séparément. Sélectionnez "
-"un dossier pour afficher son contenu dans la liste des fichiers. Vous pouvez "
-"passer de la liste des fichiers à l'arbre des dossiers en cliquant sur les "
-"dossiers ou sur la flèche qui apparaît dans l'angle supérieur de la liste "
-"des fichiers."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Propriétés du fichier"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Afficher les dossiers au-dessus des fichiers"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Affichage du nom des fichiers Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Nom de fichier seulement"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Titre si disponible"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Premier titre de niveau 1 si disponible"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Titre ou premier titre de niveau 1 si disponible"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Afficher les extensions de fichier Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Affichage de la date"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Date de la dernière modification"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Date de création du fichier"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Tri"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Pour trier les documents…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordre naturel (10 après 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Ordre ASCII (2 après 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Profils d'import et d'export"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Ouvrir l'éditeur de profiles d'import"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Ouvrir l'éditeur de profils d'export"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Paramètres d'export"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Utilisez le Pandoc interne pour les exports"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Supprimer les mot-clés des fichiers lors de l'export"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Supprimer tous les liens internes"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Supprimer les crochets des liens internes"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Ne pas modifier les liens internes"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Dossier de destination pour les fichiers exportés"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Dossier temporaire"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Même endroit que le fichier"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Demander dans quel dossier exporter"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Attention ! Les fichiers du dossier temporaire sont régulièrement supprimés. "
-"Choisir le même emplacement que le fichiers efface les fichiers portant un "
-"nom identique qui pourraient déjà exister."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Commande d'export personnalisée"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Afficher le nom"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Commande"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Entrer une commande personnalisée pour exporter. Chaque commande reçoit "
-"comme premier argument le fichier ou le dossier de projet à exporter."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Modèle pour les nouveaux noms de fichiers"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Définir un modèle pour les nouveaux noms de fichiers"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Variables disponibles: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Ne pas demander de nom lors de la création de nouveaux fichiers"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Utiliser l'apparence native des fenêtres"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-"Disponible sur Linux uniquement ; réglage par défaut sur macOS et Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Utiliser l'apparence native des fenêtres"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-"Disponible uniquement sur macOS ; rend l'arrière-plan de la fenêtre opaque."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Afficher l'application dans la zone de notification"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
-"Laisser l'application en cours d'exécution dans la zone de notification"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportement du zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Redimensionne l'ensemble de l'interface graphique"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Modifie la taille de la police de l'éditeur"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Barre latérale des pièces jointes"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-"Extensions de fichier à afficher dans la Barre latérale des pièces jointes"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Liste blanche des iFrame autorisées"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nom d'hôte"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Décompte du chien de garde"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr "Activer le décompte du chien de garde"
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Temps d'attente avant de considérer l’écriture d’un fichier commeterminée "
-"(en ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Supprimer les éléments"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-"Supprimer les éléments de façon irréversible s'il est impossible de les "
-"mettre dans la corbeille"
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Mode de diagnostic"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Activer le mode de diagnostic"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Versions bêta"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Me prévenir à propos des versions bêta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Ouvrir l'éditeur de fragments"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Langue de l'application"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Sauvegarde automatique"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Enregistrer les modifications"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Immédiatement"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Après un court délai"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Dossier par défaut pour les images"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Cliquer sur \"Sélectionner un dossier…\" ou entrez un chemin absolu ou "
-"relatif dans le champ de texte."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Comportement"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Éviter d'ouvrir des fichiers dans de nouveaux onglets si possible"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Mises à jour"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Vérifier automatiquement la présence de mises à jour"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "De quelle manière doivent être insérées vos citations ?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr "Base de données de citations (CSL JSON ou BibTex)"
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Chemin du fichier"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr "Style CSL (optionnel)"
+msgid "Last checked: %s"
+msgstr "Dernière vérification: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Démarrage de la mise à jour…"
 
 #~ msgid "Open Link"
 #~ msgstr "Ouvrir le lien"

--- a/static/lang/hu-HU.po
+++ b/static/lang/hu-HU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Az idézetek adatbázisát nem lehet betölteni."
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "A jegyzék-állomány módosítva lett. Újratöltés…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr ""
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,148 +81,6 @@ msgstr "A(z) %s opció hossza nem lehet kevesebb, mint %s."
 msgid "Option %s is required."
 msgstr "Kell hozzá a(z) %s opció."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "A Zettlr megjelenítése"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Kilépni"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló hibája (állapotkód: "
-"%s)."
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Nem sikerült ellenőrizni a frissítéseket: az ügyfél hibája (állapotkód: %s)."
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló megpróbálta "
-"átirányítani (állapotkód: %s)."
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"Nem sikerült ellenőrizni a frissítéseket: nem sikerült létrehozni a "
-"kapcsolatot."
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló nem küldött adatokat."
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "A fájlt nem lehetett létrehozni"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr ""
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr ""
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -226,24 +98,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Oké"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Mégsem"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Tényleg törölni?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "%s tényleg törlendő?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr ""
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Rosszul formázott szövegköteg: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Projektet exportálni"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exportálni …"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -298,48 +244,6 @@ msgstr "A(z) %s fájl(ok) %s típusa ismeretlen, ezért az importálás nem megy
 msgid "Import failed"
 msgstr "Az exportálás nem sikerült"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Projektet exportálni"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Oké"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exportálni …"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Nem lehet áthelyezni a könyvtárat"
@@ -357,28 +261,49 @@ msgstr "A fájlt illetve könyvtárat nem lehet áthelyezni"
 msgid "The file/directory %s already exists in target."
 msgstr "A(z) file vagy könyvtár már létezik."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Névtelen"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "A megadott név nem tartalmazott engedélyezett betűket."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "A könyvtárat nem lehetett létrehozni"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "A keresett könyvtár nem található"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Tényleg törölni?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Az exportálás nem sikerült"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Hiba történt exportálás közben: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Menteni"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "%s tényleg törlendő?"
+msgid "Exporting to %s"
+msgstr "%s exportálása"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Hiba történt exportálás közben: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -403,10 +328,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -420,126 +347,34 @@ msgstr "A(z) %s fordítás importálása sikerült"
 msgid "Could not import language file %s!"
 msgstr "A(z) %s fordítás importálása nem sikerült!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Az exportálás nem sikerült"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "A fájlt nem lehetett létrehozni"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Hiba történt exportálás közben: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Menteni"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "%s exportálása"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Névtelen"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "A könyvtárat nem lehetett létrehozni"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Hiba történt exportálás közben: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "A megadott név nem tartalmazott engedélyezett betűket."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "A keresett könyvtár nem található"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Rosszul formázott szövegköteg: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Külső változtatásokat mindig betölteni"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr ""
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "A fájl megváltozott. Menteni vagy eldobni?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Projekt-könyvtárat kinyitni"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Az idézetek adatbázisát nem lehet betölteni."
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "A jegyzék-állomány módosítva lett. Újratöltés…"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -651,6 +486,12 @@ msgstr "Fájlt átnevezni …"
 msgid "Delete file"
 msgstr "Fájlt törölni"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Kilépni"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -669,15 +510,15 @@ msgstr "Megismételni"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Kivágni"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Másolni"
 
@@ -689,8 +530,8 @@ msgstr "HTML-ként másolni"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Beilleszteni"
 
@@ -702,8 +543,8 @@ msgstr "Stílus nélkül beilleszteni"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Mindet menteni"
 
@@ -945,9 +786,168 @@ msgstr "Felolvasó megállítani"
 msgid "Bring All to Front"
 msgstr "Mindet előre"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Projekt-könyvtárat kinyitni"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Külső változtatásokat mindig betölteni"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "A fájl megváltozott. Menteni vagy eldobni?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "A Zettlr megjelenítése"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló hibája (állapotkód: "
+"%s)."
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Nem sikerült ellenőrizni a frissítéseket: az ügyfél hibája (állapotkód: %s)."
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló megpróbálta "
+"átirányítani (állapotkód: %s)."
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"Nem sikerült ellenőrizni a frissítéseket: nem sikerült létrehozni a "
+"kapcsolatot."
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Nem sikerült ellenőrizni a frissítéseket: a kiszolgáló nem küldött adatokat."
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
 msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
@@ -965,142 +965,1159 @@ msgstr "Eldobni a változásokat?"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "A fájl megváltozott. Menteni vagy eldobni?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
 #, fuzzy
-msgid "Copy path"
-msgstr "Azonosítót másolni"
+msgid "Replace"
+msgstr "Fájl cseréje"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
 msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Szűrési címkék..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Tervezett idő"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Ki"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Kövesse az operációs rendszert"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Indítani"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "A Zettlr megjelenítése"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Egyéni CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Kinyitni a könyvtárát"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "%s exportálása"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Címkéket eltávolítani"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Kikapcsolni a belső hivatkozásokat"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Eltávolítani a belső hivatkozásokat"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Kikapcsolni a belső hivatkozásokat"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Megtartani a belső hivatkozásokat"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Fájlinformációkat megjeleníteni"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Megjegyzés"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Fájlt törölni"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "A hibakeresési mód engedélyezése"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "A hibakeresési mód engedélyezése"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Értesítsen a béta kiadásokról"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Könyvtárban keresni …"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Címsorok jeleit elrejteni"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Félkövér"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Dőlt betűs"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Nem használt sorokat elrejteni a zavarmentes üzemmódban"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Kép"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Sötét mód"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Fájlinformációkat megjeleníteni"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exportálni …"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Legutóbbi dokumentumok"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Rendes sorrend (10 után 2 jön)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII sorrend (2 után 10 jön)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Idézeteket megjeleníteni"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Az azonosítókhoz használt minta"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Az azonosító reguláris kifejezése"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Az azonosítókhoz használt minta"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Egyéni CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Egyéni CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Forráskód"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Válassza ki a helyesírás ellenőrzésére használandó nyelveket."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Felhasználói szótár. A benne levő szavak rákattintással törölhetők."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s szó"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Egyéni CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "A fájlt nem lehetett létrehozni"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Kinyitni …"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Hivatkozás"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Kép"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Hivatkozást megnyitni"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Nincsen javaslat"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "A szótárhoz adni"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Félkövér betű"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Hivatkozást beszúrni"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Felsorolást beszúrni"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Számozott felsorolást beszúrni"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Fájlt bezárni"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Könyvtárat átnevezni …"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Könyvtárat eltörölni"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Könyvtárat megkeresni …"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Projektet exportálni"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr " "
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,324 +2549,322 @@ msgstr "kínai"
 msgid "Chinese"
 msgstr "kínai"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr " "
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr ""
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Egyéni CSS"
+msgid "Copy path"
+msgstr "Azonosítót másolni"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s szó"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Fájlt bezárni"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Könyvtárat átnevezni …"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Könyvtárat eltörölni"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Könyvtárat megkeresni …"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Projektet exportálni"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Félkövér"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Dőlt betűs"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Hivatkozás"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Kép"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Megjegyzés"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Forráskód"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Kinyitni …"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Hivatkozást megnyitni"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Nincsen javaslat"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "A szótárhoz adni"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Félkövér betű"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Hivatkozást beszúrni"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Felsorolást beszúrni"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Számozott felsorolást beszúrni"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "A fájlt nem lehetett létrehozni"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Van új frissítés"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Telepített verzió"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Letölthető a Zettlr új verziója. A változásokat lásd alább."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Szűrési címkék..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Projekt-könyvtárat kinyitni"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Fájlt törölni"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Fájlt törölni"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Kép"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1866,10 +2881,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1933,45 +2944,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr a következő projekteket is felhasználja:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"A pontosabb testreszabás érdekében itt felülbírálhatja a Zettlr stílusát. "
-"<strong> Figyelem: Ez a fájl felülírja az összes CSS-irányelvet! Soha ne "
-"változtassa meg az elemek geometriáját, különben az alkalmazás viselkedése "
-"előreláthatatlanná válik! </strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Egyéni CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1994,39 +2987,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr ""
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"A pontosabb testreszabás érdekében itt felülbírálhatja a Zettlr stílusát. "
+"<strong> Figyelem: Ez a fájl felülírja az összes CSS-irányelvet! Soha ne "
+"változtassa meg az elemek geometriáját, különben az alkalmazás viselkedése "
+"előreláthatatlanná válik! </strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "szavak"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "betűk"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Indítani"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Szűrési címkék..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2052,76 +3084,114 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "a múlt hónapban gépelt szó"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "napi átlag"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "ma gépelt szó"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Éget a szorgalom!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Közel áll a napi átlaghoz!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Írni kéne még meg a napi átlaghoz!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Kinyitni a könyvtárát"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Irodalom jegyzék"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Ebben a dokumentumban nincsenek idézetek."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Címkefelhő"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2131,8 +3201,8 @@ msgstr "Könyvtárak"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Fájlok"
 
@@ -2146,9 +3216,25 @@ msgstr "Betű"
 msgid "Words"
 msgstr "Szó"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Nincs nyitva fájl illetve könyvtár"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
@@ -2178,15 +3264,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2247,13 +3324,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2464,129 +3534,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Célteljesítményt kitűzni …"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Nincs nyitva fájl illetve könyvtár"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "a múlt hónapban gépelt szó"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "napi átlag"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "ma gépelt szó"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Éget a szorgalom!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Közel áll a napi átlaghoz!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Írni kéne még meg a napi átlaghoz!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2609,11 +3559,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2627,1073 +3572,134 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Címkefelhő"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "szavak"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "betűk"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Fájlt törölni"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Projekt-könyvtárat kinyitni"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Fájlt törölni"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Idézeteket megjeleníteni"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Az azonosítókhoz használt minta"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Az azonosító reguláris kifejezése"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Az azonosítókhoz használt minta"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Kikapcsolni a belső hivatkozásokat"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Fájl cseréje"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Szűrési címkék..."
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Könyvtárban keresni …"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Címsorok jeleit elrejteni"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Nem használt sorokat elrejteni a zavarmentes üzemmódban"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Tervezett idő"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Ki"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Kövesse az operációs rendszert"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "A Zettlr megjelenítése"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Kinyitni a könyvtárát"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Irodalom jegyzék"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Ebben a dokumentumban nincsenek idézetek."
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Egyéni CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Egyéni CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Válassza ki a helyesírás ellenőrzésére használandó nyelveket."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Felhasználói szótár. A benne levő szavak rákattintással törölhetők."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Sötét mód"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Fájlinformációkat megjeleníteni"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exportálni …"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Legutóbbi dokumentumok"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Rendes sorrend (10 után 2 jön)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII sorrend (2 után 10 jön)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "%s exportálása"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Címkéket eltávolítani"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Eltávolítani a belső hivatkozásokat"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Kikapcsolni a belső hivatkozásokat"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Megtartani a belső hivatkozásokat"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Fájlinformációkat megjeleníteni"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Megjegyzés"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Van új frissítés"
 
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Telepített verzió"
 
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Fájlt törölni"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "A hibakeresési mód engedélyezése"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "A hibakeresési mód engedélyezése"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Értesítsen a béta kiadásokról"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Letölthető a Zettlr új verziója. A változásokat lásd alább."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Open Link"

--- a/static/lang/id-ID.po
+++ b/static/lang/id-ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr ""
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Workspace"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,142 +82,6 @@ msgstr "Pilihan %s setidaknya harus %s (panjang karakter)."
 msgid "Option %s is required."
 msgstr "Pilihan %s diwajibkan."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Perlihatkan Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Keluar"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Pembaruan ke versi %s telah tersedia!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Tidak dapat memeriksa pembaruan: Galat Server (Kode status: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Tidak dapat memeriksa pembaruan: Galat klien (Kode status: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Tidak dapat memeriksa pembaruan: Server mencoba mengalihkan sambungan (Kode "
-"status: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Tidak dapat memeriksa pembaruan: Tidak dapat melakukan koneksi"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Tidak dapat mengecek pembaruan. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Tidak dapat memeriksa pembaruan: Server belum mengirim data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Tidak bisa membuat file"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Referensi dengan kunci %s tidak memiliki lampiran."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Tidak bisa membuka lampiran. Apakah Zotero sedang dijalankan?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -221,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Batal"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Ingin dihapus?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Kamu yakin ingin menghapus %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Referensi dengan kunci %s tidak memiliki lampiran."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Tidak bisa membuka lampiran. Apakah Zotero sedang dijalankan?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Textbundle rusak: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Ekspor Proyek"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Ekspor..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -293,48 +245,6 @@ msgstr "%s file ini tidak dapat diimpor, karena tipe file tidak diketahui: %s"
 msgid "Import failed"
 msgstr "Ekspor gagal"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Ekspor Proyek"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Ekspor..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Tidak dapat memindahkan direktori"
@@ -352,28 +262,49 @@ msgstr "Tidak bisa memindahkan file atau direktori"
 msgid "The file/directory %s already exists in target."
 msgstr "File/direktori %s sudah ada."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Tanpa Judul"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Nama yang diberikan tidak mengandung huruf yang diperbolehkan."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Tidak bisa membuat direktori"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Direktori yang diminta tidak ditemukan."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Ingin dihapus?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Ekspor gagal"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Terjadi kesalahan saat mengekspor: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Simpan"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Kamu yakin ingin menghapus %s?"
+msgid "Exporting to %s"
+msgstr "Mengekspor ke %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Terjadi kesalahan saat mengekspor: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -398,10 +329,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -415,124 +348,33 @@ msgstr "File bahasa yang diimpor: %s"
 msgid "Could not import language file %s!"
 msgstr "Tidak bisa mengimpor file bahasa %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Ekspor gagal"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Tidak bisa membuat file"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Terjadi kesalahan saat mengekspor: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Simpan"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Mengekspor ke %s"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Tanpa Judul"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Tidak bisa membuat direktori"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Terjadi kesalahan saat mengekspor: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Nama yang diberikan tidak mengandung huruf yang diperbolehkan."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Direktori yang diminta tidak ditemukan."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Textbundle rusak: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Selalu muat perubahan secara remote ke file saat ini"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr ""
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Buka folder proyek"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr ""
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
 
 #: source/app/service-providers/menu/menu.win32.ts:44
@@ -645,6 +487,12 @@ msgstr "Ubah nama file"
 msgid "Delete file"
 msgstr "Hapus file"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Keluar"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -663,15 +511,15 @@ msgstr "Kembalikan"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Potong"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Salin"
 
@@ -683,8 +531,8 @@ msgstr "Salin sebagai HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Tempel"
 
@@ -696,8 +544,8 @@ msgstr "Tempelkan tanpa gaya"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Pilih semua"
 
@@ -940,10 +788,162 @@ msgstr "Berhenti bicara"
 msgid "Bring All to Front"
 msgstr "Bawa Semua ke Depan"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Workspace"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Buka folder proyek"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Selalu muat perubahan secara remote ke file saat ini"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Perlihatkan Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Pembaruan ke versi %s telah tersedia!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Tidak dapat memeriksa pembaruan: Galat Server (Kode status: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Tidak dapat memeriksa pembaruan: Galat klien (Kode status: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Tidak dapat memeriksa pembaruan: Server mencoba mengalihkan sambungan (Kode "
+"status: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Tidak dapat memeriksa pembaruan: Tidak dapat melakukan koneksi"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Tidak dapat mengecek pembaruan. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Tidak dapat memeriksa pembaruan: Server belum mengirim data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -962,143 +962,1195 @@ msgstr ""
 "Perubahan belum tersimpan ke file saat ini. Ingin disimpan atau diabaikan "
 "saja?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Mode pengelola berkas"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Aktifkan Koreksi Otomatis"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Atribut"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "File duplikat"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Salin ID"
+msgid "Double Quotes"
+msgstr "Tidak ada"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Salin nama file"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Tidak ada"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Tidak ada"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Ganti file"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Saring ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Jadwal"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Mati"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Mengikuti Sistem Operasi"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Mulai"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Perlihatkan Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Buka direktori"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Mengekspor ke %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Gunakan pandoc internal untuk mengeskpor"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Hapus label dari file"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Hapus tautan internal"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Hapus semua tautan internal"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Hapus tautan internal"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Jangan merubah tautan internal"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Tampilkan informasi file"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Komentar"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Pola untuk nama file baru"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Pola untuk nama file baru"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Tidak"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Gunakan tampilan jendela bawaan"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Gunakan tampilan jendela bawaan"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Tampilkan aplikasi di area notifikasi"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Biarkan aplikasi berjalan di area notifikasi"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Ukuran fon editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "iFrame rendering whitelist"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nama host"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktifkan polling Watchdog"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Waktu tunggu sebelum penulisan file dianggap selesai (dalam milidetik)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Hapus file"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Aktifkan mode debug"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Aktifkan mode debug"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Beri tahu saya"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Mode masukan editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Cari dalam direktori"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Sembunyikan karakter judul"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Tebal"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Miring"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Aktifkan Editor Tabel"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Matikan garis non-fokus saat mode bebas gangguan aktif"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Jumlah kata"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr ""
+"Hitung berdasarkan karakter daripada berdasarkan kata (misalnya, untuk "
+"tulisan China)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Gambar"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Lebar maksimum citra (persen)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Tinggi maksimum citra (persen)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Ber"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Ukuran fon editor"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Inden dengan jumlah spasi berikut"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Inden dengan jumlah spasi berikut"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Ikut terima spasi saat autocomplete"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Menutup kurung siku secara otomatis"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Tampilkan informasi file"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Waktu modifikasi terakhir"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Waktu pembuatan file"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Ekspor..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Dokumen terkini"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Urutan acak (10 lalu 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Urutan ASCII (2 lalu 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Menampilkan Kutipan"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Atur autokomplet sitasi"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Tambahkan ke berkas"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Pola yang digunakan untuk membuat ID baru"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Ekspresi reguler ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Pola yang digunakan untuk membuat ID baru"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Tambahkan nama file saat menautkan file ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "Selalu"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "hanya pada saat menautkan menggunakan ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "Jangan penah"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+#, fuzzy
+msgid "Link format"
+msgstr "Awal tautan"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Lakukan pencarian ketika mengklik pranala-Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Membuat file yang tidak ada secara otomatis saat mengikuti tautan internal"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalender"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Kustom CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Kustom CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Tindakan"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kode"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Pilih bahasa yang ingin diaktifkan pemeriksaan ejaannya secara otomatis."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Kamus pengguna. Klik untuk menghapus kata."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Entri kamus"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Cari entri"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Simpan otomatis"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Waktu modifikasi terakhir"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Langsung"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Setelah jeda singkat"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Hindari membuka berkas di tab baru jika memungkinkan"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Pengecek pembaruan"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Tidak bisa membuat file"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Jumlah kata"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Buka"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Buka di tab baru"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Tautan"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Gambar"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Komentar"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Salin gambar ke papan klip"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Buka file"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Buka di peramban"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Tidak ada saran"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Tambah ke Kamus"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Miring"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Sisipkan tautan"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Sisipkan daftar tidak berurutan"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Sisipkan daftar bernomor"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Tutup File"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Ubah nama direktori"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Hapus direktori"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Periksa direktori ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Ekspor Proyek"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Tutup semua bilah lain"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Tutup semua bilah"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1530,329 +2582,320 @@ msgstr "Mandarin (Cina)"
 msgid "Chinese"
 msgstr "Mandarin (Cina)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Atribut"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "File duplikat"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr ""
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr ""
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr ""
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr ""
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
-msgstr ""
-
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr ""
-
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr ""
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Tebal"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Miring"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Tautan"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Gambar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Komentar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kode"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr ""
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr ""
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Jumlah kata"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr ""
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Buka"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Buka di tab baru"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Salin gambar ke papan klip"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Open image"
-msgstr "Buka file"
+msgid "Copy path"
+msgstr "Salin ID"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Buka di peramban"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Salin nama file"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Tidak ada saran"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Tambah ke Kamus"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Miring"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Sisipkan tautan"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Sisipkan daftar tidak berurutan"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Sisipkan daftar bernomor"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Tutup File"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Ubah nama direktori"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Hapus direktori"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Periksa direktori ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Ekspor Proyek"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Tutup semua bilah lain"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Tutup semua bilah"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Grafik"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Tidak bisa membuat file"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Januari"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Februari"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Maret"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "April"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Mei"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Juni"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Juli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agustus"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "September"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Oktober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "November"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Desember"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Pengecek pembaruan"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Tersedia pembaruan baru"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Versi kamu"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Versi terbaru dari Zettlr tersedia untuk diunduh. Harap baca log perubahan "
-"di bawah ini."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Mengunduh pembaruan"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Pembaruan tidak tersedia. Anda sudah memiliki versi terbaru."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klik untuk memulai pembaruan"
-
-#: source/tmp/win-update/App.vue.ts:45
-#, fuzzy
-msgid "never"
-msgstr "Jangan penah"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Memulai pembaruan ..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Cari"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr ""
-"Cuplikan adalah potongan teks yang dapat digunakan kembali, definisikan "
-"menggunakan peubah"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filter label..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Atur ulang"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Tambahkan"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Tindakan"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Hapus file"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Gambar"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1869,10 +2912,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1935,46 +2974,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr juga menggunakan proyek-proyek ini:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"Di sini kamu dapat mengganti gaya Zettlr untuk menyesuaikannya lebih jauh. "
-"<strong>Perhatian: File ini mengganti semua aturan CSS! Jangan pernah "
-"mengubah geometri elemen, karena dapat menyebabkan masalah pada aplikasi!</"
-"strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Menyimpan ..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Berhasil tersimpan"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1996,39 +3017,80 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr ""
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Berhasil tersimpan"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Di sini kamu dapat mengganti gaya Zettlr untuk menyesuaikannya lebih jauh. "
+"<strong>Perhatian: File ini mengganti semua aturan CSS! Jangan pernah "
+"mengubah geometri elemen, karena dapat menyebabkan masalah pada aplikasi!</"
+"strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "kata"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "karakter"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Mulai"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+"Cuplikan adalah potongan teks yang dapat digunakan kembali, definisikan "
+"menggunakan peubah"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filter label..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2054,76 +3116,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "kata bulan lalu"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Berkas yang berkaitan"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "rata-rata harian"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "kata hari ini"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Kamu sedang bersemangat!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Kamu hampir mencapai rata-rata harianmu!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Terus menulis untuk melampaui rata-rata harianmu."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Statistik selengkapnya ..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Ber"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Buka direktori"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Tidak ada berkas lainnya"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referensi"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Tidak ada kutipan pada dokumen ini."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Awan Label"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Ekspor..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Ekspor..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2133,8 +3235,8 @@ msgstr "Direktori"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "File"
 
@@ -2148,10 +3250,26 @@ msgstr "Karakter"
 msgid "Words"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Workspace"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Tidak ada file atau folder yang terbuka"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Tidak ada hasil"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Direktori belum dipilih"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Kosongkan direktori"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2181,15 +3299,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Atur ulang"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2250,13 +3359,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2466,131 +3568,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr ""
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Tidak ada hasil"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Direktori belum dipilih"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Kosongkan direktori"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Workspace"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Tidak ada file atau folder yang terbuka"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "kata bulan lalu"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "rata-rata harian"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "kata hari ini"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Kamu sedang bersemangat!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Kamu hampir mencapai rata-rata harianmu!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Terus menulis untuk melampaui rata-rata harianmu."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Statistik selengkapnya ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Ekspor..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Ekspor..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2613,11 +3593,6 @@ msgstr "Batasi pencarian dalam direktori"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Cari"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Bersihkan pencarian"
@@ -2631,1107 +3606,138 @@ msgstr "Alihkan penampilan hasil pencarian"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Awan Label"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "kata"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "karakter"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Berkas yang berkaitan"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Tambahkan"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Tindakan"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Hapus file"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Aktifkan Koreksi Otomatis"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Menampilkan Kutipan"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Januari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Februari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Maret"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "April"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Mei"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Juni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Juli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agustus"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "September"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Oktober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "November"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Desember"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Grafik"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Pola yang digunakan untuk membuat ID baru"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Ekspresi reguler ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Pola yang digunakan untuk membuat ID baru"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Hapus tautan internal"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Tambahkan nama file saat menautkan file ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "Selalu"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "hanya pada saat menautkan menggunakan ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "Jangan penah"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-#, fuzzy
-msgid "Link format"
-msgstr "Awal tautan"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Lakukan pencarian ketika mengklik pranala-Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Membuat file yang tidak ada secara otomatis saat mengikuti tautan internal"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Tidak ada"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Tidak ada"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Tidak ada"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Ganti file"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Saring ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Mode masukan editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Cari dalam direktori"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Sembunyikan karakter judul"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Aktifkan Editor Tabel"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Matikan garis non-fokus saat mode bebas gangguan aktif"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Jumlah kata"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr ""
-"Hitung berdasarkan karakter daripada berdasarkan kata (misalnya, untuk "
-"tulisan China)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Lebar maksimum citra (persen)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Tinggi maksimum citra (persen)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Ber"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Ukuran fon editor"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Inden dengan jumlah spasi berikut"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Inden dengan jumlah spasi berikut"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Ikut terima spasi saat autocomplete"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Menutup kurung siku secara otomatis"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Jadwal"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Mati"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Mengikuti Sistem Operasi"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Perlihatkan Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Buka direktori"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Tidak ada berkas lainnya"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalender"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referensi"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Tidak ada kutipan pada dokumen ini."
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Kustom CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Kustom CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Tindakan"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Pilih bahasa yang ingin diaktifkan pemeriksaan ejaannya secara otomatis."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Kamus pengguna. Klik untuk menghapus kata."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Entri kamus"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Cari entri"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Tampilkan informasi file"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Waktu modifikasi terakhir"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Waktu pembuatan file"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Ekspor..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Dokumen terkini"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Urutan acak (10 lalu 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Urutan ASCII (2 lalu 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Mengekspor ke %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Gunakan pandoc internal untuk mengeskpor"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Hapus label dari file"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Hapus semua tautan internal"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Hapus tautan internal"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Jangan merubah tautan internal"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Tampilkan informasi file"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Komentar"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Pola untuk nama file baru"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Pola untuk nama file baru"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Tidak"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Gunakan tampilan jendela bawaan"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Gunakan tampilan jendela bawaan"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Tampilkan aplikasi di area notifikasi"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Biarkan aplikasi berjalan di area notifikasi"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Ukuran fon editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "iFrame rendering whitelist"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nama host"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktifkan polling Watchdog"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Waktu tunggu sebelum penulisan file dianggap selesai (dalam milidetik)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Hapus file"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Aktifkan mode debug"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Aktifkan mode debug"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Beri tahu saya"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Simpan otomatis"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Waktu modifikasi terakhir"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Langsung"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Setelah jeda singkat"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Hindari membuka berkas di tab baru jika memungkinkan"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Pengecek pembaruan"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Tersedia pembaruan baru"
+
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Versi kamu"
+
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
+"Versi terbaru dari Zettlr tersedia untuk diunduh. Harap baca log perubahan "
+"di bawah ini."
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Atur autokomplet sitasi"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Mengunduh pembaruan"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Pembaruan tidak tersedia. Anda sudah memiliki versi terbaru."
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klik untuk memulai pembaruan"
+
+#: source/tmp/win-update/App.vue.ts:45
 #, fuzzy
-msgid "Path to file"
-msgstr "Tambahkan ke berkas"
+msgid "never"
+msgstr "Jangan penah"
 
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Memulai pembaruan ..."
 
 #~ msgid "Open Link"
 #~ msgstr "Buka Tautan"

--- a/static/lang/it-IT.po
+++ b/static/lang/it-IT.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-06-14 15:14+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,6 +18,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Impossibile caricare il database delle citazioni"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Sono stati rilevati dei cambiamenti nella libreria. Ricarica …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Caricamento area di lavoro %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -69,149 +83,6 @@ msgstr "Il campo %s necessita un valore lungo almeno %s caratteri."
 msgid "Option %s is required."
 msgstr "Il campo %s è richiesto."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Mostra Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Esci"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Aggiornamento disponbile"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Un aggiornamento alla versione %s è disponibile!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Impossibile verificare la presenza di aggiornamenti: Errore Server (Status "
-"code: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Impossibile verificare la presenza di aggiornamenti: Errore Client (Status "
-"code: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Impossibile verificare la presenza di aggiornamenti: il server ha provato a "
-"reindirizzare (Status code: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"Impossibile verificare la presenza di aggiornamenti: impossibile connettersi"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Non è stato possibile controllare gli aggiornamenti: %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Impossibile verificare la presenza di aggiornamenti: il server non ha "
-"inviato alcun dato"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Documento troppo lungo"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Impossibile creare il file"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Il riferimento con la chiave %s non sembra avere allegati."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Impossibile aprire l'allegato. Zotero è in esecuzione?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -229,24 +100,101 @@ msgstr "Sì"
 msgid "No"
 msgstr "No"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Sostituire il tag \"%s\" con \"%s\" nei file %s?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Annulla"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Eliminare per davvero?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Vuoi davvero eliminare %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Il riferimento con la chiave %s non sembra avere allegati."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Impossibile aprire l'allegato. Zotero è in esecuzione?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "TextBundle difettoso: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Seleziona il profilo di importazione"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "Esistono più profili che possono essere importati %s. Sceglierne uno."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Impossibile esportare il progetto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"Non ci sono file selezionati per l'esportazione. Seleziona i file da "
+"includere nelle impostazioni del progetto."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Mancata corrispondenza di File Progetto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Uno o più file specificati nelle impostazioni del progetto non trovati. "
+"Potrebbero essere stati spostati o eliminati. Verifica che tutti i file che "
+"desideri esportare siano inclusi."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Progetto \"%s\" esportato correttamente. Cliccare per visualizzarlo."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Esportazione Progetto"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -300,51 +248,6 @@ msgstr "Impossibile importare file %s poiché il loro formato è sconosciuto: %s
 msgid "Import failed"
 msgstr "Importazione non riuscita"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Impossibile esportare il progetto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"Non ci sono file selezionati per l'esportazione. Seleziona i file da "
-"includere nelle impostazioni del progetto."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Mancata corrispondenza di File Progetto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Uno o più file specificati nelle impostazioni del progetto non trovati. "
-"Potrebbero essere stati spostati o eliminati. Verifica che tutti i file che "
-"desideri esportare siano inclusi."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Progetto \"%s\" esportato correttamente. Cliccare per visualizzarlo."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Esportazione Progetto"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Impossibile spostare la cartella"
@@ -363,28 +266,49 @@ msgstr "Impossibile spostare il file o la cartella"
 msgid "The file/directory %s already exists in target."
 msgstr "Esiste già un file o una cartella con nome %s."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Senza titolo"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Il nome indicato non contiene alcuna lettera consentita."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Impossibile creare la cartella"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "La cartella richiesta non esiste."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Eliminare per davvero?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Esportazione non riuscita"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Vuoi davvero eliminare %s?"
+msgid "An error occurred during export: %s"
+msgstr "Si è verificato un errore durante l'esportazione: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Scegli destinazione di esportazione"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Salva"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Esportazione in %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Errore durante l'esportazione: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -409,11 +333,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Copia di %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Documento troppo lungo"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -426,127 +352,34 @@ msgstr "File di lingua importato: %s"
 msgid "Could not import language file %s!"
 msgstr "Impossibile importare il file di lingua %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Esportazione non riuscita"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Impossibile creare il file"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Si è verificato un errore durante l'esportazione: %s"
+msgid "Copy of %s"
+msgstr "Copia di %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Scegli destinazione di esportazione"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Senza titolo"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Salva"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Impossibile creare la cartella"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Esportazione in %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Errore durante l'esportazione: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Il nome indicato non contiene alcuna lettera consentita."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "La cartella richiesta non esiste."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Seleziona il profilo di importazione"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "Esistono più profili che possono essere importati %s. Sceglierne uno."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "TextBundle difettoso: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Sostituisci file"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Il file %s è stato modificato da remoto. Sovrascrivere la versione caricata "
-"con la versione più nuova da disco?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Carica sempre le modifiche remote al file corrente"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Sovrascrivi file esistente"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Il file %s esiste già nella cartella. Vuoi sovrascrivere?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Apri file"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Modifiche non salvate"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Sono presenti modifiche non salvate. Vuoi salvare prima di procedere?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Salva file"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Apri cartella progetto"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Impossibile caricare il database delle citazioni"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Sono stati rilevati dei cambiamenti nella libreria. Ricarica …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Sostituire il tag \"%s\" con \"%s\" nei file %s?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -658,6 +491,12 @@ msgstr "Rinomina file"
 msgid "Delete file"
 msgstr "Elimina file"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Esci"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -676,15 +515,15 @@ msgstr "Ripeti"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Taglia"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copia"
 
@@ -696,8 +535,8 @@ msgstr "Copia come HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Incolla"
 
@@ -709,8 +548,8 @@ msgstr "Incolla senza stile"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Seleziona tutto"
 
@@ -954,10 +793,171 @@ msgstr "Smetti di parlare"
 msgid "Bring All to Front"
 msgstr "Porta tutto in primo piano"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Apri cartella progetto"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Sostituisci file"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Caricamento area di lavoro %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Il file %s è stato modificato da remoto. Sovrascrivere la versione caricata "
+"con la versione più nuova da disco?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Carica sempre le modifiche remote al file corrente"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Modifiche non salvate"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Sono presenti modifiche non salvate. Vuoi salvare prima di procedere?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Apri file"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Salva file"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Sovrascrivi file esistente"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Il file %s esiste già nella cartella. Vuoi sovrascrivere?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Mostra Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Aggiornamento disponbile"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Un aggiornamento alla versione %s è disponibile!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Impossibile verificare la presenza di aggiornamenti: Errore Server (Status "
+"code: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Impossibile verificare la presenza di aggiornamenti: Errore Client (Status "
+"code: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Impossibile verificare la presenza di aggiornamenti: il server ha provato a "
+"reindirizzare (Status code: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"Impossibile verificare la presenza di aggiornamenti: impossibile connettersi"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Non è stato possibile controllare gli aggiornamenti: %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Impossibile verificare la presenza di aggiornamenti: il server non ha "
+"inviato alcun dato"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -971,16 +971,16 @@ msgstr "Non salvare le modifiche"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Sono presenti modifiche non salvate. Vuoi salvarle o scartarle?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "File su disco modificato"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s su disco modificato"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -990,129 +990,1161 @@ msgstr ""
 "Vuoi mantenere il contenuto corrente dell'editor o caricare il file dal "
 "disco?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Vuoi mantenere il contenuto corrente dell'editor o caricare il file dal "
 "disco?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Mantieni i contenuti dell'editor"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Carica le modifiche dal disco"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Carica sempre le modifiche dal disco se non sono presenti modifiche non "
 "salvate nell'editor"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Impossibile salvare il file"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Impossibile salvare il file %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Correzione Automatica"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Virgolette intelligenti"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Virgolette"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Disabilita Virgolette intelligenti"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Virgolette Singole"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Modelli di sostituzione testo"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Abbina parole intere"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+"Se selezionata, la Correzione Automatica non sostituirà mai parti di parole"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Sostituisci"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "Con"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Filtro"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Orario"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Off"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Segui il Sistema Operativo"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "On"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Inizia"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Fine"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Tema"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Opzioni della barra strumenti"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Proprietà"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplica file"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Copia percorso"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copia il nome del file"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Barra di stato"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS Personalizzato"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Apri editor CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Importazione ed esportazione profili"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Apri l'editor dei profili di importazione"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Apri l'editor dei profili di esportazione"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Impostazioni di esportazione"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Usa il Pandoc interno di Zettlr per le esportazioni"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Rimuovi i tag dai file nell'esportazione"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Collegamenti interni"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Rimuovi completamente i collegamenti interni"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Scollega i collegamenti interni"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Non toccare i collegamenti interni"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Cartella di destinazione per i file esportati"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Cartella temporanea"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Come il percorso del file"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Chiedi la cartella per l'esportazione"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Attenzione! I file nella cartella temporanea vengono regolarmente eliminati. "
+"Scegliendo la stessa posizione del file, i file con nomi identici verranno "
+"sovrascritti se già esistenti."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Comandi di esportazione personalizzati"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Nome visualizzato"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Comando"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Inserisci i comandi personalizzati con cui eseguire l'esportatore. Ogni "
+"comando riceve come primo argomento il file o la cartella del progetto da "
+"esportare."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Modello nomi per nuovi file"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Definire modello nomi per i nuovi file"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Variabili disponibili: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Non chiedere un nome quando si crea un nuovo file"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Aspetto"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Usa l'aspetto di default per le finestre"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+"Disponibile solo su Linux; è l'impostazione predefinita per macOS e Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Abilita finestra dinamica"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Disponibile solo su macOS; rende opaco lo sfondo della finestra."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Mostra l'app nella barra delle notifiche"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Lascia l'app in esecuzione nella barra delle notifiche"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportamento Zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Ridimensiona l'intera GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Modifica la dimensione del testo nell'editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Barra laterale Allegati"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "Estensioni dei file visibili nella barra laterale Allegati"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Whitelist er il rendering degli iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nome host"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Sorveglianza watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Tempo di attesa entro il quale si considera terminata la scrittura di un "
+"file (in ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Eliminazione elementi"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Modalità di debug"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Attiva la modalità di debug"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Rilasci di versioni beta"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Segnalami il rilascio di versioni beta"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Modalità di input dell'editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"La modalità di input determina il modo in cui interagisci con l'editor. Si "
+"consiglia di mantenere questa impostazione su \"Normale\". Scegli \"Vim\" o "
+"\"Emacs\" solo se sai cosa implica."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Direzione di scrittura"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Interpreta il Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Selezionare per formattare in tempo reale gli elementi di Markdown. Ciò "
+"nasconde i caratteri di formattazione (come **testo**) o esegue il rendering "
+"delle immagini invece di mostrarne il collegamento."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Nascondi i cancelletti dalle intestazioni"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Interpreta le enfasi (bold, italic)"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Grassetto"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Corsivo"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Controlla problemi di stile del Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Editor delle Tabelle"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"L'editor di tabelle è un'interfaccia interattiva che semplifica la creazione "
+"e la modifica delle tabelle. Fornisce pulsanti per funzionalità comuni e si "
+"occupa della formattazione Markdown."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "In modalità Senza-Distrazioni disattiva le righe non selezionate"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Contatore parole"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Conta i caratteri invece che le parole (ad es., per Cinese)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Modalità di leggibilità"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algoritmo"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Dimensioni Immagine"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Larghezza massima delle immagini (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Altezza massima delle immagini (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Altre impostazioni"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Dimensione del testo"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Dimensione del rientro (numero di spazi)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Rientra usando le tabulazioni invece degli spazi"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Evidenzia gli spazi bianchi"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Suggerisci emoji durante il completamento automatico"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Mostra anteprime dei collegamenti"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Chiudi automaticamente le coppie di caratteri corrispondenti"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Modalità display"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Sottile"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Allargata"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Combinata"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"La modalità \"Sottile\" mostra le directory e i file separatamente. "
+"Selezionare una directory per visualizzarne il contenuto nell'elenco dei "
+"file. Passa dall'elenco dei file all'albero delle directory facendo clic "
+"sulle directory o sul pulsante freccia che appare nell'angolo in alto a "
+"sinistra dell'elenco dei file."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Mostra le informazioni dei file"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Mostra le cartelle sopra i file"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Visualizza nome del documento Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Solo nome del file"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Titolo se disponibile"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Prima intestazione di livello 1, se disponibile"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Titolo o prima intestazione di livello 1, se disponibile"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Visualizza le estensioni dei file Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Visualizzazione Orologio"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Data dell'ultima modifica"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Data di creazione"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Ordinamento"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Quando si ordinano i documenti…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Usa ordine naturale (il 2 prima di 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Usa ordine ASCII (il 2 dopo il 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Citazioni"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Come vuoi l'auto-completamento per inserire le tue citazioni?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Percorso del file"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Modello per gli ID Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Utilizza espressioni regolari ECMAScript"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Modello utilizzato per generare nuovi ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Variabili disponibili: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Collegamento solo con nome file"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "Quando colleghi i file, aggiungi il nome del documento …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Sempre"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Solo quando si collega utilizzando l'ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Mai"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Formato del collegamento"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"I collegamenti interni consentono di aggiungere un titolo facoltativo, "
+"separato da una barra verticale dall'effettiva destinazione del "
+"collegamento. Qui puoi definire l'ordine dei due."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Titolo]]: prima il Link (consigliato)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Titolo|Link]]: prima il Titolo"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Avvia una ricerca full-text quando si seguono i collegamenti interni"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+"La stringa di ricerca corrisponderà al contenuto tra le parentesi: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Crea automaticamente file inesistenti in questa cartella quando segui i "
+"collegamenti interni"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Per funzionare, la cartella deve essere aperta come Area di Lavoro "
+"(Workspace) in Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Percorso della cartella"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Snippet"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Apri l'editor degli snippet"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Severità"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Standard"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Pignolo"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Lingua madre"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Non impostato"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Varianti preferite"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool non è in grado di distinguere le varianti di alcune lingue. "
+"Queste impostazioni spingeranno LanguageTool a rilevare automaticamente la "
+"tua variante preferita di queste lingue."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Interpreta inglese come"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Interpreta tedesco come"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Interpreta portoghese come"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Interpreta catalano come"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Fornitore di LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Server personalizzato"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Indirizzo del server personalizzato"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr ignorerà le impostazioni del \"Provider di LanguageTool\" se "
+"inserisci delle credenziali qui."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool Nome Utente"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool chiave API"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Controllo ortografico"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Attivo"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Lingua"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Codice"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Seleziona le lingue per cui vuoi attivare il controllo ortografico "
+"automatico."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Dizionario Utente. Rimuovi le parole cliccando su di esse."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Voce del dizionario"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Ricerca voci …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Lingua dell'applicazione"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Autosalvataggio"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Salva modifiche"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Immediatamente"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Dopo un breve ritardo"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Cartella immagini predefinita"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Fare clic su \"Seleziona cartella…\" o digita un percorso assoluto o "
+"relativo nel campo di immissione."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Comportamento"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Evita di aprire file in nuove schede, se possibile"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Aggiornamenti"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Controlla automaticamente gli aggiornamenti"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caratteri"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s parole"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Vai al riferimento alla nota a piè di pagina"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Nessuna evidenziazione"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Apri pannello di diagnostica"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Personalizzato"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Rileva automaticamente"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Rendering del grafico mermaid …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Impossibile eseguire il rendering del grafico:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Modalità leggibilità (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Immagine non trovata: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Errore di ortografia"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Il file %s non esiste."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Contatore parole"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificato"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Apri…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Apri in una nuova scheda"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Recupero anteprima del collegamento …"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Immagine"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Commento"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Nessuna nota a piè di pagina trovata."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copia il codice dell'equazione"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copia immagine negli appunti"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Apri immagine"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Rivela nel Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Rivela in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Apri nel File Browser"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Rivela ne File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Nessun suggerimento"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Chiudi file"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Aggiungi al dizionario"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Rinomina cartella"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Corsivo"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Elimina cartella"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Inserisci link"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Controllo cartelle …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Inserisci elenco non numerato"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Esporta progetto"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Inserisci elenco numerato"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Chiudi le altre schede"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Chiudi tutte le schede"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Sblocca scheda"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Blocca scheda"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-clic per seguire questo collegamento"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1520,325 +2552,319 @@ msgstr "Cinese (Taiwan)"
 msgid "Chinese"
 msgstr "Cinese"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Rileva automaticamente"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Disabilitato"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Personalizzato"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s parole"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caratteri"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Apri pannello di diagnostica"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Errore di ortografia"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Vai al riferimento alla nota a piè di pagina"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Proprietà"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Recupero anteprima del collegamento …"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplica file"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Grassetto"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Copia percorso"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Corsivo"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copia il nome del file"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Rivela in Explorer"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Immagine"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Rivela ne File Browser"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Commento"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Chiudi file"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Codice"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Rinomina cartella"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Nessuna nota a piè di pagina trovata."
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Elimina cartella"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Il file %s non esiste."
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Controllo cartelle …"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Contatore parole"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Esporta progetto"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificato"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Apri…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Apri in una nuova scheda"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Nessuna evidenziazione"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Chiudi le altre schede"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Chiudi tutte le schede"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copia immagine negli appunti"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Sblocca scheda"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Apri immagine"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Blocca scheda"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Apri nel File Browser"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendario"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Nessun suggerimento"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Grafici"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Aggiungi al dizionario"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "Statistiche FSAL"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Corsivo"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Statistiche di scrittura"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Inserisci link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Gennaio"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Inserisci elenco non numerato"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Febbraio"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Inserisci elenco numerato"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Marzo"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Aprile"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maggio"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Giugno"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copia il codice dell'equazione"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Luglio"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Modalità leggibilità (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agosto"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Immagine non trovata: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Settembre"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Ottobre"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Rendering del grafico mermaid …"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Novembre"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Impossibile eseguire il rendering del grafico:"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Dicembre"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-clic per seguire questo collegamento"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Inferiore alla media mensile"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Updater"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Superiore alla media mensile"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "È disponibile un nuovo aggiornamento"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Più del doppio della media mensile"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "La tua versione"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Esporta progetto su:"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Utilizzo"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Formato"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Conversione"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "File da includere nell'esportazione"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Seleziona almeno un profilo per creare questo progetto."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Titolo del Progetto"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "Foglio di stile CSL"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "Modelo LaTeX"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "Modello HTML"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Rimuovi file dall'esportazione"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Aggiungi file all'esportazione"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Sposta file in alto"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Sposta file in basso"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Non hai selezionato alcun file per l'esportazione."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
-"Una nuova versione di Zettlr è disponibile per il download. Si prega di "
-"leggere il changelog sottostante."
+"Alcuni file selezionati per l'esportazione non esistono più nella directory."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Aggiornamento in download"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Impostazioni Generali"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Nessun aggiornamento disponibile. Hai la versione più recente."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Clicca per iniziare l'aggiornamento"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "mai"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Ultimo controllo: %s"
+msgid "No results for \"%s\""
+msgstr "Nessun risultato per \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Inizio aggiornamento …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Cerca"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Assegna colore"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Gestore File"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Rimuovi colore"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Editor"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Nome Tag"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Colore"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Importazione - Esportazione"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Conteggio"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Avanzate"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Una breve descrizione"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Ricerca di: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-"Qui puoi assegnare colori a diversi tag. Se viene trovato un tag in un file, "
-"il riquadro nell'elenco di anteprima avrà un indicatore colorato. La "
-"descrizione verrà mostrata al passaggio del mouse."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Preferenze"
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtra i tag…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Selezione cartella…"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Selezione file…"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Aggiungi"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Azioni"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Elimina"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Inserisci Immagine da Appunti"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Dimensioni Immagine"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1856,10 +2882,6 @@ msgstr "Nome File"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Nome file univoco"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Caricamento…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1925,46 +2947,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr fa inoltre uso di questi progetti:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Qui puoi sovrascrivere lo stile di Zettlr per personalizzarlo ulteriormente. "
-"<strong>Attenzione: Questo file sovrascrive tutte le direttive CSS! Non "
-"modificare la geometria degli elementi, o l'app potrebbe comportarsi in "
-"maniera indesiderata</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Rinomina snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Gli snippets permettono di definire parti di testo riutilizzabili con delle "
+"variabili."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Apri cartella snippet"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Salvataggio …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Salvataggio fallito"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Esportazione"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Importazione"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS Personalizzato"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Snippet"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Salvato!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1991,41 +2997,81 @@ msgid "Edit the default settings for imports or exports here."
 msgstr ""
 "Modifica qui le impostazioni di default per importazione ed esportazione."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Salvato!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Esportazione"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Rinomina snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Importazione"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Gli snippets permettono di definire parti di testo riutilizzabili con delle "
-"variabili."
+"Qui puoi sovrascrivere lo stile di Zettlr per personalizzarlo ulteriormente. "
+"<strong>Attenzione: Questo file sovrascrive tutte le direttive CSS! Non "
+"modificare la geometria degli elementi, o l'app potrebbe comportarsi in "
+"maniera indesiderata</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Apri cartella snippet"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Salvataggio fallito"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "parole"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Assegna colore"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caratteri"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Rimuovi colore"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Nessun documento aperto"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Nome Tag"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Inizia"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Colore"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Conteggio"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Una breve descrizione"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Qui puoi assegnare colori a diversi tag. Se viene trovato un tag in un file, "
+"il riquadro nell'elenco di anteprima avrà un indicatore colorato. La "
+"descrizione verrà mostrata al passaggio del mouse."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtra i tag…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2051,76 +3097,114 @@ msgstr "Effetto sonoro"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "parole del mese scorso"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "media giornaliera"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "parole oggi"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Non ti ferma più nessuno!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Hai quasi raggiunto la tua media giornaliera!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Inizia a scrivere per superare la tua media giornaliera."
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Altre statistiche …"
+
+#: source/tmp/win-main/App.vue.ts:221
+#, javascript-format
+msgid "%s selected"
+msgstr "%s selezionato"
+
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s selezioni"
+
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Files correlati"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Nessun file correlato"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Relazione basata su un collegamento bidirezionale."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Relazione basata su un collegamento in uscita."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Relazione basata su un backlink."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
-#, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Relazione basata su %s tag condivisi: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Altri file"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Apri la cartella"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Nessun altro file"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "Cartella corrente"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Fonti"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Non ci sono fonti in questo documento."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Nome"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Pannello dei tag"
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Attiva/disattiva modalità di leggibilità"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Esportazione…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Esporta"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "comando"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2130,8 +3214,8 @@ msgstr "Cartelle"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "File"
 
@@ -2145,10 +3229,26 @@ msgstr "Caratteri"
 msgid "Words"
 msgstr "Parole"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Spazi di lavoro"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Non ci sono file o cartelle aperte"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Nessun risultato"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nessuna cartella selezionata"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Directory vuota"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2178,15 +3278,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2247,13 +3338,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendario"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2463,130 +3547,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Imposta traguardo di scrittura…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Nessun risultato"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nessuna cartella selezionata"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Directory vuota"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Spazi di lavoro"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Non ci sono file o cartelle aperte"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "parole del mese scorso"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "media giornaliera"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "parole oggi"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Non ti ferma più nessuno!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Hai quasi raggiunto la tua media giornaliera!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Inizia a scrivere per superare la tua media giornaliera."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Altre statistiche …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s selezionato"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s selezioni"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Attiva/disattiva modalità di leggibilità"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Esportazione…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Esporta"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "comando"
+msgid "Table size: %s &times; %s"
+msgstr "Dimensioni tabella: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2608,11 +3572,6 @@ msgstr "Restringi la ricerca alle sole cartelle"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Cerca"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Cancella ricerca"
@@ -2626,1090 +3585,137 @@ msgstr "Attiva/Disattiva risultati"
 msgid "%s matches across %s files"
 msgstr "%s corrispondenze tra %s file"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Nome"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Pannello dei tag"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "parole"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caratteri"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Nessun documento aperto"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Files correlati"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Nessun file correlato"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Relazione basata su un collegamento bidirezionale."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Relazione basata su un collegamento in uscita."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Relazione basata su un backlink."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Dimensioni tabella: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Relazione basata su %s tag condivisi: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Aggiungi"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Altri file"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Azioni"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Apri la cartella"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Elimina"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Nessun altro file"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Selezione cartella…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Cartella corrente"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Selezione file…"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Esporta progetto su:"
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Utilizzo"
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Formato"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Conversione"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "File da includere nell'esportazione"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Seleziona almeno un profilo per creare questo progetto."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Titolo del Progetto"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "Foglio di stile CSL"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "Modelo LaTeX"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "Modello HTML"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Rimuovi file dall'esportazione"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Aggiungi file all'esportazione"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Sposta file in alto"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Sposta file in basso"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Non hai selezionato alcun file per l'esportazione."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
-"Alcuni file selezionati per l'esportazione non esistono più nella directory."
 
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Impostazioni Generali"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Fonti"
 
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Non ci sono fonti in questo documento."
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "Nessun risultato per \"%s\""
+msgid "circa %s words"
+msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Aspetto"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Caricamento…"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Gestore File"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Updater"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Editor"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "È disponibile un nuovo aggiornamento"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Controllo ortografico"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "La tua versione"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Correzione Automatica"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Una nuova versione di Zettlr è disponibile per il download. Si prega di "
+"leggere il changelog sottostante."
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Citazioni"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Aggiornamento in download"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Nessun aggiornamento disponibile. Hai la versione più recente."
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Importazione - Esportazione"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Clicca per iniziare l'aggiornamento"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Avanzate"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "mai"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "Ricerca di: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Gennaio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Febbraio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Marzo"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Aprile"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maggio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Giugno"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Luglio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agosto"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Settembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Ottobre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Novembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Dicembre"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Inferiore alla media mensile"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Superiore alla media mensile"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Più del doppio della media mensile"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Grafici"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "Statistiche FSAL"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Statistiche di scrittura"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Modello per gli ID Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Utilizza espressioni regolari ECMAScript"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Modello utilizzato per generare nuovi ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Variabili disponibili: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Collegamenti interni"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Collegamento solo con nome file"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "Quando colleghi i file, aggiungi il nome del documento …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Sempre"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Solo quando si collega utilizzando l'ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Mai"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Formato del collegamento"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"I collegamenti interni consentono di aggiungere un titolo facoltativo, "
-"separato da una barra verticale dall'effettiva destinazione del "
-"collegamento. Qui puoi definire l'ordine dei due."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Titolo]]: prima il Link (consigliato)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Titolo|Link]]: prima il Titolo"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Avvia una ricerca full-text quando si seguono i collegamenti interni"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-"La stringa di ricerca corrisponderà al contenuto tra le parentesi: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Crea automaticamente file inesistenti in questa cartella quando segui i "
-"collegamenti interni"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Per funzionare, la cartella deve essere aperta come Area di Lavoro "
-"(Workspace) in Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Percorso della cartella"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Virgolette intelligenti"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Virgolette"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Disabilita Virgolette intelligenti"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Virgolette Singole"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Modelli di sostituzione testo"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Abbina parole intere"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-"Se selezionata, la Correzione Automatica non sostituirà mai parti di parole"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Sostituisci"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "Con"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Filtro"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Modalità di input dell'editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"La modalità di input determina il modo in cui interagisci con l'editor. Si "
-"consiglia di mantenere questa impostazione su \"Normale\". Scegli \"Vim\" o "
-"\"Emacs\" solo se sai cosa implica."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Direzione di scrittura"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Interpreta il Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Selezionare per formattare in tempo reale gli elementi di Markdown. Ciò "
-"nasconde i caratteri di formattazione (come **testo**) o esegue il rendering "
-"delle immagini invece di mostrarne il collegamento."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Nascondi i cancelletti dalle intestazioni"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Interpreta le enfasi (bold, italic)"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Controlla problemi di stile del Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Editor delle Tabelle"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"L'editor di tabelle è un'interfaccia interattiva che semplifica la creazione "
-"e la modifica delle tabelle. Fornisce pulsanti per funzionalità comuni e si "
-"occupa della formattazione Markdown."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "In modalità Senza-Distrazioni disattiva le righe non selezionate"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Contatore parole"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Conta i caratteri invece che le parole (ad es., per Cinese)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Modalità di leggibilità"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algoritmo"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Larghezza massima delle immagini (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Altezza massima delle immagini (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Altre impostazioni"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Dimensione del testo"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Dimensione del rientro (numero di spazi)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Rientra usando le tabulazioni invece degli spazi"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Evidenzia gli spazi bianchi"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Suggerisci emoji durante il completamento automatico"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Mostra anteprime dei collegamenti"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Chiudi automaticamente le coppie di caratteri corrispondenti"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Orario"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Off"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Segui il Sistema Operativo"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "On"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Fine"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Tema"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Opzioni della barra strumenti"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Barra di stato"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Apri editor CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Severità"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Standard"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Pignolo"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Lingua madre"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Non impostato"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Varianti preferite"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool non è in grado di distinguere le varianti di alcune lingue. "
-"Queste impostazioni spingeranno LanguageTool a rilevare automaticamente la "
-"tua variante preferita di queste lingue."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Interpreta inglese come"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Interpreta tedesco come"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Interpreta portoghese come"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Interpreta catalano come"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Fornitore di LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Server personalizzato"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Indirizzo del server personalizzato"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr ignorerà le impostazioni del \"Provider di LanguageTool\" se "
-"inserisci delle credenziali qui."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool Nome Utente"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool chiave API"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Attivo"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Lingua"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Seleziona le lingue per cui vuoi attivare il controllo ortografico "
-"automatico."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Dizionario Utente. Rimuovi le parole cliccando su di esse."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Voce del dizionario"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Ricerca voci …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Modalità display"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Sottile"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Allargata"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Combinata"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"La modalità \"Sottile\" mostra le directory e i file separatamente. "
-"Selezionare una directory per visualizzarne il contenuto nell'elenco dei "
-"file. Passa dall'elenco dei file all'albero delle directory facendo clic "
-"sulle directory o sul pulsante freccia che appare nell'angolo in alto a "
-"sinistra dell'elenco dei file."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Mostra le informazioni dei file"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Mostra le cartelle sopra i file"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Visualizza nome del documento Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Solo nome del file"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Titolo se disponibile"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Prima intestazione di livello 1, se disponibile"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Titolo o prima intestazione di livello 1, se disponibile"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Visualizza le estensioni dei file Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Visualizzazione Orologio"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Data dell'ultima modifica"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Data di creazione"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Ordinamento"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Quando si ordinano i documenti…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Usa ordine naturale (il 2 prima di 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Usa ordine ASCII (il 2 dopo il 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Importazione ed esportazione profili"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Apri l'editor dei profili di importazione"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Apri l'editor dei profili di esportazione"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Impostazioni di esportazione"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Usa il Pandoc interno di Zettlr per le esportazioni"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Rimuovi i tag dai file nell'esportazione"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Rimuovi completamente i collegamenti interni"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Scollega i collegamenti interni"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Non toccare i collegamenti interni"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Cartella di destinazione per i file esportati"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Cartella temporanea"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Come il percorso del file"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Chiedi la cartella per l'esportazione"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Attenzione! I file nella cartella temporanea vengono regolarmente eliminati. "
-"Scegliendo la stessa posizione del file, i file con nomi identici verranno "
-"sovrascritti se già esistenti."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Comandi di esportazione personalizzati"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Nome visualizzato"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Comando"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Inserisci i comandi personalizzati con cui eseguire l'esportatore. Ogni "
-"comando riceve come primo argomento il file o la cartella del progetto da "
-"esportare."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Modello nomi per nuovi file"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Definire modello nomi per i nuovi file"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Variabili disponibili: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Non chiedere un nome quando si crea un nuovo file"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Usa l'aspetto di default per le finestre"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-"Disponibile solo su Linux; è l'impostazione predefinita per macOS e Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Abilita finestra dinamica"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Disponibile solo su macOS; rende opaco lo sfondo della finestra."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Mostra l'app nella barra delle notifiche"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Lascia l'app in esecuzione nella barra delle notifiche"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportamento Zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Ridimensiona l'intera GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Modifica la dimensione del testo nell'editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Barra laterale Allegati"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "Estensioni dei file visibili nella barra laterale Allegati"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Whitelist er il rendering degli iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nome host"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Sorveglianza watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Tempo di attesa entro il quale si considera terminata la scrittura di un "
-"file (in ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Eliminazione elementi"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Modalità di debug"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Attiva la modalità di debug"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Rilasci di versioni beta"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Segnalami il rilascio di versioni beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Apri l'editor degli snippet"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Lingua dell'applicazione"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Autosalvataggio"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Salva modifiche"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Immediatamente"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Dopo un breve ritardo"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Cartella immagini predefinita"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Fare clic su \"Seleziona cartella…\" o digita un percorso assoluto o "
-"relativo nel campo di immissione."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Comportamento"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Evita di aprire file in nuove schede, se possibile"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Aggiornamenti"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Controlla automaticamente gli aggiornamenti"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Come vuoi l'auto-completamento per inserire le tue citazioni?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Percorso del file"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+msgid "Last checked: %s"
+msgstr "Ultimo controllo: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Inizio aggiornamento …"
 
 #~ msgid "Open Link"
 #~ msgstr "Apri Link"

--- a/static/lang/ja-JP.po
+++ b/static/lang/ja-JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 3.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2023-09-05 22:51+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "参考文献データベースを読み込めませんでした"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "ライブラリ ファイルの更新が検出されました。再読み込み中です…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "%s ワークスペースを読み込んでいます"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,147 +82,6 @@ msgstr "オプション%sは%s文字以上である必要があります。"
 msgid "Option %s is required."
 msgstr "オプション%sは必須です。"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Zettlrを表示する"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "終了"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "バージョン%sへのアップデートが利用可能です！"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"アップデートの確認ができませんでした：サーバ エラー(ステータス コード：%s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"アップデートの確認ができませんでした：クライアント エラー(ステータス コード："
-"%s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"アップデートの確認ができませんでした：サーバーがリダイレクトしようとしました"
-"(ステータス コード：%s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "アップデートの確認ができませんでした：接続の確立に失敗しました"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "アップデートを確認できませんでした。%s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"アップデートの確認ができませんでした：サーバからデータを受信できませんでした"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "ドキュメントが長すぎます"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "オフライン"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "ファイルを作成できません"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "キー%sの参照には添付ファイルがないようです。"
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr ""
-"添付ファイルを開けませんでした。Zoteroが起動していることを確認してください。"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -226,24 +99,98 @@ msgstr "はい"
 msgid "No"
 msgstr "いいえ"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, fuzzy, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "タグ \"%s\" を \"%s\" に置き換えますか？ 対象：%s ファイル"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "キャンセル"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "本当に削除しますか？"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "本当に%sを削除してもよろしいですか？"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "キー%sの参照には添付ファイルがないようです。"
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr ""
+"添付ファイルを開けませんでした。Zoteroが起動していることを確認してください。"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "不正な形式のTextbundleです：%s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "プロジェクトをエクスポートできません"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, fuzzy, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "プロジェクトは正常にエクスポートされました。クリックして表示します。"
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Export"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -298,47 +245,6 @@ msgstr "次の%sファイルはファイル種別が不明なためインポー�
 msgid "Import failed"
 msgstr "エクスポート失敗"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "プロジェクトをエクスポートできません"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, fuzzy, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "プロジェクトは正常にエクスポートされました。クリックして表示します。"
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Export"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "ディレクトリを移動できません"
@@ -356,28 +262,49 @@ msgstr "ディレクトリまたはファイルを移動できません"
 msgid "The file/directory %s already exists in target."
 msgstr "%s という名称のファイルまたはディレクトリは既に存在します。"
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "無題"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "提供された名前は使用可能な文字を含んでいません。"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "ディレクトリを作成できませんでした"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "要求されたディレクトリが見つかりません。"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "本当に削除しますか？"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "エクスポート失敗"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "エクスポート中にエラーが発生しました：%s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "保存先を選択"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "保存"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "本当に%sを削除してもよろしいですか？"
+msgid "Exporting to %s"
+msgstr "%sにエクスポートします"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "エクスポート中にエラーが発生しました：%s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -402,11 +329,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "%s をコピー"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "ドキュメントが長すぎます"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "オフライン"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -419,125 +348,34 @@ msgstr "言語ファイルがインポートされました：%s"
 msgid "Could not import language file %s!"
 msgstr "言語ファイル%sをインポートできませんでした。"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "エクスポート失敗"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "ファイルを作成できません"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
+#, javascript-format
+msgid "Copy of %s"
+msgstr "%s をコピー"
+
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "無題"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "ディレクトリを作成できませんでした"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "エクスポート中にエラーが発生しました：%s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "保存先を選択"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "保存"
-
-#: source/app/service-providers/commands/export.ts:145
-#, javascript-format
-msgid "Exporting to %s"
-msgstr "%sにエクスポートします"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "エクスポート中にエラーが発生しました：%s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "提供された名前は使用可能な文字を含んでいません。"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "要求されたディレクトリが見つかりません。"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "不正な形式のTextbundleです：%s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "現在のファイルに対する外部での変更を常に読み込む"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "既存のファイルを上書き"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "%s はディレクトリに既に存在します。上書きしますか？"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "ファイルを開く"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "未保存の変更"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "現在のファイルには未保存の変更があります。閉じる前に保存しますか？"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "ファイルを保存"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "プロジェクトフォルダを開く"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "参考文献データベースを読み込めませんでした"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "ライブラリ ファイルの更新が検出されました。再読み込み中です…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "タグ \"%s\" を \"%s\" に置き換えますか？ 対象：%s ファイル"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -649,6 +487,12 @@ msgstr "ファイル名を変更"
 msgid "Delete file"
 msgstr "ファイルを削除"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "終了"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -667,15 +511,15 @@ msgstr "やり直し"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "切り取り"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "コピー"
 
@@ -687,8 +531,8 @@ msgstr "HTMLとしてコピー"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "貼り付け"
 
@@ -700,8 +544,8 @@ msgstr "プレーンテキストとして貼り付け"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "すべて選択"
 
@@ -947,10 +791,166 @@ msgstr "読み上げ停止"
 msgid "Bring All to Front"
 msgstr "すべて前面に移動"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "%s ワークスペースを読み込んでいます"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "プロジェクトフォルダを開く"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "現在のファイルに対する外部での変更を常に読み込む"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "未保存の変更"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "現在のファイルには未保存の変更があります。閉じる前に保存しますか？"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "ファイルを開く"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "ファイルを保存"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "既存のファイルを上書き"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "%s はディレクトリに既に存在します。上書きしますか？"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Zettlrを表示する"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "バージョン%sへのアップデートが利用可能です！"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"アップデートの確認ができませんでした：サーバ エラー(ステータス コード：%s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"アップデートの確認ができませんでした：クライアント エラー(ステータス コード："
+"%s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"アップデートの確認ができませんでした：サーバーがリダイレクトしようとしました"
+"(ステータス コード：%s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "アップデートの確認ができませんでした：接続の確立に失敗しました"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "アップデートを確認できませんでした。%s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"アップデートの確認ができませんでした：サーバからデータを受信できませんでした"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -967,142 +967,1200 @@ msgstr "未保存の変更"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "現在のファイルには未保存の変更があります。閉じる前に保存しますか？"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "ファイルマネージャーモード"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "オートコレクトを有効化"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "プロパティ"
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "マジッククォートを無効にする"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "ファイルを複製"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "マジッククォートを無効にする"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "フルパスをコピー"
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "マジッククォートを無効にする"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "ファイル名をコピー"
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "単語全体と一致する"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "チェックすると、オートコレクトは単語の一部を置換しません"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "置き換え後"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "フィルタ…"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "スケジュール"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "オフ"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "OSの設定に従う"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "開始"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "ステータスバーを表示する"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "カスタムCSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "ディレクトリを開く"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "%sにエクスポートします"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "内蔵のPandocを使用してエクスポートする"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "ファイルからタグを取り除く"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "内部リンクをリンク解除する"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "すべての内部リンクを取り除く"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "内部リンクをリンク解除する"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "内部リンクを保持する"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "ファイル情報を表示"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "表示名"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "コマンド"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"エクスポーターを実行するカスタム コマンドを入力します。 各コマンドは、最初の"
+"引数として、エクスポートするファイルまたはプロジェクトフォルダーを受け取りま"
+"す。"
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "新規ファイル名のパターン"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "新規ファイル名のパターン"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "新規ファイル作成時にファイル名を確認しない"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "ネイティブのウィンドウ外観を使用する"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "ウィンドウのVibrancyを有効化"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "通知領域にアプリケーションを表示する"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "通知領域にアプリケーションを残す"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "ズーム操作"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "ズームでGUI全体の拡大率を変更する"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "ズームでエディタのフォントサイズを変更する"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "iframe描画ホワイトリスト"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "ホスト名"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "ウォッチドッグ監視を有効化する"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "ファイルの書き込みが完了したとみなせるまでの待機時間（ミリ秒）"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "ファイルを削除"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "デバッグ モードを有効化"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "デバッグ モードを有効化"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "ベータ版のリリースを通知する"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "エディタ入力モード"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "ディレクトリを検索"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "見出し文字を隠す"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "強調を表示"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "太字"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "斜体"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Markdown記法の問題をチェック"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "テーブルエディタを有効化"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "集中モード時にフォーカスされていない行の表示を薄くする"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "単語数"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "単語の代わりに文字を数える"
+
+#: source/win-preferences/schema/editor.ts:195
+#, fuzzy
+msgid "Readability mode"
+msgstr "可読性モード (%s)"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "画像"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "画像の最大幅（パーセント）"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "画像の最大高さ（パーセント）"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "その他のファイル"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "エディタのフォントサイズ"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "インデントに使用する空白の数"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "インデントにタブ文字を使用"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "補完中に空白を受け付ける"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "リンク先のプレビューを表示する"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "対応する括弧を自動的に入力する"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "表示名"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "ファイル情報を表示"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "フォルダをファイルより上に表示する"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "ファイル名のみ"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "タイトル(存在する場合)"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "最初のレベル1の見出し(存在する場合)"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "タイトルまたは最初のレベル1の見出し(存在する場合)"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Markdownファイルの拡張子を表示する"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "最終更新日時"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "ファイル作成日時"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exporting…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "最近使ったドキュメント"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "数値順(2→10の順番)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII順(10→2の順番)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "引用を表示"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "オートコンプリートで引用を挿入する方法を選択してください"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "ファイルに追加"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "新規IDを生成するためのパターン"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "IDの正規表現"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "新規IDを生成するためのパターン"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "ファイル名のみ"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "ファイルをリンクする際にファイル名を追加するかどうか"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "常にする"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "IDを使ってリンクした場合のみ"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "常にしない"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Zettelkastenリンクで検索を開始できるようにする"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "内部リンクを開く際にファイルが存在しなければ自動的に作成する"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+#, fuzzy
+msgid "LanguageTool"
+msgstr "LanguageToolを使用する"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "厳密性"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "通常"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+#, fuzzy
+msgid "Picky"
+msgstr "より厳密"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+#, fuzzy
+msgid "Mother language"
+msgstr "母国語"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "設定しない"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageToolプロバイダー"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "カスタムサーバー"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "カスタムサーバー"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+#, fuzzy
+msgid "LanguageTool Premium"
+msgstr "LanguageToolプロバイダー"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool ユーザー名"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool APIキー"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "有効"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Language"
+msgstr "言語コード"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "コード"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "自動スペルチェックを有効にする言語を選択。"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "ユーザ辞書。クリックで単語を削除します。"
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "辞書エントリ"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "エントリーを検索…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "アプリケーション言語"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "自動保存"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "最終更新日時"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "即時"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "遅延有り"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "ズーム操作"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "ファイルを新しいタブで開くことを可能な限り避ける"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "アップデート"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "更新を自動的にチェックする"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s文字"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s単語"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "脚注参照に移動"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "ハイライトなし"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "診断パネルを開く"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "無効"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "カスタム"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "自動検出"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Mermaidをレンダリング中 …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "レンダリングできませんでした。"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "可読性モード (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "画像が見つかりません: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "スペルミス"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "ファイル %s は存在しません。"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "単語数"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "更新日時"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "開く…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "新しいタブで開く"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "リンク"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "画像"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "コメント"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "脚注テキストが見つかりません。"
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "数式をコピー"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "画像をクリップボードにコピー"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "ファイルを開く"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Finderで表示"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "エクスプローラーで表示"
-
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
 msgstr "File Browserで表示"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "ファイルを閉じる"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "候補はありません"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "ディレクトリ名を変更"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "辞書に追加"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "ディレクトリを削除"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "斜体"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "ディレクトリをチェック…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "リンクを挿入"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "プロジェクトをエクスポート"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "箇条書きリストを挿入"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "番号付きリストを挿入"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "他のタブを閉じる"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "すべてのタブを閉じる"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "タブ固定を解除"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "タブを固定"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl キーを押しながらクリックして、このリンクをたどります"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1511,326 +2569,320 @@ msgstr "中国語 (繁体字)"
 msgid "Chinese"
 msgstr "中国語"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "自動検出"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "無効"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "カスタム"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s単語"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s文字"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "診断パネルを開く"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "スペルミス"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "脚注参照に移動"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "プロパティ"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "ファイルを複製"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "太字"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "フルパスをコピー"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "斜体"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "ファイル名をコピー"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "リンク"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "エクスプローラーで表示"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "画像"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "コメント"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "コード"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "脚注テキストが見つかりません。"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "ファイル %s は存在しません。"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "単語数"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "更新日時"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "開く…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "新しいタブで開く"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "ハイライトなし"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "画像をクリップボードにコピー"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "ファイルを開く"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr "File Browserで表示"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "候補はありません"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "ファイルを閉じる"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "辞書に追加"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "ディレクトリ名を変更"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "斜体"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "ディレクトリを削除"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "リンクを挿入"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "ディレクトリをチェック…"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "箇条書きリストを挿入"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "プロジェクトをエクスポート"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "番号付きリストを挿入"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "他のタブを閉じる"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "すべてのタブを閉じる"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "タブ固定を解除"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "タブを固定"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "カレンダー"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "図"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "数式をコピー"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "1月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "2月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "3月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "4月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "5月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "6月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "7月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "8月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "9月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "10月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "11月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "12月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "月平均未満"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "月平均以上"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "月平均の2倍以上"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
+msgid ""
+"Some files are selected for export but no longer exist in the directory."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Readability mode (%s)"
-msgstr "可読性モード (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "画像が見つかりません: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Mermaidをレンダリング中 …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "検索"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "リセット"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
 #, fuzzy
-msgid "Could not render Graph:"
-msgstr "レンダリングできませんでした。"
+msgid "Select folder…"
+msgstr "プロジェクトフォルダを開く"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl キーを押しながらクリックして、このリンクをたどります"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "ファイルを削除"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "アップデート"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "追加"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "新しいバージョンが利用可能です"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "アクション"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "現在のバージョン"
-
-#: source/tmp/win-update/App.vue.ts:34
-msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"新しいバージョンのZettlrがダウンロード可能です。以下の更新履歴を確認してくだ"
-"さい。"
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "更新をダウンロード中"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "アップデートはありません。最新バージョンを利用中です。"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "アップデートを開始する"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
-#, javascript-format
-msgid "Last checked: %s"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "アップデートを開始…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "カウント"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "タグを絞り込む…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "削除"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "画像"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1847,10 +2899,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1917,46 +2965,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlrは以下のプロジェクトを利用しています："
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"ここで、Zettlrのスタイルをオーバーライドすることで、さらにカスタマイズを行う"
-"ことができます。<strong>注意：このファイルはすべてのCSSディレクティブをオー"
-"バーライドします。アプリケーションが予期せぬ動作をする可能性があるため、要素"
-"の形状を変更しないでください。</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "スニペット名の変更"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"スニペットを利用すると、変数を利用して再利用可能な文字列を定義することができ"
+"ます。"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "保存中…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "保存できませんでした"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "カスタムCSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "保存しました。"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1982,41 +3014,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "インポートまたはエクスポートのデフォルト設定を変更できます。"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "保存しました。"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "スニペット名の変更"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-"スニペットを利用すると、変数を利用して再利用可能な文字列を定義することができ"
-"ます。"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "単語"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "文字"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"ここで、Zettlrのスタイルをオーバーライドすることで、さらにカスタマイズを行う"
+"ことができます。<strong>注意：このファイルはすべてのCSSディレクティブをオー"
+"バーライドします。アプリケーションが予期せぬ動作をする可能性があるため、要素"
+"の形状を変更しないでください。</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "開いているドキュメントはありません"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "保存できませんでした"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "開始"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "カウント"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "タグを絞り込む…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2042,76 +3111,115 @@ msgstr "効果音"
 msgid "Volume"
 msgstr "ボリューム"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "単語(直近1カ月)"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "関連ファイル"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "一日当たりの平均値"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "関連ファイルがありません"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "単語(本日)"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "このリレーションは双方向リンクです。"
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥燃えてますね！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "このリレーションはアウトバウンドリンクです。"
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪もう少しで一日当たりの平均値に到達します！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "このリレーションはバックリンクです。"
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼一日当たりの平均値を超えました。"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "統計情報の詳細…"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "このリレーションは%s個のタグを共有しています：%s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "その他のファイル"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "ディレクトリを開く"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "その他のファイルはありません"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "参考文献"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "このドキュメントには参考文献が存在しません。"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "名称"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "タグ クラウド"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Exporting…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Export"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "コマンド"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2121,8 +3229,8 @@ msgstr "ディレクトリ"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "ファイル"
 
@@ -2136,10 +3244,26 @@ msgstr "文字"
 msgid "Words"
 msgstr "単語"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "ワークスペース"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "開いているファイルまたはディレクトリはありません"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "検索結果なし"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "ディレクトリが選択されていません"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "空のディレクトリ"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2169,15 +3293,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "リセット"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2238,13 +3353,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "カレンダー"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2454,131 +3562,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "執筆目標を設定…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "検索結果なし"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "ディレクトリが選択されていません"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "空のディレクトリ"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "ワークスペース"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "開いているファイルまたはディレクトリはありません"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "単語(直近1カ月)"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "一日当たりの平均値"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "単語(本日)"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥燃えてますね！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪もう少しで一日当たりの平均値に到達します！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼一日当たりの平均値を超えました。"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "統計情報の詳細…"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Exporting…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Export"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "コマンド"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2600,11 +3587,6 @@ msgstr "検索対象のディレクトリ"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "検索"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "検索をクリア"
@@ -2618,1113 +3600,137 @@ msgstr "結果を切り替え"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "名称"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "タグ クラウド"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "単語"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "文字"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "開いているドキュメントはありません"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "関連ファイル"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "関連ファイルがありません"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "このリレーションは双方向リンクです。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "このリレーションはアウトバウンドリンクです。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "このリレーションはバックリンクです。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "追加"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "アクション"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "削除"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "プロジェクトフォルダを開く"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "ファイルを削除"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "オートコレクトを有効化"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "引用を表示"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "1月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "2月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "3月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "4月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "5月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "6月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "7月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "8月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "9月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "10月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "11月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "12月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "月平均未満"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "月平均以上"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "月平均の2倍以上"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "図"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "新規IDを生成するためのパターン"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "IDの正規表現"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "新規IDを生成するためのパターン"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "内部リンクをリンク解除する"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "ファイル名のみ"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "ファイルをリンクする際にファイル名を追加するかどうか"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "常にする"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "IDを使ってリンクした場合のみ"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "常にしない"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Zettelkastenリンクで検索を開始できるようにする"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "内部リンクを開く際にファイルが存在しなければ自動的に作成する"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "マジッククォートを無効にする"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "マジッククォートを無効にする"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "マジッククォートを無効にする"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "単語全体と一致する"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "チェックすると、オートコレクトは単語の一部を置換しません"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "置き換え後"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "フィルタ…"
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "エディタ入力モード"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "ディレクトリを検索"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "見出し文字を隠す"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "強調を表示"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Markdown記法の問題をチェック"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "テーブルエディタを有効化"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "集中モード時にフォーカスされていない行の表示を薄くする"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "単語数"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "単語の代わりに文字を数える"
-
-#: source/win-preferences/schema/editor.ts:195
-#, fuzzy
-msgid "Readability mode"
-msgstr "可読性モード (%s)"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "画像の最大幅（パーセント）"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "画像の最大高さ（パーセント）"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "このリレーションは%s個のタグを共有しています：%s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "その他のファイル"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "エディタのフォントサイズ"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "インデントに使用する空白の数"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "インデントにタブ文字を使用"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "補完中に空白を受け付ける"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "リンク先のプレビューを表示する"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "対応する括弧を自動的に入力する"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "スケジュール"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "オフ"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "OSの設定に従う"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "ステータスバーを表示する"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "ディレクトリを開く"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-#, fuzzy
-msgid "LanguageTool"
-msgstr "LanguageToolを使用する"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "その他のファイルはありません"
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "厳密性"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "通常"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-#, fuzzy
-msgid "Picky"
-msgstr "より厳密"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-#, fuzzy
-msgid "Mother language"
-msgstr "母国語"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "設定しない"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "参考文献"
 
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "このドキュメントには参考文献が存在しません。"
 
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageToolプロバイダー"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "カスタムサーバー"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "カスタムサーバー"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-#, fuzzy
-msgid "LanguageTool Premium"
-msgstr "LanguageToolプロバイダー"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool ユーザー名"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool APIキー"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "有効"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Language"
-msgstr "言語コード"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "自動スペルチェックを有効にする言語を選択。"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "ユーザ辞書。クリックで単語を削除します。"
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "辞書エントリ"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "エントリーを検索…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "表示名"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "ファイル情報を表示"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "フォルダをファイルより上に表示する"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "ファイル名のみ"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "タイトル(存在する場合)"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "最初のレベル1の見出し(存在する場合)"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "タイトルまたは最初のレベル1の見出し(存在する場合)"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Markdownファイルの拡張子を表示する"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "最終更新日時"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "ファイル作成日時"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exporting…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "最近使ったドキュメント"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "数値順(2→10の順番)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII順(10→2の順番)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "%sにエクスポートします"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "内蔵のPandocを使用してエクスポートする"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "ファイルからタグを取り除く"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "すべての内部リンクを取り除く"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "内部リンクをリンク解除する"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "内部リンクを保持する"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "ファイル情報を表示"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "表示名"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "コマンド"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"エクスポーターを実行するカスタム コマンドを入力します。 各コマンドは、最初の"
-"引数として、エクスポートするファイルまたはプロジェクトフォルダーを受け取りま"
-"す。"
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "新規ファイル名のパターン"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "新規ファイル名のパターン"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "新規ファイル作成時にファイル名を確認しない"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "ネイティブのウィンドウ外観を使用する"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "ウィンドウのVibrancyを有効化"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "通知領域にアプリケーションを表示する"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "通知領域にアプリケーションを残す"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "ズーム操作"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "ズームでGUI全体の拡大率を変更する"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "ズームでエディタのフォントサイズを変更する"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "iframe描画ホワイトリスト"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "ホスト名"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "ウォッチドッグ監視を有効化する"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "ファイルの書き込みが完了したとみなせるまでの待機時間（ミリ秒）"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "ファイルを削除"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "デバッグ モードを有効化"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "デバッグ モードを有効化"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "ベータ版のリリースを通知する"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "アプリケーション言語"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "自動保存"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "最終更新日時"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "即時"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "遅延有り"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "ズーム操作"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "ファイルを新しいタブで開くことを可能な限り避ける"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "アップデート"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "更新を自動的にチェックする"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "新しいバージョンが利用可能です"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "オートコンプリートで引用を挿入する方法を選択してください"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "現在のバージョン"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"新しいバージョンのZettlrがダウンロード可能です。以下の更新履歴を確認してくだ"
+"さい。"
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "更新をダウンロード中"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "アップデートはありません。最新バージョンを利用中です。"
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "アップデートを開始する"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "ファイルに追加"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "アップデートを開始…"
 
 #~ msgid "Open Link"
 #~ msgstr "リンクを開く"

--- a/static/lang/ko-KO.po
+++ b/static/lang/ko-KO.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "인용 데이터베이스를 불러올 수 없습니다"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "라이브러리 파일이 변경되었습니다. 다시 읽는 중 ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "워크스페이스"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,143 +81,6 @@ msgstr "%s 옵션은 %s (문자 길이) 이상이어야 합니다."
 msgid "Option %s is required."
 msgstr "%s 옵션이 필요합니다."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Zettlr 보기"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "종료"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "업데이트를 확인할 수 없습니다: 서버 오류 (상태 코드 : %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "업데이트를 확인할 수 없습니다: 클라이언트 오류 (상태 코드 : %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"업데이트를 확인할 수 없습니다: 서버가 리다이렉트를 시도했습니다 (상태 코드 : "
-"%s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "업데이트를 확인할 수 없습니다: 연결할 수 없습니다."
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"업데이트를 확인할 수 없습니다: 서버에서 아무런 데이터를 보내지 않습니다."
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "파일을 생성할 수 없습니다"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "%s 키를 가진 레퍼런스는 첨부파일이 없는 것으로 보입니다."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "첨부파일을 열 수 없습니다. 혹시 Zotero 가 실행 중입니까?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -221,24 +98,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "확인"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "취소"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "정말 삭제 하시겠습니까?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "%s 정말 삭제 하시겠습니까?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "%s 키를 가진 레퍼런스는 첨부파일이 없는 것으로 보입니다."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "첨부파일을 열 수 없습니다. 혹시 Zotero 가 실행 중입니까?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "올바르지 않은 Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "프로젝트 내보내기"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "내보내기..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -293,48 +244,6 @@ msgstr "파일 유형을 알 수 없기 때문에 파일을 가져올 수 없습
 msgid "Import failed"
 msgstr "내보내기 실패"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "프로젝트 내보내기"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "확인"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "내보내기..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "디렉토리를 이동할 수 없습니다."
@@ -352,28 +261,49 @@ msgstr "디렉토리 또는 파일을 이동할 수 없습니다."
 msgid "The file/directory %s already exists in target."
 msgstr "파일/디렉토리 %s 가 이미 목적지 안에 존재합니다."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Untitled"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "제공된 이름에는 허용된 문자가 없습니다."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "디렉토리를 생성할 수 없습니다"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "요청한 디렉토리를 찾을 수 없습니다."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "정말 삭제 하시겠습니까?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "내보내기 실패"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "내보내기 중 오류 발생: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "저장"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "%s 정말 삭제 하시겠습니까?"
+msgid "Exporting to %s"
+msgstr "%s 로 내보내는 중"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "내보내기 중 오류 발생: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -398,10 +328,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -415,128 +347,34 @@ msgstr "가져온 언어 파일: %s"
 msgid "Could not import language file %s!"
 msgstr "%s 언어 파일을 가져올 수 없습니다!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "내보내기 실패"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "파일을 생성할 수 없습니다"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "내보내기 중 오류 발생: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "저장"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "%s 로 내보내는 중"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Untitled"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "디렉토리를 생성할 수 없습니다"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "내보내기 중 오류 발생: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "제공된 이름에는 허용된 문자가 없습니다."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "요청한 디렉토리를 찾을 수 없습니다."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "올바르지 않은 Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "현재 파일의 외부 수정을 항상 반영"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "기존 파일 덮어쓰기"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "%s 파일이 이미 이 디렉토리에 있습니다. 덮어 쓰시겠습니까?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "파일 열기"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"현재 파일에 저장하지 않은 변경 사항이 있습니다. 변경 사항을 생략하거나 아니"
-"면 저장할까요?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "프로젝트 폴더 열기"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "인용 데이터베이스를 불러올 수 없습니다"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "라이브러리 파일이 변경되었습니다. 다시 읽는 중 ..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -648,6 +486,12 @@ msgstr "파일 이름 변경"
 msgid "Delete file"
 msgstr "파일 삭제"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "종료"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -666,15 +510,15 @@ msgstr "다시 실행"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "자르기"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "복사"
 
@@ -686,8 +530,8 @@ msgstr "HTML로 복사"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "붙이기"
 
@@ -699,8 +543,8 @@ msgstr "스타일없이 붙이기"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "모두 선택"
 
@@ -942,10 +786,166 @@ msgstr "말하기 중지"
 msgid "Bring All to Front"
 msgstr "모두 앞으로 가져오기"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "워크스페이스"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "프로젝트 폴더 열기"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "현재 파일의 외부 수정을 항상 반영"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"현재 파일에 저장하지 않은 변경 사항이 있습니다. 변경 사항을 생략하거나 아니"
+"면 저장할까요?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "파일 열기"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "기존 파일 덮어쓰기"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "%s 파일이 이미 이 디렉토리에 있습니다. 덮어 쓰시겠습니까?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Zettlr 보기"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "업데이트를 확인할 수 없습니다: 서버 오류 (상태 코드 : %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "업데이트를 확인할 수 없습니다: 클라이언트 오류 (상태 코드 : %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"업데이트를 확인할 수 없습니다: 서버가 리다이렉트를 시도했습니다 (상태 코드 : "
+"%s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "업데이트를 확인할 수 없습니다: 연결할 수 없습니다."
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"업데이트를 확인할 수 없습니다: 서버에서 아무런 데이터를 보내지 않습니다."
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -964,143 +964,1186 @@ msgstr ""
 "현재 파일에 저장하지 않은 변경 사항이 있습니다. 변경 사항을 생략하거나 아니"
 "면 저장할까요?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "파일 관리자 모드"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "자동 수정 켜기"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "속성"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "파일 복제"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "ID 복사"
+msgid "Double Quotes"
+msgstr "없음"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "파일 이름 복사"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "없음"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "없음"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "파일 바꾸기"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "필터 태그..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "일정"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "끄기"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "운영체제를 따름"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "시작"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Zettlr 보기"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "커스텀 CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "디렉토리 열기"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "%s 로 내보내는 중"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "내보내기에 내장 Pandoc 사용"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "파일에서 태그 제거"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "내부 링크 연결 해제"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "내부 링크를 완전히 제거"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "내부 링크 연결 해제"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "내부 링크를 수정하지 않음"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "파일 정보 표시"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "주석"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "새 파일 이름 패턴"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "새 파일 이름 패턴"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "새 파일을 만들 때 파일 이름을 물어보지 않음"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "기본 창 모양 사용"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "기본 창 모양 사용"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "편집기 폰트 크기"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "와치독 폴링 활성화"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "파일 쓰기가 완료된 것으로 간주하기 전에 대기할 시간 (밀리초)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "파일 삭제"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "디버그 모드 활성화"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "디버그 모드 활성화"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "베타 출시를 알림"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "편집기 입력 모드"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "디렉토리 안에서 찾기..."
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "헤딩(heading) 문자 숨기기"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "굵게"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "이탤릭체"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "테이블 편집기 사용"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "집중 모드에서 포커스를 가지지 않은 라인 감추기"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "단어 대신 문자 세기 (예 : 중국어)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "그림"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "이미지의 가로 최대 크기(퍼센트)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "이미지의 세로 최대 크기(퍼센트)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "편집기 폰트 크기"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "다음 공백만큼 들여쓰기"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "다음 공백만큼 들여쓰기"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "자동완성 중에 공백 허용"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "일치하는 문자 쌍 자동으로 닫기"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "다크 모드"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "파일 정보 표시"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "마크다운 파일의 확장자를 표시"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "마지막 수정 시간"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "파일이 만들어진 시간"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "내보내기..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "최근 문서"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "일반적인 순서 (2 다음에 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII 순서(2가 10 다음에 옴)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "인용(Citation) 보이기"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "인용이 자동 완성되는 방식을 선택할 수 있습니다."
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "파일 보기"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "새로운 ID를 생성하는데 사용할 패턴"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID 정규표현식"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "새로운 ID를 생성하는데 사용할 패턴"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "파일을 연결할 때, 파일 이름 추가…"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "항상"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "ID를 사용하여 연결하는 경우에만"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "안함"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "제텔카스텐 링크를 따라갈 때 검색 시작"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "내부 링크를 따라갈 때 존재하지 않는 파일을 자동으로 생성"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "커스텀 CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "커스텀 CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "코드"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "자동 맞춤법 ​​검사를 활성화할 언어를 선택하십시오."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "사용자 사전. 단어를 클릭하여 제거할 수 있습니다."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "자동 저장"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "마지막 수정 시간"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "즉시"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "잠시 쉴 때"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "가능하면 파일을 새로운 탭으로 열지 않기"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "자동으로 업데이트를 확인"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s 단어"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "커스텀 CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "파일을 생성할 수 없습니다"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "열기..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "새 탭에서 열기"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "링크"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "그림"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "주석"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "이미지를 클립 보드에 복사"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "파일 열기"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "브라우저에서 열기"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "제안 없음"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "사전 추가"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "이탤릭체"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "링크 삽입"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "순서 없는 목록 삽입"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "숫자 목록 삽입"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "파일 닫기"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "디렉토리 이름 변경"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "디렉토리 삭제"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "디렉토리 검사..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "프로젝트 내보내기"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "모든 탭 닫기"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,326 +2575,322 @@ msgstr "Chinese (China)"
 msgid "Chinese"
 msgstr "Chinese (China)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "속성"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "파일 복제"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "커스텀 CSS"
+msgid "Copy path"
+msgstr "ID 복사"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s 단어"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "파일 이름 복사"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "파일 닫기"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "디렉토리 이름 변경"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "디렉토리 삭제"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "디렉토리 검사..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "프로젝트 내보내기"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "모든 탭 닫기"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "굵게"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "이탤릭체"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "링크"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "그림"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "주석"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "코드"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "열기..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "새 탭에서 열기"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "이미지를 클립 보드에 복사"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "파일 열기"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "브라우저에서 열기"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "제안 없음"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "사전 추가"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "이탤릭체"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "링크 삽입"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "순서 없는 목록 삽입"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "숫자 목록 삽입"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "파일을 생성할 수 없습니다"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "새로운 업데이트 사용 가능"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "현재 버전"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Zettlr 새 버전을 다운로드할 수 있습니다. 아래 변경 로그를 읽어 보십시오."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "필터 태그..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "프로젝트 폴더 열기"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "파일 삭제"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "파일 삭제"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "그림"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1868,10 +2907,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1933,45 +2968,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "또한 Zettlr는 다음 프로젝트를 사용합니다."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"여기에서 Zettlr의 스타일을 재정의하고 원하는데로 변경할 수 있습니다.  "
-"<strong>주의: 이 파일은 모든 CSS 지시문을 재정의합니다! 요소의 형상을 변경하"
-"지 마십시오.  그렇지 않으면 앱이 원치 않는 동작을 노출 할 수 있습니다.</"
-"strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "커스텀 CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1994,39 +3011,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "불러오기와 내보내기의 기본 설정을 변경합니다."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"여기에서 Zettlr의 스타일을 재정의하고 원하는데로 변경할 수 있습니다.  "
+"<strong>주의: 이 파일은 모든 CSS 지시문을 재정의합니다! 요소의 형상을 변경하"
+"지 마십시오.  그렇지 않으면 앱이 원치 않는 동작을 노출 할 수 있습니다.</"
+"strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "단어"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "글자"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "시작"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "필터 태그..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2052,76 +3108,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "지난 달에 작성한 단어"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "일일 평균"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "오늘 작성한 단어"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 당신은 불타고 있습니다!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 일일 평균에 거의 도달했습니다!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 일일 평균을 능가하기 위해 글을 쓰자"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "더 많은 통계 ..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "디렉토리 열기"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "레퍼런스"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "현재 문서에는 인용이 없습니다."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "태크 클라우드"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "내보내기..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "내보내기..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2131,8 +3227,8 @@ msgstr "디렉토리"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "파일"
 
@@ -2146,10 +3242,26 @@ msgstr "글자"
 msgid "Words"
 msgstr "단어"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "워크스페이스"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "열린 파일이나 디렉토리가 없음"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "결과 없음"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "선택된 디렉토리 없음"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "빈 디렉토리"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2178,15 +3290,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2247,13 +3350,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2464,131 +3560,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "쓰기 목표 설정..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "결과 없음"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "선택된 디렉토리 없음"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "빈 디렉토리"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "워크스페이스"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "열린 파일이나 디렉토리가 없음"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "지난 달에 작성한 단어"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "일일 평균"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "오늘 작성한 단어"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 당신은 불타고 있습니다!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 일일 평균에 거의 도달했습니다!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 일일 평균을 능가하기 위해 글을 쓰자"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "더 많은 통계 ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "내보내기..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "내보내기..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2611,11 +3585,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2629,1098 +3598,135 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "태크 클라우드"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "단어"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "글자"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "파일 삭제"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "프로젝트 폴더 열기"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "파일 삭제"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "자동 수정 켜기"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "인용(Citation) 보이기"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "새로운 ID를 생성하는데 사용할 패턴"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID 정규표현식"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "새로운 ID를 생성하는데 사용할 패턴"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "내부 링크 연결 해제"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "파일을 연결할 때, 파일 이름 추가…"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "항상"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "ID를 사용하여 연결하는 경우에만"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "안함"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "제텔카스텐 링크를 따라갈 때 검색 시작"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "내부 링크를 따라갈 때 존재하지 않는 파일을 자동으로 생성"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "없음"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "없음"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "없음"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "파일 바꾸기"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "필터 태그..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "편집기 입력 모드"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "디렉토리 안에서 찾기..."
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "헤딩(heading) 문자 숨기기"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "테이블 편집기 사용"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "집중 모드에서 포커스를 가지지 않은 라인 감추기"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "단어 대신 문자 세기 (예 : 중국어)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "이미지의 가로 최대 크기(퍼센트)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "이미지의 세로 최대 크기(퍼센트)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "편집기 폰트 크기"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "다음 공백만큼 들여쓰기"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "다음 공백만큼 들여쓰기"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "자동완성 중에 공백 허용"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "일치하는 문자 쌍 자동으로 닫기"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "일정"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "끄기"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "운영체제를 따름"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Zettlr 보기"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "디렉토리 열기"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "레퍼런스"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "현재 문서에는 인용이 없습니다."
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "커스텀 CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "커스텀 CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "자동 맞춤법 ​​검사를 활성화할 언어를 선택하십시오."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "사용자 사전. 단어를 클릭하여 제거할 수 있습니다."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "다크 모드"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "파일 정보 표시"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "마크다운 파일의 확장자를 표시"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "마지막 수정 시간"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "파일이 만들어진 시간"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "내보내기..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "최근 문서"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "일반적인 순서 (2 다음에 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII 순서(2가 10 다음에 옴)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "%s 로 내보내는 중"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "내보내기에 내장 Pandoc 사용"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "파일에서 태그 제거"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "내부 링크를 완전히 제거"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "내부 링크 연결 해제"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "내부 링크를 수정하지 않음"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "파일 정보 표시"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "주석"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "새 파일 이름 패턴"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "새 파일 이름 패턴"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "새 파일을 만들 때 파일 이름을 물어보지 않음"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "기본 창 모양 사용"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "기본 창 모양 사용"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "새로운 업데이트 사용 가능"
 
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "현재 버전"
 
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "편집기 폰트 크기"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "와치독 폴링 활성화"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "파일 쓰기가 완료된 것으로 간주하기 전에 대기할 시간 (밀리초)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "파일 삭제"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "디버그 모드 활성화"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "디버그 모드 활성화"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "베타 출시를 알림"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "자동 저장"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "마지막 수정 시간"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "즉시"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "잠시 쉴 때"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Zettlr 새 버전을 다운로드할 수 있습니다. 아래 변경 로그를 읽어 보십시오."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "가능하면 파일을 새로운 탭으로 열지 않기"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "자동으로 업데이트를 확인"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "인용이 자동 완성되는 방식을 선택할 수 있습니다."
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "파일 보기"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
+msgstr ""
 
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Open Link"

--- a/static/lang/nl-NL.po
+++ b/static/lang/nl-NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2022-12-29 23:16+0100\n"
 "Last-Translator: Marcel van den Brink <marcel.vandenbrink@gmail.com>\n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "De citaten database kan niet worden geladen"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Wijzigingen in het bibliotheek bestand gedetecteerd. Opnieuw laden ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Kon werkruimte %s niet openen."
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,142 +82,6 @@ msgstr "Optie %s moet minimaal %s karakters lang zijn."
 msgid "Option %s is required."
 msgstr "Optie %s is verplicht."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Toon Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Afsluiten"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Er is een update naar versie %s beschikbaar!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Kon niet controleren op nieuwe versies. Serverfout (status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Kon niet controleren op nieuwe versies. Clientfout (status code: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Kon niet controleren op nieuwe versies. De server heeft geprobeerd door te "
-"verwijzen (status code: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Kon niet controleren op updates: Kon geen verbinding maken"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Kon niet controloren op updates. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Kon niet controleren op updates: Server heeft geen data gestuurd"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Kon bestand niet aanmaken"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "De referentie met sleutel %s lijkt geen bijlagen te hebben."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Kan de bijlage niet openen. Draait Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -221,24 +99,98 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Tag “%s” vervangen door “%s” in %s bestanden?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Annuleren"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Echt verwijderen?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Wil je echt %s verwijderen?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "De referentie met sleutel %s lijkt geen bijlagen te hebben."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Kan de bijlage niet openen. Draait Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Misvormde tekstbundel: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Exporteer project"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, fuzzy, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Project succesvol geëxporteerd. Klik om te tonen."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exporteren"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -295,48 +247,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Export mislukt"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Exporteer project"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, fuzzy, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Project succesvol geëxporteerd. Klik om te tonen."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exporteren"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Kan map niet verplaatsen"
@@ -355,28 +265,49 @@ msgstr "Kan map of bestand niet verplaatsen"
 msgid "The file/directory %s already exists in target."
 msgstr "Bestand/map %s bestaat al in doel."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Naamloos"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "De opgegeven naam bevat geen toegestane letters."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Kon map niet aanmaken"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "De opgevraagde map was niet gevonden."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Echt verwijderen?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Export mislukt"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Er is een fout opgetreden bij het exporteren: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Kies exportbestemming"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Opslaan"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Wil je echt %s verwijderen?"
+msgid "Exporting to %s"
+msgstr "Exporteren naar %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Er is een fout opgetreden bij het exporteren: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -401,11 +332,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Kopie van %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -418,125 +351,34 @@ msgstr "Taalbestand geïmporteerd: %s"
 msgid "Could not import language file %s!"
 msgstr "Kon taalbestand %s niet importeren!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Export mislukt"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Kon bestand niet aanmaken"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Er is een fout opgetreden bij het exporteren: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Kies exportbestemming"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Opslaan"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exporteren naar %s"
+msgid "Copy of %s"
+msgstr "Kopie van %s"
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Naamloos"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Kon map niet aanmaken"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Er is een fout opgetreden bij het exporteren: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "De opgegeven naam bevat geen toegestane letters."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "De opgevraagde map was niet gevonden."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Misvormde tekstbundel: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Vervang bestand"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Altijd externe wijzigingen in het huidige bestand laden"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Bestaand bestand overschrijven"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Het bestand %s bestaat al in de map. Overschrijven?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Bestand openen"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Onopgeslagen wijzigingen"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Er zijn niet-opgeslagen wijzigingen. Wil je deze eerst opslaan?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Open project map"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "De citaten database kan niet worden geladen"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Wijzigingen in het bibliotheek bestand gedetecteerd. Opnieuw laden ..."
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Tag “%s” vervangen door “%s” in %s bestanden?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -649,6 +491,12 @@ msgstr "Bestand hernoemen"
 msgid "Delete file"
 msgstr "Verwijder bestand"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Afsluiten"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -667,15 +515,15 @@ msgstr "Opnieuw"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Knippen"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -687,8 +535,8 @@ msgstr "Kopieer als HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Plakken"
 
@@ -700,8 +548,8 @@ msgstr "Plakken zonder stijl"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Selecteer alles"
 
@@ -944,10 +792,162 @@ msgstr "Stop met praten"
 msgid "Bring All to Front"
 msgstr "Breng alles naar voren"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Kon werkruimte %s niet openen."
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Open project map"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Vervang bestand"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Altijd externe wijzigingen in het huidige bestand laden"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Onopgeslagen wijzigingen"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Er zijn niet-opgeslagen wijzigingen. Wil je deze eerst opslaan?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Bestand openen"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Bestaand bestand overschrijven"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Het bestand %s bestaat al in de map. Overschrijven?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Toon Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Er is een update naar versie %s beschikbaar!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Kon niet controleren op nieuwe versies. Serverfout (status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Kon niet controleren op nieuwe versies. Clientfout (status code: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Kon niet controleren op nieuwe versies. De server heeft geprobeerd door te "
+"verwijzen (status code: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Kon niet controleren op updates: Kon geen verbinding maken"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Kon niet controloren op updates. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Kon niet controleren op updates: Server heeft geen data gestuurd"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -964,143 +964,1202 @@ msgstr "Nee, wijzigingen verwerpen"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Er zijn niet-opgeslagen wijzigingen. Wil je deze eerst opslaan?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Bestandsmanager modus"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Zet autocorrectie aan"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Eigenschappen"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Dupliceer bestand"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Volledig pad kopiëren"
+msgid "Double Quotes"
+msgstr "Geen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopieer bestandsnaam"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Geen"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Geen"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Vervang bestand"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filter ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Schema"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Uit"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Volg het besturingssysteem"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Toon Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Aangepaste CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Open map"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Exporteren naar %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Gebruik de interne Pandoc voor export"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Verwijder labels uit bestanden"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Ontkoppel interne links"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Verwijder alle interne links"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Ontkoppel interne links"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Raak de interne links niet aan"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Toon bestandsinformatie"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Toon knop om afbeelding in te voegen"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Commentaar"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Patroon voor nieuwe bestandsnamen"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Patroon voor nieuwe bestandsnamen"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr ""
+"Vraag niet naar de bestandsnaam wanneer nieuwe bestanden worden aangemaakt"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Gebruik het systeemeigen vensteruiterlijk"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Gebruik het systeemeigen vensteruiterlijk"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Toon app in het systeemvak"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Laat de app draaien in het systeemvak"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoomgedrag"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Zoom verandert de hele gebruiksinterface"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Zoomen verandert de tekengrootte in de editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Witte lijst voor iFrame-weergave"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostnaam"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Activeer Watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Tijdsduur om te wachten voordat er wordt aangenomen dat het schrijven naar "
+"een bestand is afgerond (in ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Verwijder bestand"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Zet debug mode aan"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Zet debug mode aan"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notificeer mij bij beta releases"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Invoermodus editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Zoek in map"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Verberg karakters voor kopteksten"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Geef de nadruk weer"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Vet"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Cursief"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Controleer Markdown op stijlproblemen"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Zet tabel editor aan"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Maak regels zonder focus minder opvallend in afleidingsvrije modus"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Aantal woorden"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Tel karakters in plaats van woorden (bijv. voor Chinees)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Afbeelding"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Maximale afbeeldingsbreedte (procent)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Maximale afbeeldingshoogte (procent)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Andere bestanden"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Tekengrootte in de editor"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Spring in met het volgende aantal spaties"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Inspringen met tabs"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Aanvaard spaties bij automatisch aanvullen"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Sluit automatisch bijpassende tekenparen"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Toon knop om afbeelding in te voegen"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Toon bestandsinformatie"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Toon mappen boven bestanden"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Alleen bestandsnaam"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Titel (indien van toepassing)"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Eerste kop niveau 1 indien van toepassing"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Titel of eerste kop (indien van toepassing)"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Toon Markdown bestandsextensies"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Tijdstip waarop de laatste aanpassingen zijn gemaakt."
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Tijdstip waarop het bestand is aangemaakt."
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exporteren..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Recente documenten"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Natuurlijke volgorde (10 na 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII volgorde (2 na 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Geef citaten weer"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Hoe moeten uw verwijzingen automatisch ingevoegd worden?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Voeg toe aan bestand"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Patroon dat gebruikt wordt om nieuwe IDs te genereren."
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID reguliere expressie"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Patroon dat gebruikt wordt om nieuwe IDs te genereren."
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Link met alleen de bestandsnaam"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Wanneer bestanden worden gekoppeld, voeg de bestandsnaam toe ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "altijd"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "alleen wanneer er bij het koppelen het ID gebruikt wordt"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "nooit"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Begin een zoekopdracht bij klik op een Zettelkasten-link"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Automatisch aanmaken van niet-bestaande bestanden wanneer interne links "
+"worden gevolgd"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalender"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Aangepaste CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Aangepaste CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Acties"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Code"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Selecteer de talen waarvoor je de automatische spellingscontrole wil "
+"aanzetten."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Gebruikerswoordenboek. Verwijder woorden door op ze te klikken."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Woordenboeklemma"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Zoeken naar invoer …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automatisch opslaan"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Tijdstip waarop de laatste aanpassingen zijn gemaakt."
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Onmiddellijk"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Na een korte wachttijd"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Zoomgedrag"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Vermijd indien mogelijk bestanden in nieuwe tabbladen te openen"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Bijwerker"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Controleer automatisch op updates"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s karakters"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s woorden"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Geen markering"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Aangepaste CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Kon bestand niet aanmaken"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Afbeelding niet gevonden: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Spelfout"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Bestand %s bestaat niet."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Aantal woorden"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Gewijzigd"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Open…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Open in nieuw tabblad"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Afbeelding"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Commentaar"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Geen voetnoottekst gevonden."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Vergelijkingscode kopiëren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Afbeelding naar klembord kopiëren"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Bestand openen"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Open in browser"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Geen suggesties"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Voeg toe aan map"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Cursief"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Link invoegen"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Voeg ongeordende lijst in"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Voeg genummerde lijst in"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Sluit bestand"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Map hernoemen"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Verwijder map"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Controleer op map ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exporteer project"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Andere tabbladen sluiten"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Alle tabbladen sluiten"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Tabblad losmaken"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Tabblad vastzetten"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,327 +2591,321 @@ msgstr "Chinees (China)"
 msgid "Chinese"
 msgstr "Chinees (China)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Eigenschappen"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Dupliceer bestand"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Aangepaste CSS"
+msgid "Copy path"
+msgstr "Volledig pad kopiëren"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s woorden"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopieer bestandsnaam"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s karakters"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Spelfout"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Sluit bestand"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Map hernoemen"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Verwijder map"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Controleer op map ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exporteer project"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Vet"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Andere tabbladen sluiten"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Cursief"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Alle tabbladen sluiten"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Tabblad losmaken"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Afbeelding"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Tabblad vastzetten"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Commentaar"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Code"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Grafieken"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Geen voetnoottekst gevonden."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Bestand %s bestaat niet."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Aantal woorden"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Gewijzigd"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Open…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Open in nieuw tabblad"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Geen markering"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "januari"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "februari"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "maart"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "april"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "mei"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "juni"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "juli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "augustus"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "september"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "oktober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "november"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "december"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Onder het maandelijks gemiddelde"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Meer dan het maandelijks gemiddelde"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Meer dan het dubbele maandelijks gemiddelde"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Afbeelding naar klembord kopiëren"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Bestand openen"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Open in browser"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Geen suggesties"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Voeg toe aan map"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Cursief"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Link invoegen"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Voeg ongeordende lijst in"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Voeg genummerde lijst in"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Vergelijkingscode kopiëren"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Afbeelding niet gevonden: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Kon bestand niet aanmaken"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Bijwerker"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Nieuwe updates beschikbaar"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Jouw versie"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Er is een nieuwe versie van Zettlr beschikbaar om te downloaden. Lees de "
-"wijzigingen hieronder."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Update downloaden ..."
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Geen update beschikbaar, u heeft de meest recente versie."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klik om update te starten"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Update starten ..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Zoeken"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Tellen"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filter labels…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Open project map"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Verwijder bestand"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Toevoegen"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Acties"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Verwijder"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Afbeelding"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1869,10 +2922,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1936,46 +2985,29 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr maakt ook gebruik van de volgende projecten:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Hier kun je verschillende stijlen van Zettlr herschrijven om het nog verder "
-"aan te passen. <strong>Let op: Dit bestand overschrijft alle CSS-"
-"richtlijnen! Verander nooit de geometrie van de elementen anders kan Zettlr "
-"ongewenst gedrag vertonen!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Hernoem fragment"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Met fragmenten kunt u herbruikbare stukken tekst met variabelen definiëren."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Opslaan ..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Opslaan mislukt"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Aangepaste CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Opgeslagen!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1999,40 +3031,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Bewerk de standaardinstellingen voor importeren en exporteren."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Opgeslagen!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Hernoem fragment"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-"Met fragmenten kunt u herbruikbare stukken tekst met variabelen definiëren."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "woorden"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "karakters"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Hier kun je verschillende stijlen van Zettlr herschrijven om het nog verder "
+"aan te passen. <strong>Let op: Dit bestand overschrijft alle CSS-"
+"richtlijnen! Verander nooit de geometrie van de elementen anders kan Zettlr "
+"ongewenst gedrag vertonen!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Geen open document"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Opslaan mislukt"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Tellen"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filter labels…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2058,76 +3128,115 @@ msgstr "Geluidseffect"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "woorden afgelopen maand"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Gerelateerde bestanden"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "dagelijks gemiddelde"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Geen gerelateerde bestanden"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "woorden vandaag"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Je staat in brand!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Je staat op het punt je dagelijkse gemiddelde te halen!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Ga schrijven om je dagelijkse gemiddelde te overtreffen."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Meer statistieken ..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Andere bestanden"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Open map"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Geen andere bestanden"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referenties"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Er zijn geen citaten in dit document."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Naam"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Wolk met labels"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Exporteren..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exporteren"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2137,8 +3246,8 @@ msgstr "Mappen"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Bestanden"
 
@@ -2152,10 +3261,26 @@ msgstr "Karakters"
 msgid "Words"
 msgstr "Woorden"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Werkruimten"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Geen open bestanden of mappen"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Geen resultaten"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Geen map geselecteerd"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Lege map"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2185,15 +3310,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2254,13 +3370,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2470,130 +3579,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Zet schrijfdoel..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Geen resultaten"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Geen map geselecteerd"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Lege map"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Werkruimten"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Geen open bestanden of mappen"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "woorden afgelopen maand"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "dagelijks gemiddelde"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "woorden vandaag"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Je staat in brand!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Je staat op het punt je dagelijkse gemiddelde te halen!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Ga schrijven om je dagelijkse gemiddelde te overtreffen."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Meer statistieken ..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Exporteren..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exporteren"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2616,11 +3604,6 @@ msgstr "Alleen zoeken in map"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Zoeken"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Zoekopdracht verwijderen"
@@ -2634,1114 +3617,137 @@ msgstr "Toon resultaten"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Naam"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Wolk met labels"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "woorden"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "karakters"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Geen open document"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Gerelateerde bestanden"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Geen gerelateerde bestanden"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Toevoegen"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Acties"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Verwijder"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Open project map"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Verwijder bestand"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Zet autocorrectie aan"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Geef citaten weer"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "januari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "februari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "maart"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "april"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "mei"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "juni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "juli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "augustus"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "september"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "oktober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "november"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "december"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Onder het maandelijks gemiddelde"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Meer dan het maandelijks gemiddelde"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Meer dan het dubbele maandelijks gemiddelde"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Grafieken"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Patroon dat gebruikt wordt om nieuwe IDs te genereren."
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID reguliere expressie"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Patroon dat gebruikt wordt om nieuwe IDs te genereren."
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Ontkoppel interne links"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Link met alleen de bestandsnaam"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Wanneer bestanden worden gekoppeld, voeg de bestandsnaam toe ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "altijd"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "alleen wanneer er bij het koppelen het ID gebruikt wordt"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "nooit"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Begin een zoekopdracht bij klik op een Zettelkasten-link"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Automatisch aanmaken van niet-bestaande bestanden wanneer interne links "
-"worden gevolgd"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Geen"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Geen"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Geen"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Vervang bestand"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filter ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Invoermodus editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Zoek in map"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Verberg karakters voor kopteksten"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Geef de nadruk weer"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Controleer Markdown op stijlproblemen"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Zet tabel editor aan"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Maak regels zonder focus minder opvallend in afleidingsvrije modus"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Aantal woorden"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Tel karakters in plaats van woorden (bijv. voor Chinees)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Maximale afbeeldingsbreedte (procent)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Maximale afbeeldingshoogte (procent)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Andere bestanden"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Tekengrootte in de editor"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Spring in met het volgende aantal spaties"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Inspringen met tabs"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Aanvaard spaties bij automatisch aanvullen"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Sluit automatisch bijpassende tekenparen"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Schema"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Uit"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Volg het besturingssysteem"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Toon Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Open map"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Geen andere bestanden"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalender"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referenties"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Er zijn geen citaten in dit document."
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Aangepaste CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Aangepaste CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Acties"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Selecteer de talen waarvoor je de automatische spellingscontrole wil "
-"aanzetten."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Gebruikerswoordenboek. Verwijder woorden door op ze te klikken."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Woordenboeklemma"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Zoeken naar invoer …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Toon knop om afbeelding in te voegen"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Toon bestandsinformatie"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Toon mappen boven bestanden"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Alleen bestandsnaam"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Titel (indien van toepassing)"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Eerste kop niveau 1 indien van toepassing"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Titel of eerste kop (indien van toepassing)"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Toon Markdown bestandsextensies"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Tijdstip waarop de laatste aanpassingen zijn gemaakt."
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Tijdstip waarop het bestand is aangemaakt."
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exporteren..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Recente documenten"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Natuurlijke volgorde (10 na 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII volgorde (2 na 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Exporteren naar %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Gebruik de interne Pandoc voor export"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Verwijder labels uit bestanden"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Verwijder alle interne links"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Ontkoppel interne links"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Raak de interne links niet aan"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Toon bestandsinformatie"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Toon knop om afbeelding in te voegen"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Commentaar"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Patroon voor nieuwe bestandsnamen"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Patroon voor nieuwe bestandsnamen"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr ""
-"Vraag niet naar de bestandsnaam wanneer nieuwe bestanden worden aangemaakt"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Gebruik het systeemeigen vensteruiterlijk"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Gebruik het systeemeigen vensteruiterlijk"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Toon app in het systeemvak"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Laat de app draaien in het systeemvak"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoomgedrag"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Zoom verandert de hele gebruiksinterface"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Zoomen verandert de tekengrootte in de editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Witte lijst voor iFrame-weergave"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostnaam"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Activeer Watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Tijdsduur om te wachten voordat er wordt aangenomen dat het schrijven naar "
-"een bestand is afgerond (in ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Verwijder bestand"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Zet debug mode aan"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Zet debug mode aan"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notificeer mij bij beta releases"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automatisch opslaan"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Tijdstip waarop de laatste aanpassingen zijn gemaakt."
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Onmiddellijk"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Na een korte wachttijd"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Zoomgedrag"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Vermijd indien mogelijk bestanden in nieuwe tabbladen te openen"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Bijwerker"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Controleer automatisch op updates"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Nieuwe updates beschikbaar"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Hoe moeten uw verwijzingen automatisch ingevoegd worden?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Jouw versie"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Er is een nieuwe versie van Zettlr beschikbaar om te downloaden. Lees de "
+"wijzigingen hieronder."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Update downloaden ..."
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Geen update beschikbaar, u heeft de meest recente versie."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klik om update te starten"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Voeg toe aan bestand"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Update starten ..."
 
 #~ msgid "Open Link"
 #~ msgstr "Open link"

--- a/static/lang/pl-PL.po
+++ b/static/lang/pl-PL.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Nie udało się załadować bazy cytowań"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Wykryto zmiany w pliku biblioteki. Trwa ładowanie..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Obszary robocze"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,141 +82,6 @@ msgstr "Opcja %s musi mieć długość min. %s znaków."
 msgid "Option %s is required."
 msgstr "Opcja %s jest obowiązkowa."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Pokaż Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Wyjdź"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Dostępna jest wersja %s"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Nie można sprawdzić aktualizacji: Błąd serwera (kod: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Nie można sprawdzić aktualizacji: Błąd klienta (kod błędu: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Nie można sprawdzić aktualizacji: Serwer starał się przekierowąć (kod: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Nie można sprawdzić aktualizacji: Nie można się połączyć"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Nie mogę sprawdzić aktualizacji. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Nie można sprawdzić aktualizacji: Serwer nie przesłał danych"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Nie można stworzyć pliku"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Odniesienie z kluczem %s nie ma załączników."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Nie można otworzyć załącznika. Czy Zotero jest włączone?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -220,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Anuluj"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Usunąć?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Czy chcesz usunąć %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Odniesienie z kluczem %s nie ma załączników."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Nie można otworzyć załącznika. Czy Zotero jest włączone?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Błędna wiązka: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Eksportuj projekt"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Eksportuj..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -292,48 +245,6 @@ msgstr "%s plików nie mogło zostać wczytanych, ich typ jest nieznany: %s"
 msgid "Import failed"
 msgstr "Eksport nie powiódł się"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Eksportuj projekt"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Eksportuj..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Nie mogę przenieść katalogu"
@@ -351,28 +262,49 @@ msgstr "Nie można przenieść katalogu lub pliku"
 msgid "The file/directory %s already exists in target."
 msgstr "Plik albo katalog %s już istnieje."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Bez tytułu"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Nazwa nie zawiera dozwolonych liter."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Nie można stworzyć katalogu"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Żądany katalog nie został znaleziony"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Usunąć?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Eksport nie powiódł się"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Błąd eksportu: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Zapisz"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Czy chcesz usunąć %s?"
+msgid "Exporting to %s"
+msgstr "Eksportuję do %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Błąd eksportu: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -397,10 +329,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -414,126 +348,34 @@ msgstr "Wczytano plik języka: %s"
 msgid "Could not import language file %s!"
 msgstr "Nie mogę wczytać pliku języka %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Eksport nie powiódł się"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Nie można stworzyć pliku"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Błąd eksportu: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
+#, javascript-format
+msgid "Copy of %s"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Zapisz"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Bez tytułu"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Nie można stworzyć katalogu"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Eksportuję do %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Błąd eksportu: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Nazwa nie zawiera dozwolonych liter."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Żądany katalog nie został znaleziony"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Błędna wiązka: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Zastąp plik"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Zawsze ładuj zewnętrzne zmiany"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Zastąp istniejący plik"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Plik %s już istnieje. Zastąpić?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Otwórz plik"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Niezapisane zmiany"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Plik zawiera niezapisane zmiany. Pominąć je czy zapisać?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Otwórz folder projektu"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Nie udało się załadować bazy cytowań"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Wykryto zmiany w pliku biblioteki. Trwa ładowanie..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -645,6 +487,12 @@ msgstr "Zmień nazwę pliku"
 msgid "Delete file"
 msgstr "Usuń plik"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Wyjdź"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -663,15 +511,15 @@ msgstr "Powtórz"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Wytnij"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -683,8 +531,8 @@ msgstr "Kopiuj jako HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Wklej"
 
@@ -696,8 +544,8 @@ msgstr "Wklej bez formatowania"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Zaznacz wszystko"
 
@@ -940,10 +788,162 @@ msgstr "Przestań mówić"
 msgid "Bring All to Front"
 msgstr "Wysuń wszystkie"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Obszary robocze"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Otwórz folder projektu"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Zastąp plik"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Zawsze ładuj zewnętrzne zmiany"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Niezapisane zmiany"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Plik zawiera niezapisane zmiany. Pominąć je czy zapisać?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Otwórz plik"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Zastąp istniejący plik"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Plik %s już istnieje. Zastąpić?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Pokaż Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Dostępna jest wersja %s"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Nie można sprawdzić aktualizacji: Błąd serwera (kod: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Nie można sprawdzić aktualizacji: Błąd klienta (kod błędu: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Nie można sprawdzić aktualizacji: Serwer starał się przekierowąć (kod: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Nie można sprawdzić aktualizacji: Nie można się połączyć"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Nie mogę sprawdzić aktualizacji. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Nie można sprawdzić aktualizacji: Serwer nie przesłał danych"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -960,143 +960,1195 @@ msgstr "Niezapisane zmiany"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Plik zawiera niezapisane zmiany. Pominąć je czy zapisać?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Tryb menedżera plików"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Włącz autokorektę"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Właściwości"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplikuj plik"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Kopiuj ID"
+msgid "Double Quotes"
+msgstr "Brak"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopiuj nazwę pliku"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Brak"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Brak"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Zastąp plik"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtr..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "W godzinach"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Wyłączony"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Naśladuj system operacyjny"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Pokaż Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Własny CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Otwórz katalog"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Eksportuję do %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Używaj wbudowanej biblioteki Pandoc przy eksporcie"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Usuwaj tagi z plików"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Rozłączaj wewnętrze łącza"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Usuwaj wewnętrzne łącza w całości"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Rozłączaj wewnętrze łącza"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Nie zmieniaj wewnętrznych łączy"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Pokaż informacje o pliku"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Komentarz"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Wzorzec dla nazw nowych plików"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Wzorzec dla nazw nowych plików"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Nie pytaj o nazwę pliku przy tworzeniu"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Używaj systemowego wyglądu okna"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Używaj systemowego wyglądu okna"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Pokaż aplikację w panelu powiadomień"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Pozostaw w obszarze powiadomień"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zachowanie przybliżenia"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Przybliżenie zmienia wielkość całego interfejsu"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Przybliżenie zmienia wielkość fonta w edytorze"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Biała lista wyświetlanych iFrames"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nazwa hosta"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Monitoruj aktywność systemu plików"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Czas oczekiwania, zanim zapis pliku zostanie uznany za dokonany (w ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Usuń plik"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Tryb debugowania"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Tryb debugowania"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Powiadamiaj mnie o wydaniach beta"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Tryb wprowadzania"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Znajdź w katalogu"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Wyświetlaj nagłówki"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Wyświetlaj emfazę"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Pogrubienie"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursywa"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Włącz edytor tabeli"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Wygaś pozostałe linie w trybie bez rozproszeń"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Liczba słów"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Liczenie znaków zamiast słów"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Obraz"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Maksymalna szerokość obrazu (%)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Maksymalna wysokość obrazu (%)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Inne pliki"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Wielkość liter w edytorze"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Liczba spacji wcięcia"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Wcięcia z użyciem tabulatora"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Akceptuj spacje podczas autouzupełniania"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Automatycznie zamykaj pary znaków"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Tryb nocny"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Pokaż informacje o pliku"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Pokaż foldery ponad plikami"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Tylko nazwa pliku"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Tytuł, jeśli dostępny"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Nagłówek 1. poziomu, gdy dostępny"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Tytuł albo nagłówek 1. poziomu, jeśli dostępne"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Wyświetlaj rozszerzenia plików Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Czas ostatniej modyfikacji"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Czas utworzenia pliku"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Eksportuj..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Ostatnie dokumenty"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Porządek naturalny (10 po 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Porządek ASCII (2 po 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Wyświetlaj cytowania"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Wybierz tryb autouzupełniania przypisów"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Dodaj do pliku"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Wzór do generowania nowych identyfikatorów"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Wyrażenie regularne identyfikatora"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Wzór do generowania nowych identyfikatorów"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Tylko nazwa pliku"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Łącząc pliku, dodaj nazwę pliku..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "zawsze"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "tylko przy łączeniu za pomocą identyfikatora"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "nigdy"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Rozpocznij wyszukiwanie przy wybraniu łącza Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Automatycznie twórz nowe pliki podążając za łączami wewnętrznymi"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalendarz"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Własny CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Własny CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Działania"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kod"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Wybierz języki automatycznego sprawdzania pisowni"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Słownik osobisty. Kliknięcie usuwa słowa."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Wpis słownika"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Szukaj wpisów..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Zapis automatyczny"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Czas ostatniej modyfikacji"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Natychmiast"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Z krótkim opóźnieniem"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Zachowanie przybliżenia"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Unikaj otwierania plików w nowych kartach"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Aktualizacje"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Automatycznie sprawdzaj aktualizacje"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "Znaki: %s"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s słów"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Własny CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Nie można stworzyć pliku"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Liczba słów"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Zmodyfikowany"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Otwórz..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Otwórz w nowej karcie"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Obraz"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Komentarz"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Skopiuj kod równania"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Skopiuj obraz do schowka"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Otwórz plik"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Otwórz w przeglądarce"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Brak sugestii"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Dodaj do słownika"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursywa"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Wstaw link"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Wstaw listę wypunktowaną"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Wstaw listę numerowaną"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Zamknij plik"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Zmień nazwę katalogu"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Usuń katalog"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Sprawdź katalog"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Eksportuj projekt"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Zamknij pozostałe karty"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Zamknij wszystkie karty"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1528,325 +2580,322 @@ msgstr "Chiński (Chiny)"
 msgid "Chinese"
 msgstr "Chiński (Chiny)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Właściwości"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplikuj plik"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Własny CSS"
+msgid "Copy path"
+msgstr "Kopiuj ID"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s słów"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopiuj nazwę pliku"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "Znaki: %s"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Zamknij plik"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Zmień nazwę katalogu"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Usuń katalog"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Sprawdź katalog"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Eksportuj projekt"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Zamknij pozostałe karty"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Zamknij wszystkie karty"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Pogrubienie"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursywa"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Obraz"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Komentarz"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kod"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalendarz"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Wykresy"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Liczba słów"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Zmodyfikowany"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Otwórz..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Otwórz w nowej karcie"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Styczeń"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Luty"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Marzec"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Kwiecień"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maj"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Czerwiec"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Lipiec"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Sierpień"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Wrzesień"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Październik"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Listopad"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Grudzień"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Poniżej średniej miesięcznej"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Powyżej średniej miesięcznej"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Dwukrotnie ponad średnią miesięczną"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Skopiuj obraz do schowka"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Otwórz plik"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Otwórz w przeglądarce"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Brak sugestii"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Dodaj do słownika"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursywa"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Wstaw link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Wstaw listę wypunktowaną"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Wstaw listę numerowaną"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Skopiuj kod równania"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Nie można stworzyć pliku"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Aktualizacje"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Dostępna jest aktualizacja"
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Twoja wersja"
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Jest nowa wersja Zettlr. Zobacz listę zmian."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Pobieram aktualizację"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Zettlr jest aktualny"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Rozpocznij aktualizację"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Aktualizuję..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Szukaj"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Flitruj tagi"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Otwórz folder projektu"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Usuń plik"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Dodaj"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Działania"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Usuń plik"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Obraz"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1863,10 +2912,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1928,45 +2973,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr korzysta również z tych projektów:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Możesz tutaj nadpisywać style programu. <strong>Ten plik nadpisuje wszystkie "
-"dyrektywy CSS. Nie zmieniaj geometrii elementów, program może przestać "
-"działać poprawnie!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Zmień nazwę wycinka"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Wycinki to zapisane fragmenty tekstu ze zmiennymi"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Zapisuję..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Zapis nie powiódł się"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Własny CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Zapisano!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1988,39 +3016,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Domyślne ustawiania importu i eksportu"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Zapisano!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Zmień nazwę wycinka"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Wycinki to zapisane fragmenty tekstu ze zmiennymi"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "słów"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "znaków"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Możesz tutaj nadpisywać style programu. <strong>Ten plik nadpisuje wszystkie "
+"dyrektywy CSS. Nie zmieniaj geometrii elementów, program może przestać "
+"działać poprawnie!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Brak otwartych plików"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Zapis nie powiódł się"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Flitruj tagi"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2046,76 +3112,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "słów w ubiegłym miesiącu"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Pliki pokrewne"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "dzienna średnia"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Brak plików pokrewnych"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "słów dzisiaj"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Wymiatasz!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Zbliżasz się do swojej dziennej średniej!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Pobij dzienną średnią."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Więcej statystyk..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Inne pliki"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Otwórz katalog"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Żadnych innych plików"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Bibliografia"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Nie ma cytowań w tym dokumencie"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Chmura tagów"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Eksportuj..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Eksportuj..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2125,8 +3231,8 @@ msgstr "Foldery"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Pliki"
 
@@ -2140,10 +3246,26 @@ msgstr "Znaki"
 msgid "Words"
 msgstr "Słowa"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Obszary robocze"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Brak otwartych plików/katalogów"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Brak wyników"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nie wybrano katalogu"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Pusty katalog"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2173,15 +3295,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2242,13 +3355,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalendarz"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2458,131 +3564,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Ustaw cel pisania"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Brak wyników"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nie wybrano katalogu"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Pusty katalog"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Obszary robocze"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Brak otwartych plików/katalogów"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "słów w ubiegłym miesiącu"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "dzienna średnia"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "słów dzisiaj"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Wymiatasz!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Zbliżasz się do swojej dziennej średniej!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Pobij dzienną średnią."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Więcej statystyk..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Eksportuj..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Eksportuj..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2605,11 +3589,6 @@ msgstr "Ogranicz wyszukiwanie do folderu"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Szukaj"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Wyczyść wyszukiwanie"
@@ -2623,1108 +3602,135 @@ msgstr "Przełącz rezultaty"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Chmura tagów"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "słów"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "znaków"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Brak otwartych plików"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Pliki pokrewne"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Brak plików pokrewnych"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Dodaj"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Działania"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Usuń plik"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Otwórz folder projektu"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Usuń plik"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Włącz autokorektę"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Wyświetlaj cytowania"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Styczeń"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Luty"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Marzec"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Kwiecień"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maj"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Czerwiec"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Lipiec"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Sierpień"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Wrzesień"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Październik"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Listopad"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Grudzień"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Poniżej średniej miesięcznej"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Powyżej średniej miesięcznej"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Dwukrotnie ponad średnią miesięczną"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Wykresy"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Wzór do generowania nowych identyfikatorów"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Wyrażenie regularne identyfikatora"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Wzór do generowania nowych identyfikatorów"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Rozłączaj wewnętrze łącza"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Tylko nazwa pliku"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Łącząc pliku, dodaj nazwę pliku..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "zawsze"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "tylko przy łączeniu za pomocą identyfikatora"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "nigdy"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Rozpocznij wyszukiwanie przy wybraniu łącza Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Automatycznie twórz nowe pliki podążając za łączami wewnętrznymi"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Brak"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Brak"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Brak"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Zastąp plik"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtr..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Tryb wprowadzania"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Znajdź w katalogu"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Wyświetlaj nagłówki"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Wyświetlaj emfazę"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Włącz edytor tabeli"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Wygaś pozostałe linie w trybie bez rozproszeń"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Liczba słów"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Liczenie znaków zamiast słów"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Maksymalna szerokość obrazu (%)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Maksymalna wysokość obrazu (%)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Inne pliki"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Wielkość liter w edytorze"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Liczba spacji wcięcia"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Wcięcia z użyciem tabulatora"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Akceptuj spacje podczas autouzupełniania"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Automatycznie zamykaj pary znaków"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "W godzinach"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Wyłączony"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Naśladuj system operacyjny"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Pokaż Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Otwórz katalog"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Żadnych innych plików"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalendarz"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Bibliografia"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Nie ma cytowań w tym dokumencie"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Własny CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Własny CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Działania"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Wybierz języki automatycznego sprawdzania pisowni"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Słownik osobisty. Kliknięcie usuwa słowa."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Wpis słownika"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Szukaj wpisów..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Tryb nocny"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Pokaż informacje o pliku"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Pokaż foldery ponad plikami"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Tylko nazwa pliku"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Tytuł, jeśli dostępny"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Nagłówek 1. poziomu, gdy dostępny"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Tytuł albo nagłówek 1. poziomu, jeśli dostępne"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Wyświetlaj rozszerzenia plików Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Czas ostatniej modyfikacji"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Czas utworzenia pliku"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Eksportuj..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Ostatnie dokumenty"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Porządek naturalny (10 po 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Porządek ASCII (2 po 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Eksportuję do %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Używaj wbudowanej biblioteki Pandoc przy eksporcie"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Usuwaj tagi z plików"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Usuwaj wewnętrzne łącza w całości"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Rozłączaj wewnętrze łącza"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Nie zmieniaj wewnętrznych łączy"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Pokaż informacje o pliku"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Komentarz"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Wzorzec dla nazw nowych plików"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Wzorzec dla nazw nowych plików"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Nie pytaj o nazwę pliku przy tworzeniu"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Używaj systemowego wyglądu okna"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Używaj systemowego wyglądu okna"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Pokaż aplikację w panelu powiadomień"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Pozostaw w obszarze powiadomień"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zachowanie przybliżenia"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Przybliżenie zmienia wielkość całego interfejsu"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Przybliżenie zmienia wielkość fonta w edytorze"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Biała lista wyświetlanych iFrames"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nazwa hosta"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Monitoruj aktywność systemu plików"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Czas oczekiwania, zanim zapis pliku zostanie uznany za dokonany (w ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Usuń plik"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Tryb debugowania"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Tryb debugowania"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Powiadamiaj mnie o wydaniach beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Zapis automatyczny"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Czas ostatniej modyfikacji"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Natychmiast"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Z krótkim opóźnieniem"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Zachowanie przybliżenia"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Unikaj otwierania plików w nowych kartach"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Aktualizacje"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Automatycznie sprawdzaj aktualizacje"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Dostępna jest aktualizacja"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Wybierz tryb autouzupełniania przypisów"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Twoja wersja"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Jest nowa wersja Zettlr. Zobacz listę zmian."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Pobieram aktualizację"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Zettlr jest aktualny"
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Rozpocznij aktualizację"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Dodaj do pliku"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Aktualizuję..."
 
 #~ msgid "Open Link"
 #~ msgstr "Otwórz link"

--- a/static/lang/pt-BR.po
+++ b/static/lang/pt-BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "O banco de dados de citações não pôde ser carregado"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Alterações no arquivo da biblioteca detectadas. Recarregando…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Não foi possível abrir área de trabalho"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,150 +81,6 @@ msgstr "A opção %s deve ter pelo menos %s (caracteres)."
 msgid "Option %s is required."
 msgstr "A opção %s é necessária."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Mostrar Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Sair"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Uma atualização para a versão %s está disponível!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há atualizações: Erro do Servidor (Código de "
-"status: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há atualizações: Erro do cliente (código de "
-"status: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há atualizações: o servidor tentou "
-"redirecionar (Código de status: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"Não foi possível verificar se há atualizações: Não foi possível estabelecer "
-"conexão"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Não foi possível buscar por atualizações. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Não foi possível verificar se há atualizações: o servidor não enviou nenhum "
-"dado"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Documento muito longo"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "offline"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Não foi possível criar arquivo"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "A referência com a chave %s parace não ter anexos."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "O anexo não pode ser aberto. O Zotero está aberto?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -228,24 +98,98 @@ msgstr "Sim"
 msgid "No"
 msgstr "Não"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Substituir a tag \"%s\" por \"%s\" nos arquivos %s?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Realmente excluir?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Deseja mesmo remover %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "A referência com a chave %s parace não ter anexos."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "O anexo não pode ser aberto. O Zotero está aberto?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Pacote de texto malformado: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Exportar Projeto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, fuzzy, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Projeto exportado com sucesso. Clique para exibir."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exportar"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -302,48 +246,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Falha na exportação"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Exportar Projeto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, fuzzy, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Projeto exportado com sucesso. Clique para exibir."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exportar"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Não é possível mover a pasta"
@@ -361,28 +263,49 @@ msgstr "Não é possível mover pasta ou arquivo"
 msgid "The file/directory %s already exists in target."
 msgstr "O arquivo/pasta %s já existe no destino."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sem título"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "O nome fornecido não continha nenhuma letra permitida."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Não foi possível criar pasta"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "A pasta solicitada não foi encontrada."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Realmente excluir?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Falha na exportação"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Ocorreu um erro na exportação: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Selecione a pasta para exportação"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Salvar"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Deseja mesmo remover %s?"
+msgid "Exporting to %s"
+msgstr "Exportando para %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Ocorreu um erro na exportação: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -407,11 +330,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Cópia de %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Documento muito longo"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "offline"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -424,125 +349,34 @@ msgstr "Arquivo de idioma importado: %s"
 msgid "Could not import language file %s!"
 msgstr "Não foi possível importar o arquivo de idioma %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Falha na exportação"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Não foi possível criar arquivo"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Ocorreu um erro na exportação: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Selecione a pasta para exportação"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Salvar"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exportando para %s"
+msgid "Copy of %s"
+msgstr "Cópia de %s"
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sem título"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Não foi possível criar pasta"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Ocorreu um erro na exportação: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "O nome fornecido não continha nenhuma letra permitida."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "A pasta solicitada não foi encontrada."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Pacote de texto malformado: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Sempre carregar alterações remotas no arquivo atual"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Sobrescrever arquivo existente"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "O arquivo %s já existe nesta pasta. Sobrescrever?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Abrir arquivo"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Alterações não salvas"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Há alterações não salvas. Você quer salvá-los primeiro?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Salvar arquivo"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Abrir pasta do projeto"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "O banco de dados de citações não pôde ser carregado"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Alterações no arquivo da biblioteca detectadas. Recarregando…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Substituir a tag \"%s\" por \"%s\" nos arquivos %s?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -654,6 +488,12 @@ msgstr "Renomear arquivo"
 msgid "Delete file"
 msgstr "Apagar arquivo"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Sair"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -672,15 +512,15 @@ msgstr "Refazer"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Recortar"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copiar"
 
@@ -692,8 +532,8 @@ msgstr "Copiar como HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Colar"
 
@@ -705,8 +545,8 @@ msgstr "Colar sem formatação"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Selecionar tudo"
 
@@ -949,10 +789,170 @@ msgstr "Pare de falar"
 msgid "Bring All to Front"
 msgstr "Trazer Tudo para a frente"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Não foi possível abrir área de trabalho"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Abrir pasta do projeto"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Sempre carregar alterações remotas no arquivo atual"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Alterações não salvas"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Há alterações não salvas. Você quer salvá-los primeiro?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Abrir arquivo"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Salvar arquivo"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Sobrescrever arquivo existente"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "O arquivo %s já existe nesta pasta. Sobrescrever?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Mostrar Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Uma atualização para a versão %s está disponível!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há atualizações: Erro do Servidor (Código de "
+"status: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há atualizações: Erro do cliente (código de "
+"status: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há atualizações: o servidor tentou "
+"redirecionar (Código de status: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"Não foi possível verificar se há atualizações: Não foi possível estabelecer "
+"conexão"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Não foi possível buscar por atualizações. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Não foi possível verificar se há atualizações: o servidor não enviou nenhum "
+"dado"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -969,143 +969,1203 @@ msgstr "Alterações não salvas"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Há alterações não salvas. Você quer salvá-los primeiro?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Modo gerenciador de arquivos"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Ligar Auto Correção"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Propriedades"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicate file"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Copiar localização do arquivo completa"
+msgid "Double Quotes"
+msgstr "Desabilitar Magic Quotes"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copiar nome de arquivo"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Desabilitar Magic Quotes"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Desabilitar Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Substituir arquivo"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtro ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Agendar"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Desativado"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Seguir Sistema Operacional"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Iniciar"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Mostrar barra de status"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personalizado"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Abrir pasta"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Exportando para %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Use o Pandoc interno para exportar"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Remova as tags do arquivos"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Desligue os links internos."
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Remova completamente os links internos."
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Desligue os links internos."
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Não mexa nos links internos."
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Mostrar informações do arquivo"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Exibir botão de imagem"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Comentário"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Padrão para novos nomes de arquivos"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Padrão para novos nomes de arquivos"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Não perguntar pelo nome do arquivo quando criá-lo"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Usar aparência de janela nativa"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Usar aparência de janela nativa"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Mostrar o programa na área de notificações"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Deixe o aplicativo em execução na área de notificação"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportamento do zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "O zoom redimensiona a interface completa"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Aplicar zoom altera o tamanho da fonte no editor de texto"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Permitir renderização de iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Nome do host"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Monitorar alteração em arquivos"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Tempo de espera antes de considerar mudanças como finalizadas (em ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Apagar arquivo"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Ativar modo de depuração"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Ativar modo de depuração"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notificar sobre versões beta"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Modo editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Localizar na pasta"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ocultar caracteres de cabeçalho"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Renderizar ênfase"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Negrito"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Itálico"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Verifique problemas de estilo no Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Habilitar editor de tabela"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Esmaecer linhas não focadas no modo sem distrações"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Contagem de palavras"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Contar caracteres em vez de palavras (por exemplo, para chinês)"
+
+#: source/win-preferences/schema/editor.ts:195
+#, fuzzy
+msgid "Readability mode"
+msgstr "Modo de legibilidade (%s)"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Imagem"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Largura máxima das imagens (porcentagem)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Altura máxima das imagens (porcentagem)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Outros arquivos"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Tamanho da fonte do editor"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Indentar com o seguinte número de espaços"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Usar \"tab\" para mudar o recuo"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Aceitar espaços durante o autocompletar"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Mostrar previsão de links"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Fechar automaticamente pares de caracteres correspondentes"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Exibir botão de imagem"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Mostrar informações do arquivo"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Mostrar pastas no topo da lista antes dos arquivos"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Apenas nome do arquivo"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Título se aplicável"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Caso aplicável, primeiro título no nível 1"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Caso aplicável, título ou primeiro título de nível 1"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Mostrar as extensões do arquivo Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Horário da última modificação"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Hora de criação do arquivo"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exportar..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Documentos recentes"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordem natural (10 após 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Ordem ASCII (2 após 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Renderizar citações"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+"Como você gostaria que o preenchimento automático inserisse suas citações?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Adicionar ao arquivo"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Padrão usado para gerar novos IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Expressão regular de ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Padrão usado para gerar novos IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Link contendo apenas o nome do arquivo"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Quando linkar arquivos, adicione o nome do arquivo …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "sempre"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "somente quando linkar usando a ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "nunca"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Inicia uma busca ao percorrer links Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Criar arquivos inexistentes automaticamente ao clicar em links internos"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+#, fuzzy
+msgid "LanguageTool"
+msgstr "Use a ferramente de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Rigor"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Padrão"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Exigente"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Provedor de ferramenta de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Servidor personalilzado"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Servidor personalilzado"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+#, fuzzy
+msgid "LanguageTool Premium"
+msgstr "Provedor de ferramenta de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Usuário da ferramenta de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "Chave API da ferramenta de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Ações"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Language"
+msgstr "Provedor de ferramenta de idioma"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Código"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Selecione os idiomas para os quais deseja ativar a verificação ortográfica "
+"automática."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Dicionário do usuário. Remova as palavras clicando nelas."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Verbete do dicionário"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Busque por itens ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Idioma do aplicativo"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Salvar automaticamente"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Horário da última modificação"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Imediatamente"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Após um breve atraso"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Comportamento do zoom"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Evite abrir arquivos em novas guias, se possível"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Atualizador"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Verificar atualizações automaticamente"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caracteres"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s palavras"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Sem destaques"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Abrir painel de diagnóstico"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Desabillitado"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "CSS customizado"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Detectar automaticamente"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Não foi possível criar arquivo"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Modo de legibilidade (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Imagem não encontrada: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Erro de grafia"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "O arquivo %s não existe."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Contagem de palavras"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificado"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Abrir..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Abrir em Nova Aba"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Imagem"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comentário"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Nenhum texto de nota de rodapé encontrado."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copiar código da equação"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copiar imagem para a area de transferência"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Abrir arquivo"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Abrir no navegador"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Nenhuma sugestão"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Adicionar ao dicionário"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Itálico"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Inserir link"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Inserir lista não ordenada"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Inserir lista numerada"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Fechar arquivo"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Renomear pasta"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Apagar pasta"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Verificar pasta..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportar Projeto"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Fechar outras abas"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Fechar todas as abas"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Desafixar Aba"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Fixar Aba"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1537,327 +2597,321 @@ msgstr "Chinês (Taiwan)"
 msgid "Chinese"
 msgstr "Chinês"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Detectar automaticamente"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Desabillitado"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
+msgstr ""
+
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Propriedades"
+
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicate file"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "CSS customizado"
+msgid "Copy path"
+msgstr "Copiar localização do arquivo completa"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s palavras"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copiar nome de arquivo"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caracteres"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Abrir painel de diagnóstico"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Erro de grafia"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Fechar arquivo"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Renomear pasta"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Apagar pasta"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Verificar pasta..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportar Projeto"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Negrito"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Itálico"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Imagem"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comentário"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Código"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Nenhum texto de nota de rodapé encontrado."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "O arquivo %s não existe."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Contagem de palavras"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificado"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Abrir..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Abrir em Nova Aba"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Sem destaques"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Fechar outras abas"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Fechar todas as abas"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Desafixar Aba"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Fixar Aba"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendário"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Tabelas"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Janeiro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Fevereiro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Março"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Abril"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maio"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Junho"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Julho"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agosto"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Setembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Outubro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Novembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Dezembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Abaixo da média mensal"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Acima da média mensal"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Mais que o dobro da média mensal"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copiar imagem para a area de transferência"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Abrir arquivo"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Abrir no navegador"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Nenhuma sugestão"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Adicionar ao dicionário"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Itálico"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Inserir link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Inserir lista não ordenada"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Inserir lista numerada"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copiar código da equação"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Modo de legibilidade (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Imagem não encontrada: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Não foi possível criar arquivo"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Atualizador"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Nova atualização disponível"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Sua versão"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Existe uma nova versão do Zettlr disponível para download. Por favor, leia o "
-"changelog abaixo."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Baixando a atualização"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Não existem atualizações. Você já possui a versão mais recente."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Clique para atualizar"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Iniciando a atualização"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Busca"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Contar"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrar tags ..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Resetar"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Abrir pasta do projeto"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Apagar arquivo"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Adicionar"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Ações"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Excluir"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Imagem"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1874,10 +2928,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1944,46 +2994,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr também faz uso desses outros projetos:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Aqui você pode substituir os estilos do Zettlr para personalizá-lo ainda "
-"mais. <strong> Atenção: Este arquivo substitui todas as diretivas CSS! Nunca "
-"altere a geometria dos elementos, caso contrário, o aplicativo pode "
-"apresentar comportamentos indesejados! </strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Renomear snippet (fragmento)"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Snippets permitem que você defina trechos de texto com variáveis"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Salvando..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Falha ao salvar"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personalizado"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Salvo!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -2009,39 +3041,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Edite as configurações padrão para importações ou exportações aqui."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Salvo!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Renomear snippet (fragmento)"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Snippets permitem que você defina trechos de texto com variáveis"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "palavras"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caracteres"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Aqui você pode substituir os estilos do Zettlr para personalizá-lo ainda "
+"mais. <strong> Atenção: Este arquivo substitui todas as diretivas CSS! Nunca "
+"altere a geometria dos elementos, caso contrário, o aplicativo pode "
+"apresentar comportamentos indesejados! </strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Nenhum arquivo aberto"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Falha ao salvar"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Iniciar"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Contar"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrar tags ..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2067,76 +3138,115 @@ msgstr "Efeito Sonoro"
 msgid "Volume"
 msgstr "Volume"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "Palavras no último mês"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Arquivos relacionados"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "Média diária"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Sem arquivos relacionados"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "palavras hoje"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Esta relação é baseada em um link bidirecional."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Você está determinado!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Esta relação é baseada em um link de saída."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Você está perto de atingir sua média diária!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Esta relação é baseada em um backlink."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Comece a escrever para superar sua média diária."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Mais estatísticas..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Esta relação é baseada em %s tags compartilhadas: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Outros arquivos"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Abrir pasta"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Nenhum outro arquivo"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referências"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Não há citações neste documento."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Nome"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Nuvem de Tags"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Exportar..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Exportar"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2146,8 +3256,8 @@ msgstr "Pastas"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Arquivos"
 
@@ -2161,10 +3271,26 @@ msgstr "Caracteres"
 msgid "Words"
 msgstr "Palavras"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Áreas de trabalho"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Nenhuma pasta ou arquivo aberto."
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Sem resultados"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nenhuma pasta selecionada"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Diretório vazio"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2194,15 +3320,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Resetar"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2263,13 +3380,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendário"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2479,130 +3589,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Definir destino de gravação..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Sem resultados"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nenhuma pasta selecionada"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Diretório vazio"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Áreas de trabalho"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Nenhuma pasta ou arquivo aberto."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "Palavras no último mês"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "Média diária"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "palavras hoje"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Você está determinado!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Você está perto de atingir sua média diária!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Comece a escrever para superar sua média diária."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Mais estatísticas..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Exportar..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Exportar"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2625,11 +3614,6 @@ msgstr "Restringir pesquisa ao diretório"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Busca"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Limpar busca"
@@ -2643,1115 +3627,137 @@ msgstr "Ativar ou desativar resultados"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Nome"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Nuvem de Tags"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "palavras"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caracteres"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Nenhum arquivo aberto"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Arquivos relacionados"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Sem arquivos relacionados"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Esta relação é baseada em um link bidirecional."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Esta relação é baseada em um link de saída."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Esta relação é baseada em um backlink."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Adicionar"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Ações"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Excluir"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Abrir pasta do projeto"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Apagar arquivo"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Ligar Auto Correção"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Renderizar citações"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Janeiro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Fevereiro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Março"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Abril"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Junho"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Julho"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agosto"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Setembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Outubro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Novembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Dezembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Abaixo da média mensal"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Acima da média mensal"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Mais que o dobro da média mensal"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Tabelas"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Padrão usado para gerar novos IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Expressão regular de ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Padrão usado para gerar novos IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Desligue os links internos."
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Link contendo apenas o nome do arquivo"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Quando linkar arquivos, adicione o nome do arquivo …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "sempre"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "somente quando linkar usando a ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "nunca"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Inicia uma busca ao percorrer links Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Criar arquivos inexistentes automaticamente ao clicar em links internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Desabilitar Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Desabilitar Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Desabilitar Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Substituir arquivo"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtro ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Modo editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Localizar na pasta"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ocultar caracteres de cabeçalho"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Renderizar ênfase"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Verifique problemas de estilo no Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Habilitar editor de tabela"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Esmaecer linhas não focadas no modo sem distrações"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Contagem de palavras"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Contar caracteres em vez de palavras (por exemplo, para chinês)"
-
-#: source/win-preferences/schema/editor.ts:195
-#, fuzzy
-msgid "Readability mode"
-msgstr "Modo de legibilidade (%s)"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Largura máxima das imagens (porcentagem)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Altura máxima das imagens (porcentagem)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Esta relação é baseada em %s tags compartilhadas: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Outros arquivos"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Tamanho da fonte do editor"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Indentar com o seguinte número de espaços"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Usar \"tab\" para mudar o recuo"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Aceitar espaços durante o autocompletar"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Mostrar previsão de links"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Fechar automaticamente pares de caracteres correspondentes"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Agendar"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Desativado"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Seguir Sistema Operacional"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Mostrar barra de status"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Abrir pasta"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-#, fuzzy
-msgid "LanguageTool"
-msgstr "Use a ferramente de idioma"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Nenhum outro arquivo"
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Rigor"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Padrão"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Exigente"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referências"
 
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Não há citações neste documento."
 
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Provedor de ferramenta de idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Servidor personalilzado"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Servidor personalilzado"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-#, fuzzy
-msgid "LanguageTool Premium"
-msgstr "Provedor de ferramenta de idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Usuário da ferramenta de idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "Chave API da ferramenta de idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Ações"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Language"
-msgstr "Provedor de ferramenta de idioma"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Selecione os idiomas para os quais deseja ativar a verificação ortográfica "
-"automática."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Dicionário do usuário. Remova as palavras clicando nelas."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Verbete do dicionário"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Busque por itens ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Exibir botão de imagem"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Mostrar informações do arquivo"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Mostrar pastas no topo da lista antes dos arquivos"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Apenas nome do arquivo"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Título se aplicável"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Caso aplicável, primeiro título no nível 1"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Caso aplicável, título ou primeiro título de nível 1"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Mostrar as extensões do arquivo Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Horário da última modificação"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Hora de criação do arquivo"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exportar..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Documentos recentes"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordem natural (10 após 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Ordem ASCII (2 após 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Exportando para %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Use o Pandoc interno para exportar"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Remova as tags do arquivos"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Remova completamente os links internos."
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Desligue os links internos."
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Não mexa nos links internos."
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Mostrar informações do arquivo"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Exibir botão de imagem"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Comentário"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Padrão para novos nomes de arquivos"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Padrão para novos nomes de arquivos"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Não perguntar pelo nome do arquivo quando criá-lo"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Usar aparência de janela nativa"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Usar aparência de janela nativa"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Mostrar o programa na área de notificações"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Deixe o aplicativo em execução na área de notificação"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportamento do zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "O zoom redimensiona a interface completa"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Aplicar zoom altera o tamanho da fonte no editor de texto"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Permitir renderização de iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Nome do host"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Monitorar alteração em arquivos"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Tempo de espera antes de considerar mudanças como finalizadas (em ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Apagar arquivo"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Ativar modo de depuração"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Ativar modo de depuração"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notificar sobre versões beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Idioma do aplicativo"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Salvar automaticamente"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Horário da última modificação"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Imediatamente"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Após um breve atraso"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Comportamento do zoom"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Evite abrir arquivos em novas guias, se possível"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Atualizador"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Verificar atualizações automaticamente"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Nova atualização disponível"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Sua versão"
+
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
 msgstr ""
-"Como você gostaria que o preenchimento automático inserisse suas citações?"
+"Existe uma nova versão do Zettlr disponível para download. Por favor, leia o "
+"changelog abaixo."
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Baixando a atualização"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Não existem atualizações. Você já possui a versão mais recente."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Clique para atualizar"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Adicionar ao arquivo"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Iniciando a atualização"
 
 #~ msgid "Open Link"
 #~ msgstr "Abrir Link"

--- a/static/lang/pt-PT.po
+++ b/static/lang/pt-PT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Não foi possível carregar a base de dados de citações"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Foram detectadas alterações ao ficheiro de biblioteca. Recarregando..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Áreas de Trabalho"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,150 +82,6 @@ msgstr "A opção %s tem de ter pelo menos %s (número de caracteres)"
 msgid "Option %s is required."
 msgstr "A opção %s é obrigatória."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Mostrar Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Sair"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Está disponível uma atualização para a versão %s"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há actualizações: Server Error (Status code: "
-"%s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há actualizações: Client Error (Status code: "
-"%s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Não foi possível verificar se há actualizações: O servidor tentou "
-"redireccionar o pedido (Status code: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr ""
-"Não foi possível verificar se há actualizações: Não foi possível estabelecer "
-"ligação"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Não foi possível verificar actualizações. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Não foi possível verificar se há actualizações: O servidor não enviou "
-"quaisquer dados"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Não foi possível criar o ficheiro"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "A refrência com a chave %s aparenta não ter anexos."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Não foi possível abrir o anexo. O Zotero está aberto?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -229,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Apagar mesmo?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Tem a certeza que quer remover %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "A refrência com a chave %s aparenta não ter anexos."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Não foi possível abrir o anexo. O Zotero está aberto?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Textbundle mal formatado: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Exportar Projecto"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exportar..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -303,48 +247,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Exportação falhou"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Exportar Projecto"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exportar..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Não é possível mover a pasta"
@@ -362,28 +264,49 @@ msgstr "Não é possível mover o ficheiro ou pasta"
 msgid "The file/directory %s already exists in target."
 msgstr "O ficheiro/pasta %s já existe no destino."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Sem título"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "O nome introduzido não contém nenhuma letra autorizada."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Não foi possível criar a pasta"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "A pasta especificada não foi encontrada."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Apagar mesmo?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Exportação falhou"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Ocorreu um erro ao exportar: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Guardar"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Tem a certeza que quer remover %s?"
+msgid "Exporting to %s"
+msgstr "Exportando para %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Ocorreu um erro ao exportar: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -408,10 +331,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -425,127 +350,34 @@ msgstr "Ficheiro de idioma importado: %s"
 msgid "Could not import language file %s!"
 msgstr "Não foi possível importar ficheiro de idioma %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Exportação falhou"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Não foi possível criar o ficheiro"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Ocorreu um erro ao exportar: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
+#, javascript-format
+msgid "Copy of %s"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Guardar"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Sem título"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Não foi possível criar a pasta"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exportando para %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Ocorreu um erro ao exportar: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "O nome introduzido não contém nenhuma letra autorizada."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "A pasta especificada não foi encontrada."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Textbundle mal formatado: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Carregar sempre modificações externas ao ficheiro actual"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Reescrever ficheiro existente"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "O ficheiro %s já existe nesta pasta. Escrever por cima?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Abrir ficheiro"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Modificações não gravadas"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Há alterações não guardadas no ficheiro actual. Quer apagá-las ou guardar?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Guardar ficheiro"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Abrir pasta de projecto"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Não foi possível carregar a base de dados de citações"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Foram detectadas alterações ao ficheiro de biblioteca. Recarregando..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -657,6 +489,12 @@ msgstr "Mudar o nome do ficheiro"
 msgid "Delete file"
 msgstr "Apagar ficheiro"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Sair"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -675,15 +513,15 @@ msgstr "Refazer"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Cortar"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copiar"
 
@@ -695,8 +533,8 @@ msgstr "Copiar como HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Colar"
 
@@ -708,8 +546,8 @@ msgstr "Colar sem formatação"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Seleccionar tudo"
 
@@ -952,10 +790,172 @@ msgstr "Parar de falar"
 msgid "Bring All to Front"
 msgstr "Trazer todos para a frente"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Áreas de Trabalho"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Abrir pasta de projecto"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Carregar sempre modificações externas ao ficheiro actual"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Modificações não gravadas"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Há alterações não guardadas no ficheiro actual. Quer apagá-las ou guardar?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Abrir ficheiro"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Guardar ficheiro"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Reescrever ficheiro existente"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "O ficheiro %s já existe nesta pasta. Escrever por cima?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Mostrar Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Está disponível uma atualização para a versão %s"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há actualizações: Server Error (Status code: "
+"%s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há actualizações: Client Error (Status code: "
+"%s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Não foi possível verificar se há actualizações: O servidor tentou "
+"redireccionar o pedido (Status code: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr ""
+"Não foi possível verificar se há actualizações: Não foi possível estabelecer "
+"ligação"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Não foi possível verificar actualizações. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Não foi possível verificar se há actualizações: O servidor não enviou "
+"quaisquer dados"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -973,143 +973,1198 @@ msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr ""
 "Há alterações não guardadas no ficheiro actual. Quer apagá-las ou guardar?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Modo de gestão de ficheiros"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Ligar a Correcção Automática"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Propriedades"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicar ficheiro"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Copiar ID"
+msgid "Double Quotes"
+msgstr "Nenhuma"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copiar nome do ficheiro"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Nenhuma"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Nenhuma"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Substituir ficheiro"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtro ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Horário"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Desligada"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Acompanhar o sistema operativo"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Iniciar"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Mostrar Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personalizado"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Abrir pasta"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Exportando para %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Usar o Pandoc interno para exportar"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Remover etiquetas dos ficheiros"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Desligar (unlink) os links internos"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Remover links internos completamente"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Desligar (unlink) os links internos"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Não alterar os links internos"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Mostrar informação de ficheiro"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Comentário"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Padrão para novos nomes de ficheiro"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Padrão para novos nomes de ficheiro"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Não perguntar pelo nome do ficheiro ao criar um novo ficheiro"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Usar aspecto nativo para as janelas"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Usar aspecto nativo para as janelas"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Mostrar a aplicação na área de notificações"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Deixar a aplicação a correr na área de notificações"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Comportamento do zoom"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Fazer zoom altera o tamanho de todo o interface"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Fazer zoom altera o tamanho da letra do editor"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Permissões de renderização de iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Servidor"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Activar monitorização de mudanças externas"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Tempo de espera até a gravação do ficheiro estar concluída (em ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Apagar ficheiro"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Ligar modo debug"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Ligar modo debug"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Notifique-me de actualizações beta"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Modo de introdução do editor"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Localizar na pasta"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ocultar caracteres de cabeçalho"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Lembrar ênfase"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Negrito"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Itálico"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Activar Editor de Tabelas"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Esbater linhas não seleccionadas no modo Concentração"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Contagem de palavras"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Contar caracteres em vez de palavras (em Chinês, p. ex.)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Imagem"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Largura máxima das imagens (percentagem)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Altura máxima das imagens (percentagem)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Outros ficheiros"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Editor de tamanho de fonte"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Indentar com o seguinte número de espaços"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Indentar usando tabs"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Aceitar espaços para completar automaticamente"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Fechar automaticamente pares de caracteres compatíveis"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Modo escuro"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Mostrar informação de ficheiro"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Mostrar directórios acima de ficheiros"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Apenas o nome do ficheiro"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Título, se aplicável"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Primeiro cabeçalho de nível 1, se aplicável"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Título ou primeiro cabeçalho de nível 1, se aplicável"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Mostrar a extensão de ficheiros Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Data da última modificação"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Data de criação do ficheiro"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exportar..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Documentos recentes"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordem natural (10 depois do 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Ordem ASCII (2 depois do 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Mostrar Citações"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Qual o comportamento do preenchimento automático de citações?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Adicionar ao ficheiro"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Padrão usado para gerar IDs novas"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Expressão regular ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Padrão usado para gerar IDs novas"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Apenas o nome do ficheiro"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Quando ligar um ficheiro, adicionar o nome ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "sempre"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "apenas ao ligar usando uma ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "nunca"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Iniciar uma pesquisa ao seguir links Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Criar automaticamente ficheiros não existentes ao seguir links internos"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Calendário"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "CSS personalizado"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "CSS personalizado"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Ações"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Código"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Escolha as línguas para as quais quer activar a correcção ortográfica "
+"automática"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Dicionário do utilizador. Remova palavras clicando nelas."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Entrada do dicionário"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Procurar entradas ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Gravação automática"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Data da última modificação"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Imediata"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Após uma breve pausa"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Comportamento do zoom"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Se possível evitar abrir ficheiros em novas abas"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Atualizador"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Verificar atualizações automáticamente"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s caracteres"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s palavras"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "CSS personalizado"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Não foi possível criar o ficheiro"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Contagem de palavras"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Modificado"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Abrir..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Abrir num novo separador"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Imagem"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Comentário"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Copiar código da equação"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Copiar imagem para a área de transferência"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Abrir ficheiro"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Abrir no navegador"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Sem sugestões"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Adicionar ao dicionário"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Itálico"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Inserir link"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Inserir lista não ordenada"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Inserir lista numerada"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Fechar ficheiro"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Mudar o nome da pasta"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Apagar pasta"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Verificar a pasta..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportar Projecto"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Fechar outros separadores"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Fechar todos os separadores"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1541,327 +2596,322 @@ msgstr "Chinês (China)"
 msgid "Chinese"
 msgstr "Chinês (China)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Propriedades"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicar ficheiro"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "CSS personalizado"
+msgid "Copy path"
+msgstr "Copiar ID"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s palavras"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copiar nome do ficheiro"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s caracteres"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Fechar ficheiro"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Mudar o nome da pasta"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Apagar pasta"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Verificar a pasta..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportar Projecto"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Fechar outros separadores"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Fechar todos os separadores"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Negrito"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Itálico"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Imagem"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Comentário"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Código"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Calendário"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Gráficos"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Contagem de palavras"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Modificado"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Abrir..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Abrir num novo separador"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Janeiro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Fevereiro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Março"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Abril"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maio"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Junho"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Julho"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Agosto"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Setembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Outubro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Novembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Dezembro"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Abaixo da média mensal"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Acima da média mensal"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Mais do dobro da média mensal"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Copiar imagem para a área de transferência"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Abrir ficheiro"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Abrir no navegador"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Sem sugestões"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Adicionar ao dicionário"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Itálico"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Inserir link"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Inserir lista não ordenada"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Inserir lista numerada"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Copiar código da equação"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Não foi possível criar o ficheiro"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Atualizador"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Há uma actualização disponível"
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "A sua versão"
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Há uma nova versão do Zettlr disponível. Por favor consulta a lista de "
-"modificações abaixo."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Descarregando atualização"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Nenhuma atualização disponível. Tem a versão mais recente."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Clique para iniciar actualização"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "A Iniciar atualização ..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Procurar"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrar etiquetas..."
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Reset"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Abrir pasta de projecto"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Apagar ficheiro"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Adicionar"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Ações"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Apagar ficheiro"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Imagem"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1878,10 +2928,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1944,46 +2990,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr também utiliza estes projetos:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Aqui pode substituir os estilos do Zettlr para personalizá-lo ainda mais. "
-"<strong>Atenção: Este ficheiro substitui todas as directivas CSS! Nunca "
-"altere a geometria dos elementos, caso contrário, a aplicação poderá "
-"apresentar comportamentos indesejados!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Renomear snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Snippets permitem-lhe definir pequenos trechos de texto com variáveis"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Gravando ..."
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Falha ao gravar"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personalizado"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Gravado!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -2006,39 +3034,78 @@ msgid "Edit the default settings for imports or exports here."
 msgstr ""
 "Editar as definições pré-definidas para importações ou exportações aqui"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Gravado!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Renomear snippet"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Snippets permitem-lhe definir pequenos trechos de texto com variáveis"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "palavras"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caracteres"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Aqui pode substituir os estilos do Zettlr para personalizá-lo ainda mais. "
+"<strong>Atenção: Este ficheiro substitui todas as directivas CSS! Nunca "
+"altere a geometria dos elementos, caso contrário, a aplicação poderá "
+"apresentar comportamentos indesejados!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Nenhum documento aberto"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Falha ao gravar"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Iniciar"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrar etiquetas..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2064,76 +3131,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "palavras o mês passado"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Ficheiros relacionados"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "Média diária"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Nenhum ficheiro relacionado"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "palavras hoje"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Até o teclado fumega!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Está perto de atingir a sua média diária!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Toca a escrever para atingir a sua média diária."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Mais estatísticas..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Outros ficheiros"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Abrir pasta"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Nenhum outro ficheiro"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referências"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Não há citações neste documento."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Nuvem de etiquetas"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Exportar..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Exportar..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2143,8 +3250,8 @@ msgstr "Pastas"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Ficheiros"
 
@@ -2158,10 +3265,26 @@ msgstr "Caracteres"
 msgid "Words"
 msgstr "Palavras"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Áreas de Trabalho"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Sem pastas ou ficheiros aberto"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Sem resultados"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nenhuma pasta seleccionada"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Pasta vazia"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2191,15 +3314,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Reset"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2260,13 +3374,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Calendário"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2476,131 +3583,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Escolher objectivo de escrita..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Sem resultados"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nenhuma pasta seleccionada"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Pasta vazia"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Áreas de Trabalho"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Sem pastas ou ficheiros aberto"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "palavras o mês passado"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "Média diária"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "palavras hoje"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Até o teclado fumega!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Está perto de atingir a sua média diária!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Toca a escrever para atingir a sua média diária."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Mais estatísticas..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Exportar..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Exportar..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2623,11 +3608,6 @@ msgstr "Restringir a pesquisa à pasta"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Procurar"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Limpar pesquisa"
@@ -2641,1111 +3621,137 @@ msgstr "Alternar vista de resultados"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Nuvem de etiquetas"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "palavras"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caracteres"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Nenhum documento aberto"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Ficheiros relacionados"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Nenhum ficheiro relacionado"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Adicionar"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Ações"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Apagar ficheiro"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Abrir pasta de projecto"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Apagar ficheiro"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Ligar a Correcção Automática"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Mostrar Citações"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Janeiro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Fevereiro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Março"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Abril"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maio"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Junho"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Julho"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Agosto"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Setembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Outubro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Novembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Dezembro"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Abaixo da média mensal"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Acima da média mensal"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Mais do dobro da média mensal"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Gráficos"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Padrão usado para gerar IDs novas"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Expressão regular ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Padrão usado para gerar IDs novas"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Desligar (unlink) os links internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Apenas o nome do ficheiro"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Quando ligar um ficheiro, adicionar o nome ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "sempre"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "apenas ao ligar usando uma ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "nunca"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Iniciar uma pesquisa ao seguir links Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Criar automaticamente ficheiros não existentes ao seguir links internos"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Nenhuma"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Nenhuma"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Nenhuma"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Substituir ficheiro"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtro ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Modo de introdução do editor"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Localizar na pasta"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ocultar caracteres de cabeçalho"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Lembrar ênfase"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Activar Editor de Tabelas"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Esbater linhas não seleccionadas no modo Concentração"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Contagem de palavras"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Contar caracteres em vez de palavras (em Chinês, p. ex.)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Largura máxima das imagens (percentagem)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Altura máxima das imagens (percentagem)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Outros ficheiros"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Editor de tamanho de fonte"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Indentar com o seguinte número de espaços"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Indentar usando tabs"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Aceitar espaços para completar automaticamente"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Fechar automaticamente pares de caracteres compatíveis"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Horário"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Desligada"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Acompanhar o sistema operativo"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Mostrar Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Abrir pasta"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Nenhum outro ficheiro"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Calendário"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referências"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Não há citações neste documento."
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "CSS personalizado"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "CSS personalizado"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Ações"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Escolha as línguas para as quais quer activar a correcção ortográfica "
-"automática"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Dicionário do utilizador. Remova palavras clicando nelas."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Entrada do dicionário"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Procurar entradas ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Modo escuro"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Mostrar informação de ficheiro"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Mostrar directórios acima de ficheiros"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Apenas o nome do ficheiro"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Título, se aplicável"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Primeiro cabeçalho de nível 1, se aplicável"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Título ou primeiro cabeçalho de nível 1, se aplicável"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Mostrar a extensão de ficheiros Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Data da última modificação"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Data de criação do ficheiro"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exportar..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Documentos recentes"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordem natural (10 depois do 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Ordem ASCII (2 depois do 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Exportando para %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Usar o Pandoc interno para exportar"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Remover etiquetas dos ficheiros"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Remover links internos completamente"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Desligar (unlink) os links internos"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Não alterar os links internos"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Mostrar informação de ficheiro"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Comentário"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Padrão para novos nomes de ficheiro"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Padrão para novos nomes de ficheiro"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Não perguntar pelo nome do ficheiro ao criar um novo ficheiro"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Usar aspecto nativo para as janelas"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Usar aspecto nativo para as janelas"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Mostrar a aplicação na área de notificações"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Deixar a aplicação a correr na área de notificações"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Comportamento do zoom"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Fazer zoom altera o tamanho de todo o interface"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Fazer zoom altera o tamanho da letra do editor"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Permissões de renderização de iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Servidor"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Activar monitorização de mudanças externas"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Tempo de espera até a gravação do ficheiro estar concluída (em ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Apagar ficheiro"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Ligar modo debug"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Ligar modo debug"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Notifique-me de actualizações beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Gravação automática"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Data da última modificação"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Imediata"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Após uma breve pausa"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Comportamento do zoom"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Se possível evitar abrir ficheiros em novas abas"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Atualizador"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Verificar atualizações automáticamente"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Há uma actualização disponível"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Qual o comportamento do preenchimento automático de citações?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "A sua versão"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Há uma nova versão do Zettlr disponível. Por favor consulta a lista de "
+"modificações abaixo."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Descarregando atualização"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Nenhuma atualização disponível. Tem a versão mais recente."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Clique para iniciar actualização"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Adicionar ao ficheiro"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "A Iniciar atualização ..."
 
 #~ msgid "Open Link"
 #~ msgstr "Abrir Link"

--- a/static/lang/ro-RO.po
+++ b/static/lang/ro-RO.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Baza de date ce conține căutările nu poate fi încărcată."
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Au fost detectate schimbări în fișierul bibliotecă. Repornire..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr ""
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,142 +81,6 @@ msgstr "Opțiunea %s trebuie să aibă cel puțin %s caractere."
 msgid "Option %s is required."
 msgstr "Opțiunea %s este necesară."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr ""
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Renunță"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Nu am putut verifica actualizările: Eroare de server (cod %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Nu am putut verifica actualizările: Eroare client (cod %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Nu am putut verifica actualizările: Serverul a încercat o redirecționare "
-"(cod %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Nu am putut verifica actualizările: Nu s-a putut realiza o conexiune"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Nu am putut verifica actualizările: Serverul nu a trimis date."
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Fișierul nu a putut fi creat"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Referința notată cu %s nu pare să aibă fișiere atașate"
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Nu am reușit să deschid fișierul atașat. Este Zotero pornit?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -220,24 +98,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Anulează"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Ești sigur că vrei să ștergi?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Vrei cu-adevărat să ștergi %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Referința notată cu %s nu pare să aibă fișiere atașate"
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Nu am reușit să deschid fișierul atașat. Este Zotero pornit?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Textbundle incorect: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Exportă proiectul"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exportă..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -294,48 +246,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Procesul de exportare a eșuat"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Exportă proiectul"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exportă..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Dosarul nu poate fi mutat"
@@ -353,28 +263,49 @@ msgstr "Dosarul sau fișierul nu pot fi mutate"
 msgid "The file/directory %s already exists in target."
 msgstr "Fișierul/Dosarul %s există deja"
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Fără nume"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Numele furnizat nu conține nici un caracter permis"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Dosarul nu a putut fi creat"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Dosarul solicitat nu a fost găsit"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Ești sigur că vrei să ștergi?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Procesul de exportare a eșuat"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "O eroare a apărut cînd s-a încercat exportarea: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Salvează"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Vrei cu-adevărat să ștergi %s?"
+msgid "Exporting to %s"
+msgstr "Export în %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "O eroare a apărut cînd s-a încercat exportarea: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -399,10 +330,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -416,128 +349,34 @@ msgstr "Fișierul pentru limba %s a fost importat"
 msgid "Could not import language file %s!"
 msgstr "Fișierul pentru limba %s nu a putut fi importat"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Procesul de exportare a eșuat"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Fișierul nu a putut fi creat"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "O eroare a apărut cînd s-a încercat exportarea: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Salvează"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Export în %s"
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Fără nume"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Dosarul nu a putut fi creat"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "O eroare a apărut cînd s-a încercat exportarea: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Numele furnizat nu conține nici un caracter permis"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Dosarul solicitat nu a fost găsit"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Textbundle incorect: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Încarcă întotdeauna modificările de la distanță pentru fișierul curent"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Suprascriu fișier deja existent"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Acest fișier există deja în dosar. Suprascriu?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr ""
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Există modificări nesalvate pentru fișierul curent. Vrei să le omiți ori să "
-"le salvezi?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Deschide dosarul proiect"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Baza de date ce conține căutările nu poate fi încărcată."
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Au fost detectate schimbări în fișierul bibliotecă. Repornire..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -649,6 +488,12 @@ msgstr "Redenumește fișierul"
 msgid "Delete file"
 msgstr "Șterge fișierul"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Renunță"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -667,15 +512,15 @@ msgstr "Refă"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Taie"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Copiază"
 
@@ -687,8 +532,8 @@ msgstr "Copiază ca HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Lipește"
 
@@ -700,8 +545,8 @@ msgstr "Lipește fără a păstra stilul"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Selectează tot"
 
@@ -943,9 +788,164 @@ msgstr "Oprește lectura"
 msgid "Bring All to Front"
 msgstr "Toate în prim-plan"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Deschide dosarul proiect"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Încarcă întotdeauna modificările de la distanță pentru fișierul curent"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Există modificări nesalvate pentru fișierul curent. Vrei să le omiți ori să "
+"le salvezi?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Suprascriu fișier deja existent"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Acest fișier există deja în dosar. Suprascriu?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr ""
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Nu am putut verifica actualizările: Eroare de server (cod %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Nu am putut verifica actualizările: Eroare client (cod %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Nu am putut verifica actualizările: Serverul a încercat o redirecționare "
+"(cod %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Nu am putut verifica actualizările: Nu s-a putut realiza o conexiune"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Nu am putut verifica actualizările: Serverul nu a trimis date."
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
 msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
@@ -965,142 +965,1173 @@ msgstr ""
 "Există modificări nesalvate pentru fișierul curent. Vrei să le omiți ori să "
 "le salvezi?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
-msgstr ""
-
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr ""
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Fișier duplicat"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
 #, fuzzy
-msgid "Copy path"
-msgstr "Copiază ID"
+msgid "Autocorrect"
+msgstr "Activează Corectorul automat"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Copiază numele fișierului"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr ""
 
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Nici unul"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Nici unul"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Nici unul"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Înlocuiește fișierul"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtrează etichetele..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Programează"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Anulează"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Folosește setările sistemului de operare"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "CSS personalizat"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Deschide dosarul"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Export în %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Șterge etichetele din fișiere"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Elimină legăturile interne"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Șterge definitiv legăturile interne"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Elimină legăturile interne"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Nu modifica legăturile interne"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Arată informațiile fișierului"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Cometariu"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Șablon pentru nume fișiere noi"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Șablon pentru nume fișiere noi"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Nu cere nume fișier când se creează fișiere noi"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Șterge fișierul"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Activează modulul dezvoltator"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Activează modulul dezvoltator"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Informează-mă despre versiunile beta disponibile"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Găsește dosarul"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Vizualizare #"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Aldin"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Cursiv"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Permite editorul de tabele"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Ascunde liniile inactive în modul fără abaterea atenției"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Numără caractere, în loc de cuvinte (e.g. pentru limba chineză)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Imagine"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Separa cu următorul număr de caractere"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Separa cu următorul număr de caractere"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Închise automat perechile de caractere"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Arată informațiile fișierului"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Timpul ultimei modificări"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Timpul de creare a fișierului"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exportă..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Documente recente"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Ordine naturală (10 după 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Ordine ASCII (2 după 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Vizualizare citări"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Arată fișierul"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Model folosit pentru generarea de noi ID-uri"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Expresie regulată ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Model folosit pentru generarea de noi ID-uri"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr ""
+"Atunci când sunt incluse link-uri către alte fișiere, include numele "
+"fișierului..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "De fiecare dată"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "Doar când se folosesc link-uri cu ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "Niciodată"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "CSS personalizat"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "CSS personalizat"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Cod"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Selectează limba pentru care vrei să activezi corectura ortografică."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Dicționarul utilizatorului. Eliminați cuvinte apăsîndu-le"
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Timpul ultimei modificări"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "cuvinte"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "CSS personalizat"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Fișierul nu a putut fi creat"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Deschide"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Legătură"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Imagine"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Cometariu"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Deschide legătura"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Fără sugestii"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Adaugă în dicționar"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Cursiv"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Introdu o legătură"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Introdu o listă neordonată"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Introdu o listă ordonată"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Închide fișierul"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Redenumește dosarul"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Șterge dosarul"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Cautare dosar..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportă proiectul"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,326 +2563,322 @@ msgstr "Chineză"
 msgid "Chinese"
 msgstr "Chineză"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Fișier duplicat"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "CSS personalizat"
+msgid "Copy path"
+msgstr "Copiază ID"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "cuvinte"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Copiază numele fișierului"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Închide fișierul"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Redenumește dosarul"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Șterge dosarul"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Cautare dosar..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportă proiectul"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Aldin"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Cursiv"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Legătură"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Imagine"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Cometariu"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Cod"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Deschide"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Deschide legătura"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Fără sugestii"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Adaugă în dicționar"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Cursiv"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Introdu o legătură"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Introdu o listă neordonată"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Introdu o listă ordonată"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Fișierul nu a putut fi creat"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "O versiune nouă disponibilă"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Versiunea ta"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"O nouă versiune Zettlr este disponibilă pentru descărcare. Citește te rog "
-"fișierul cu istoricul modificărilor."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr ""
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrează etichetele..."
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Deschide dosarul proiect"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Șterge fișierul"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr ""
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Șterge fișierul"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Imagine"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1868,10 +2895,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1934,45 +2957,27 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr folosește de asemenea următoarele proiecte:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
 msgstr ""
-"Aici se pot modifica parametrii de stil ai aplicației Zettlr personalizîndu-"
-"l și mai mult. <strong>Atenție: Acest fișier șterge toate valorile CSS! Nu "
-"modifica geometria elemetentelor, în caz contrar aplicația poate prezenta un "
-"comportament nedorit!</strong>"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr ""
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "CSS personalizat"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
 msgstr ""
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
@@ -1995,39 +3000,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr ""
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Aici se pot modifica parametrii de stil ai aplicației Zettlr personalizîndu-"
+"l și mai mult. <strong>Atenție: Acest fișier șterge toate valorile CSS! Nu "
+"modifica geometria elemetentelor, în caz contrar aplicația poate prezenta un "
+"comportament nedorit!</strong>"
+
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
 msgstr ""
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "cuvinte"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "caractere"
-
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
 msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrează etichetele..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2053,76 +3097,114 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "cuvinte în ultima luna"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "media zilnică"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "cuvinte astăzi"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "Ai depășit media zilnică!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "Te apropii de media zilnică..."
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "Mai scrie ca să-ți depășești media zilnică!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Deschide dosarul"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Bibliografie"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Nu sînt citări în acest document"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Noianul de etichete"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2132,8 +3214,8 @@ msgstr "Dosare"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Fișiere"
 
@@ -2147,10 +3229,26 @@ msgstr "Caractere"
 msgid "Words"
 msgstr "Cuvinte"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
 msgstr ""
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Nu sînt fișiere ori dosare deschise"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Nici un rezultat"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Nici un dosar selectat"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Dosar gol"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2179,15 +3277,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
@@ -2248,13 +3337,6 @@ msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
-msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
 msgstr ""
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
@@ -2465,129 +3547,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Definește norma de scris"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Nici un rezultat"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Nici un dosar selectat"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Dosar gol"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr ""
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Nu sînt fișiere ori dosare deschise"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "cuvinte în ultima luna"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "media zilnică"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "cuvinte astăzi"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "Ai depășit media zilnică!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "Te apropii de media zilnică..."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "Mai scrie ca să-ți depășești media zilnică!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2610,11 +3572,6 @@ msgstr ""
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr ""
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr ""
@@ -2628,1087 +3585,136 @@ msgstr ""
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Noianul de etichete"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "cuvinte"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "caractere"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr ""
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Șterge fișierul"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Deschide dosarul proiect"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Șterge fișierul"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Activează Corectorul automat"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Vizualizare citări"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr ""
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Model folosit pentru generarea de noi ID-uri"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Expresie regulată ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Model folosit pentru generarea de noi ID-uri"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Elimină legăturile interne"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr ""
-"Atunci când sunt incluse link-uri către alte fișiere, include numele "
-"fișierului..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "De fiecare dată"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "Doar când se folosesc link-uri cu ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "Niciodată"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Nici unul"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Nici unul"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Nici unul"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Înlocuiește fișierul"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtrează etichetele..."
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Găsește dosarul"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Vizualizare #"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Permite editorul de tabele"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Ascunde liniile inactive în modul fără abaterea atenției"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Numără caractere, în loc de cuvinte (e.g. pentru limba chineză)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Separa cu următorul număr de caractere"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Separa cu următorul număr de caractere"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Închise automat perechile de caractere"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Programează"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Anulează"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Folosește setările sistemului de operare"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Deschide dosarul"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Bibliografie"
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Nu sînt citări în acest document"
 
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "CSS personalizat"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "CSS personalizat"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Selectează limba pentru care vrei să activezi corectura ortografică."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Dicționarul utilizatorului. Eliminați cuvinte apăsîndu-le"
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Arată informațiile fișierului"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Timpul ultimei modificări"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Timpul de creare a fișierului"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exportă..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Documente recente"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Ordine naturală (10 după 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Ordine ASCII (2 după 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Export în %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Șterge etichetele din fișiere"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Șterge definitiv legăturile interne"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Elimină legăturile interne"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Nu modifica legăturile interne"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Arată informațiile fișierului"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Cometariu"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Șablon pentru nume fișiere noi"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Șablon pentru nume fișiere noi"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Nu cere nume fișier când se creează fișiere noi"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "O versiune nouă disponibilă"
 
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Versiunea ta"
 
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Șterge fișierul"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Activează modulul dezvoltator"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Activează modulul dezvoltator"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Informează-mă despre versiunile beta disponibile"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Timpul ultimei modificări"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"O nouă versiune Zettlr este disponibilă pentru descărcare. Citește te rog "
+"fișierul cu istoricul modificărilor."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Arată fișierul"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
 msgstr ""
 
 #~ msgid "Open Link"

--- a/static/lang/ru-RU.po
+++ b/static/lang/ru-RU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2023-08-10 16:49+0500\n"
 "Last-Translator: Dmitriy K <dmitry@atsip.ru>\n"
 "Language-Team: \n"
@@ -16,6 +16,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "База данных цитат не может быть загружена"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Обнаружены изменения в файле библиотеки. Обновление …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Загрузка рабочего пространства %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,142 +81,6 @@ msgstr "Значение %s должно быть не меньше %s симв�
 msgid "Option %s is required."
 msgstr "Значение %s должно быть установлено."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Показать Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Выход"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Доступно обновление"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Доступно обновление до версии %s!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Ошибка проверки обновления: ошибка сервера (код статуса: %s)."
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Ошибка проверки обновления: ошибка клиента (код статуса: %s)."
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Невозможно проверить наличие обновлений: попытка перенаправления соединения "
-"(код ошибки: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Невозможно проверить наличие обновлений: ошибка подключения"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Проверка обновлений не удалась. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Невозможно проверить наличие обновлений: не получен ответ от сервера"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Слишком длинный документ"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "оффлайн"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Невозможно создать файл"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Ссылка с ключом %s не имеет вложений."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Не удалось открыть вложение. Запущен ли Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -220,24 +98,103 @@ msgstr "Да"
 msgid "No"
 msgstr "Нет"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Заменить тег \"%s\" на \"%s\" в %s файлах?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Принять"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Отменить"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Действительно удалить?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Вы действительно хотите удалить %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Ссылка с ключом %s не имеет вложений."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Не удалось открыть вложение. Запущен ли Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Некорректная текстовая связка: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Выберите профиль импорта"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+"Существует несколько профилей, которые могут импортировать %s. Пожалуйста, "
+"выберите один."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Невозможно экспортировать проект"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"Для экспорта не выбрано ни одного файла. Пожалуйста, выберите файлы, которые "
+"будут включены  в настройках проекта."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Несовпадение файлов проекта"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Один или несколько файлов, указанных в настройках проекта, не найдены. "
+"Возможно, они переместились или были удалены. Убедитесь, что все файлы, "
+"которые вы хотели бы экспортировать, включены."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Проект \"%s\" успешно экспортирован. Нажмите, чтобы показать."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Экспорт проектов"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -291,51 +248,6 @@ msgstr "Файл %s не может быть импортирован, так к
 msgid "Import failed"
 msgstr "Импорт не удался"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Невозможно экспортировать проект"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"Для экспорта не выбрано ни одного файла. Пожалуйста, выберите файлы, которые "
-"будут включены  в настройках проекта."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Несовпадение файлов проекта"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Один или несколько файлов, указанных в настройках проекта, не найдены. "
-"Возможно, они переместились или были удалены. Убедитесь, что все файлы, "
-"которые вы хотели бы экспортировать, включены."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Принять"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Проект \"%s\" успешно экспортирован. Нажмите, чтобы показать."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Экспорт проектов"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Невозможно переместить директорию"
@@ -353,28 +265,49 @@ msgstr "Ошибка перемещения"
 msgid "The file/directory %s already exists in target."
 msgstr "Файл/директория %s уже существует."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Без названия"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Указанное имя не содержит разрешенных символов."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Невозможно создать директорию"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Запрашиваемый каталог не найден."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Действительно удалить?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Экспорт не удался"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Вы действительно хотите удалить %s?"
+msgid "An error occurred during export: %s"
+msgstr "Во время экспорта произошла ошибка: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Выберите назначение экспорта"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Сохранить изменения"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Экспорт в %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Во время экспорта произошла ошибка: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -399,11 +332,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Скопировать из %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Слишком длинный документ"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "оффлайн"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -416,130 +351,34 @@ msgstr "Языковой файл %s импортирован"
 msgid "Could not import language file %s!"
 msgstr "Ошибка импорта файла перевода %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Экспорт не удался"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Невозможно создать файл"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Во время экспорта произошла ошибка: %s"
+msgid "Copy of %s"
+msgstr "Скопировать из %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Выберите назначение экспорта"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Без названия"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Сохранить изменения"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Невозможно создать директорию"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Экспорт в %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Во время экспорта произошла ошибка: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Указанное имя не содержит разрешенных символов."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Запрашиваемый каталог не найден."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Выберите профиль импорта"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-"Существует несколько профилей, которые могут импортировать %s. Пожалуйста, "
-"выберите один."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Некорректная текстовая связка: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Заменить файл"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Файл %s был изменен удаленно. Заменить загруженную версию на более новую с "
-"диска?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Всегда перезагружать файл, в случае изменения извне"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Заменить существующий файл"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Файл %s уже существует в этой директории. Заменить файл?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Открыть файл"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Несохраненные изменения"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Текущий файл содержит несохранённые изменения. Хотите сперва сохранить их?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Сохранить файл"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Открыть папку проекта"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "База данных цитат не может быть загружена"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Обнаружены изменения в файле библиотеки. Обновление …"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Заменить тег \"%s\" на \"%s\" в %s файлах?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -651,6 +490,12 @@ msgstr "Переименовать файл"
 msgid "Delete file"
 msgstr "Удалить файл"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Выход"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -669,15 +514,15 @@ msgstr "Повтор"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Вырезать"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Скопировать"
 
@@ -689,8 +534,8 @@ msgstr "Копировать как HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Вставить"
 
@@ -702,8 +547,8 @@ msgstr "Вставить только текст"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Выделить всё"
 
@@ -946,10 +791,165 @@ msgstr "Остановить речь"
 msgid "Bring All to Front"
 msgstr "На передний план"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Открыть папку проекта"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Заменить файл"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Загрузка рабочего пространства %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Файл %s был изменен удаленно. Заменить загруженную версию на более новую с "
+"диска?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Всегда перезагружать файл, в случае изменения извне"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Несохраненные изменения"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Текущий файл содержит несохранённые изменения. Хотите сперва сохранить их?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Открыть файл"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Сохранить файл"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Заменить существующий файл"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Файл %s уже существует в этой директории. Заменить файл?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Показать Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Доступно обновление"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Доступно обновление до версии %s!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Ошибка проверки обновления: ошибка сервера (код статуса: %s)."
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Ошибка проверки обновления: ошибка клиента (код статуса: %s)."
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Невозможно проверить наличие обновлений: попытка перенаправления соединения "
+"(код ошибки: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Невозможно проверить наличие обновлений: ошибка подключения"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Проверка обновлений не удалась. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Невозможно проверить наличие обновлений: не получен ответ от сервера"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -963,16 +963,16 @@ msgstr "Отменить изменения"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Есть несохраненные изменения. Вы хотите сохранить или отменить их?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "Файл изменен на диске"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s изменено на диске"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -981,128 +981,1154 @@ msgstr ""
 "%s изменился на диске, но редактор содержит несохраненные изменения. Хотите "
 "ли вы сохранить текущее содержимое редактора или загрузить файл с диска?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Вы хотите сохранить текущее содержимое редактора или загрузить файл с диска?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Сохраните содержимое редактора"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Загрузка изменений с диска"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Всегда загружайте изменения с диска, если в редакторе нет несохраненных "
 "изменений"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Не удалось сохранить файл"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Не удалось сохранить файл %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Автокоррекция"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Умные цитаты"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Двойные кавычки"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Отключить Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Одиночные кавычки"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Шаблоны замены текста"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Сопоставить целые слова"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "Если выбрано - автокоррекция никогда не будет заменять части слов"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Заменить"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "С"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Фильтр"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Расписание"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Выкл"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Система слежения"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Вкл"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Пуск"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Конец"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Тема"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Параметры панели инструментов"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Настройки"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Создать дубликат файла"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Путь копирования"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Копировать файл"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Статус бар"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Собственная CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Открыть редактор CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Импорт и экспорт профилей"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Откройте редактор профилей импорта"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Откройте редактор профилей экспорта"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Настройки экспорта"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Используйте внутренний Pandoc от Zettlr для экспорта."
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Удаление тегов из файлов при экспорте"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Внутренние ссылки"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Удалить внутренние ссылки полностью"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Расцепить внутренние ссылки"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Не трогать внутренние ссылки"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Папка назначения для экспортированных файлов"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Временная папка"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "То же, что и расположение файла"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Запрос папки при экспорте"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Внимание! Файлы во временной папке регулярно удаляются. Выбор то же место, "
+"что и файл, перезаписывает файлы с идентичными именами, если они уже "
+"существуют."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Пользовательские команды экспорта"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Отображаемое имя"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Комманда"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Введите пользовательские команды для запуска экспортера. Каждая команда "
+"получает в качестве первого аргумента файл или каталог проекта, который "
+"необходимо экспортировать."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Шаблон для новых имен файлов"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Определите шаблон для имен новых файлов"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Доступные переменные: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Не запрашивать имя файла при его создании"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Внешний вид"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Использовать вид окна по умолчанию"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+"Доступно только в Linux; для macOS и Windows оно используется по умолчанию."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Обеспечение вибрации окон"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Доступно только в macOS; делает фон окна непрозрачным."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Показывать в области уведомлений"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Показывать в области уведомлений вместо закрытия"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Масштабирование"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Изменение размеров всего графического интерфейса"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Изменение размера шрифта редактора"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Боковая панель вложений"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "Расширения файлов должны быть видны на боковой панели Вложения"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Белый список Iframe"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Имя компьютера"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Время ожидания до момента, когда запись файла будет считаться оконченной "
+"(мс)."
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Удаление элементов"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Режим отладки"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Включить режим отладки"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Бета-версии"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Сообщать о выходе бета-версий"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Режим ввода"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Режим ввода определяет, как вы будете взаимодействовать с редактором. Мы "
+"рекомендуем держать эту настройку на \"Normal\". Выбирайте \"Vim\" или "
+"\"Emacs\" только в том случае, если вы знаете, что это значит."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Направление письма"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Рендеринг в формате Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Проверьте, чтобы включить живое отображение различных элементов Markdown для "
+"форматирования внешний вид. Это позволяет скрыть символы форматирования "
+"(например, **текст**) или отобразить изображения вместо их ссылок"
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Спрятать симоволы заголовков"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Отображать выделение"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Жирный"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Курсив"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Проверьте Markdown на наличие проблем со стилем"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Редактор таблиц"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"Редактор таблиц - это интерактивный интерфейс, который упрощает создание и "
+"редактирование таблиц. Он предоставляет кнопки для общей функциональности и "
+"заботится о форматировании Markdown."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Приглушать строки вне курсора в режиме фокусировки внимания"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Счетчик слов"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Число заменяемых символов в словах (в том числе для китайского языка)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Режим читаемости"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Алгоритм"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Размер изображения"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Максимальная ширина изображений (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Максимальная высота изображений (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Другие настройки"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Размер шрифта"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Размер отступа (количество пробелов)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Отступы с использованием табуляции вместо пробелов"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Выделите пробелы"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Предлагайте emojis во время автозаполнения"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Показать превью ссылок"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Автодополнение парных символов"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Режим отображения"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Тонкий"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Расширенный"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Комбинированный"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"Тонкий режим показывает каталоги и файлы по отдельности. Выберите каталог, "
+"чтобы его содержимое отобразилось в списке файлов. Переключайтесь между "
+"списком файлов и деревом каталогов, щелкая по каталогам или кнопке со "
+"стрелкой которая находится в левом верхнем углу списка файлов."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Информация о файле"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Показывать папки перед файлами"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Отображение имени документа в формате Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Только имя файла"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Название (если есть)"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Первый заголовок 1-го уровня (если есть)"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Название или заголовок 1-го уровня (если есть)"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Отобрадать расширения для файлов Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Отображение времени"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Дата последнего изменения"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Время создания файлы"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Сортировка"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "При сортировке документов…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Используйте естественный порядок (2 идет перед 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Используйте порядок ASCII (2 идет после 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Цитаты"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Как автозавершение должно вставлять цитаты?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Путь к файлу"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Шаблон Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Использует регулярные выражения ECMAScript"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Шаблон для генерации нового ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Доступные переменные: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Ссылка только на имя файла"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "При связывании файлов добавьте имя документа …"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Всегда"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Только при связывании с помощью ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Никогда"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Формат ссылок"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Внутренние ссылки позволяют добавить необязательный заголовок, отделенный "
+"вертикальной штрих-символом от фактической цели ссылки. Здесь вы можете "
+"определить порядок двух."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Title]]: Ссылка первая (рекомендуется)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Title|Link]]: Ссылка первая (рекомендуется)"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "Запуск полнотекстового поиска при переходе по внутренним ссылкам"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "Строка поиска будет соответствовать содержимому между скобками: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Автоматически создавать несуществующие файлы в этой папке при переходе по "
+"внутренние ссылки"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Чтобы это сработало, папка должна быть открыта как рабочая область в Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Путь к папке"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Фрагменты"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Откройте редактор фрагментов"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Строгость"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Стандартный"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Придирчивый"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Родной язык"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Не установлено"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Предпочтительные варианты"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool не может различить некоторые варианты языка. Эти настройки "
+"подтолкнут LanguageTool к автоматическому определению предпочтительного для "
+"вас варианта этих языков."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Переведите английский язык как"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Переведите немецкий язык как"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Переведите португальский язык как"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Переведите на каталанский как"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Поставщик LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Пользовательский сервер"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Пользовательский адрес сервера"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr будет игнорировать настройки \"LanguageTool provider\", если вы "
+"введете какие-либо учетные данные здесь."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Имя пользователя LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "Ключ API LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Проверка орфографии"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Действие"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Язык"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Код"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Выберите языки для проверки орфорграфии."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Словарь пользователя (слова можно удалять, кликая по ним)."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Элемент словаря"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Поиск элементов …"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Язык приложения"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Автосохранение"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Сохранить изменения"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Немедленно"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "После короткой задержки"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Папка для изображений по умолчанию"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Нажмите кнопку \"Выбрать папку...\" или введите абсолютный или относительный "
+"путь непосредственно в поле ввода."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Поведение"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "По возможности, избегайте открытия файлов в новых вкладках"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Обновления"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Автоматически проверять обновления"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s символов"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s слов"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Перейти к ссылке на сноску"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Без выделения"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Открыть панель диагностики"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Отключено"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Пользовательский"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Обнаружить автоматически"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Отображение русалочьего графа …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Не удалось отобразить график:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Режим удобочитаемости (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Изображение не найдено: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Орфографическая ошибка"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Файл %s не существует."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Количество слов"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Изменен"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Открыть…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Открыть в новой вкладке"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Получение предварительного просмотра ссылок…"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Ссылка"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Изображение"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Комментарий"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Текст сноски не найден."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Копировать код формулы"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Копирование изображения в буфер обмена"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Открыть изображение"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Раскрыть в Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Раскрыть в проводнике"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Открыть в браузере файлов"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Раскрыть в файловом браузере"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Без предложений"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Закрыть файл"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Добавить в словарь"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Переименовать директорию"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Курсив"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Удалить директорию"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Вставить ссылку"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Проверить директорию …"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Вставить ненумерованный список"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Экспортировать проект"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Вставить нумерованный список"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Закрыть остальные вкладки"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Закрыть все вкладки"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Открепить вкладку"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Закрепить вкладку"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Зажмите Cmd/Ctrl для перехода по этой ссылке"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1510,323 +2536,319 @@ msgstr "Китайский (Тайвань)"
 msgid "Chinese"
 msgstr "Китайский"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Обнаружить автоматически"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Отключено"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Пользовательский"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s слов"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s символов"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Открыть панель диагностики"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Орфографическая ошибка"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Перейти к ссылке на сноску"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Настройки"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Получение предварительного просмотра ссылок…"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Создать дубликат файла"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Жирный"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Путь копирования"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Курсив"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Копировать файл"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Ссылка"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Раскрыть в проводнике"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Изображение"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Раскрыть в файловом браузере"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Комментарий"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Закрыть файл"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Код"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Переименовать директорию"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Текст сноски не найден."
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Удалить директорию"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Файл %s не существует."
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Проверить директорию …"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Количество слов"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Экспортировать проект"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Изменен"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Открыть…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Открыть в новой вкладке"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Без выделения"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Закрыть остальные вкладки"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Закрыть все вкладки"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Копирование изображения в буфер обмена"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Открепить вкладку"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Открыть изображение"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Закрепить вкладку"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Открыть в браузере файлов"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Календарь"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Без предложений"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Диаграммы"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Добавить в словарь"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "Статистика FSAL"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Курсив"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Статистика написания"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Вставить ссылку"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Январь"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Вставить ненумерованный список"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Февраль"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Вставить нумерованный список"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Март"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Апрель"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Май"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Июнь"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Копировать код формулы"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Июль"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Режим удобочитаемости (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Август"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Изображение не найдено: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Сентябрь"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Октябрь"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Отображение русалочьего графа …"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Ноябрь"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Не удалось отобразить график:"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Декабрь"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Зажмите Cmd/Ctrl для перехода по этой ссылке"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Меньше среднего за месяц"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Программа обновления"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Больше среднего за месяц"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Доступно обновление"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "В два раза больше среднего за месяц"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Ваша версия"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Экспортируйте проект в:"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Использовать"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Формат"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Преобразование"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Файлы, которые будут включены в экспорт"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Пожалуйста, выберите хотя бы один профиль для создания этого проекта."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Название проекта"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "Таблица стилей CSL"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "Шаблон LaTeX"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "Шаблон HTML"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Удалить файл из экспорта"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Добавить файл для экспорта"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Переместить файл наверх"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Переместить файл вниз"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Вы не выбрали ни одного файла для экспорта."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
+"Некоторые файлы выбраны для экспорта, но больше не существуют в каталоге."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Загрузка обновления"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Общие сведения"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Обновлений нет. Используется новейшая версия."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Щелкните для начала обновления"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "никогда"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Последняя проверка: %s"
+msgid "No results for \"%s\""
+msgstr "Нет результатов для \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Запуск обновления …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Поиск"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Назначить цвет"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Файловый менеджер"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Убрать цвет"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Редактор"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Название тега"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Цвет"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Импорт и экспорт"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Количество"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Расширенный"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Краткое описание"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Поиск: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-"Здесь вы можете назначить цвета для различных тегов. Если тег найден в "
-"файле, его плитка в списке предварительного просмотра получит цветной "
-"индикатор. При этом описание будет показано при наведении мыши."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Параметры"
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Фильтр по тегам…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Сброс"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Выбрать папку…"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Выбрать файл…"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Добавить"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Действия"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Удалить"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Вставка изображения из буфера обмена"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Размер изображения"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1844,10 +2866,6 @@ msgstr "Имя файла"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Уникальное имя файла"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Загрузка…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1913,46 +2931,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr использует следующие проекты:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Здесь Вы можете переопределить стили Zettlr и настроить их по своему "
-"желанию. <strong>Внимание! Этот файл переопределяет все директивы CSS. "
-"Никогда не изменяйте геометрию элементов, в противном случае приложение "
-"может вести себя не предсказуемо.</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Переименовать фрагмент"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Фрагменты позволяют вам определять многократно используемые фрагменты текста "
+"с переменными."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Откройте папку с фрагментами"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Сохранение …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Сохранение не удалось"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Экспортирование"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Импортирование"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Собственная CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Фрагменты"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Сохранено!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1978,41 +2980,81 @@ msgstr "Откройте папку по умолчанию"
 msgid "Edit the default settings for imports or exports here."
 msgstr "Здесь можно изменить настройки по умолчанию для импорта или экспорта."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Сохранено!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Экспортирование"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Переименовать фрагмент"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Импортирование"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Фрагменты позволяют вам определять многократно используемые фрагменты текста "
-"с переменными."
+"Здесь Вы можете переопределить стили Zettlr и настроить их по своему "
+"желанию. <strong>Внимание! Этот файл переопределяет все директивы CSS. "
+"Никогда не изменяйте геометрию элементов, в противном случае приложение "
+"может вести себя не предсказуемо.</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Откройте папку с фрагментами"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Сохранение не удалось"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "слов(а)"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Назначить цвет"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "символов"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Убрать цвет"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Нет открытых документов"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Название тега"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Пуск"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Цвет"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Количество"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Краткое описание"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Здесь вы можете назначить цвета для различных тегов. Если тег найден в "
+"файле, его плитка в списке предварительного просмотра получит цветной "
+"индикатор. При этом описание будет показано при наведении мыши."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Фильтр по тегам…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2038,76 +3080,114 @@ msgstr "Звуковой эффект"
 msgid "Volume"
 msgstr "Громкость"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "слов за последний месяц"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "среднее за день"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "слов сегодня"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Потрясающе!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Дневная цель почти достигнута!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Пишите больше, дневная цель ещё не достигнута."
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Больше статистики …"
+
+#: source/tmp/win-main/App.vue.ts:221
+#, javascript-format
+msgid "%s selected"
+msgstr "%s выбран"
+
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s выбрано"
+
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Связанные файлы"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Нет связанных файлов"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Это отношение основано на двунаправленной связи."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Это отношение основано на исходящей ссылке."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Это отношение основано на обратной ссылке."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
-#, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Это отношение основано на общих тегах %s: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Другие файлы"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Открыть директорию"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Нет прочих файлов"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "Текущая папка"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Ссылка"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Документ не содержит цитат."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Имя"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Облако тегов"
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Переключение режима чтения"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Экспортирование…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Экспорт"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "комманда"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2117,8 +3197,8 @@ msgstr "Директории"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Файлы"
 
@@ -2132,10 +3212,26 @@ msgstr "Символы"
 msgid "Words"
 msgstr "Слова"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Рабочее окружение"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Нет открытых файлов или каталогов"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Нет результатов"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Не выбраны директории"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Пустая директория"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2165,15 +3261,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Сброс"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2234,13 +3321,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Календарь"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2450,130 +3530,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Установить цель записи…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Нет результатов"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Не выбраны директории"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Пустая директория"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Рабочее окружение"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Нет открытых файлов или каталогов"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "слов за последний месяц"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "среднее за день"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "слов сегодня"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Потрясающе!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Дневная цель почти достигнута!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Пишите больше, дневная цель ещё не достигнута."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Больше статистики …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s выбран"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s выбрано"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Переключение режима чтения"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Экспортирование…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Экспорт"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "комманда"
+msgid "Table size: %s &times; %s"
+msgstr "Размер таблицы: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2595,11 +3555,6 @@ msgstr "Ограничить поиск каталогом"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Поиск"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Очистить поиск"
@@ -2613,1084 +3568,135 @@ msgstr "Переключить результаты"
 msgid "%s matches across %s files"
 msgstr "%s совпадений в %s файлах"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Имя"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Облако тегов"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "слов(а)"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "символов"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Нет открытых документов"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Связанные файлы"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Нет связанных файлов"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Это отношение основано на двунаправленной связи."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Это отношение основано на исходящей ссылке."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Это отношение основано на обратной ссылке."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Размер таблицы: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Это отношение основано на общих тегах %s: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Добавить"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Другие файлы"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Действия"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Открыть директорию"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Удалить"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Нет прочих файлов"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Выбрать папку…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Текущая папка"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Выбрать файл…"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Экспортируйте проект в:"
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Использовать"
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Формат"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Преобразование"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Файлы, которые будут включены в экспорт"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Пожалуйста, выберите хотя бы один профиль для создания этого проекта."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Название проекта"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "Таблица стилей CSL"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "Шаблон LaTeX"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "Шаблон HTML"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Удалить файл из экспорта"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Добавить файл для экспорта"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Переместить файл наверх"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Переместить файл вниз"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Вы не выбрали ни одного файла для экспорта."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
-"Некоторые файлы выбраны для экспорта, но больше не существуют в каталоге."
 
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Общие сведения"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Ссылка"
 
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Документ не содержит цитат."
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "Нет результатов для \"%s\""
+msgid "circa %s words"
+msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Внешний вид"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Загрузка…"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Файловый менеджер"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Программа обновления"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Редактор"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Доступно обновление"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Проверка орфографии"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Ваша версия"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Автокоррекция"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Цитаты"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Загрузка обновления"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Обновлений нет. Используется новейшая версия."
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Импорт и экспорт"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Щелкните для начала обновления"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Расширенный"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "никогда"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "Поиск: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Параметры"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Январь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Февраль"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Март"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Апрель"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Май"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Июнь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Июль"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Август"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Сентябрь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Октябрь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Ноябрь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Декабрь"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Меньше среднего за месяц"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Больше среднего за месяц"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "В два раза больше среднего за месяц"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Диаграммы"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "Статистика FSAL"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Статистика написания"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Шаблон Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Использует регулярные выражения ECMAScript"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Шаблон для генерации нового ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Доступные переменные: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Внутренние ссылки"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Ссылка только на имя файла"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "При связывании файлов добавьте имя документа …"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Всегда"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Только при связывании с помощью ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Никогда"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Формат ссылок"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Внутренние ссылки позволяют добавить необязательный заголовок, отделенный "
-"вертикальной штрих-символом от фактической цели ссылки. Здесь вы можете "
-"определить порядок двух."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Title]]: Ссылка первая (рекомендуется)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Title|Link]]: Ссылка первая (рекомендуется)"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "Запуск полнотекстового поиска при переходе по внутренним ссылкам"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "Строка поиска будет соответствовать содержимому между скобками: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Автоматически создавать несуществующие файлы в этой папке при переходе по "
-"внутренние ссылки"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Чтобы это сработало, папка должна быть открыта как рабочая область в Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Путь к папке"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Умные цитаты"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Двойные кавычки"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Отключить Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Одиночные кавычки"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Шаблоны замены текста"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Сопоставить целые слова"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "Если выбрано - автокоррекция никогда не будет заменять части слов"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Заменить"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "С"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Фильтр"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Режим ввода"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Режим ввода определяет, как вы будете взаимодействовать с редактором. Мы "
-"рекомендуем держать эту настройку на \"Normal\". Выбирайте \"Vim\" или "
-"\"Emacs\" только в том случае, если вы знаете, что это значит."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Направление письма"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Рендеринг в формате Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Проверьте, чтобы включить живое отображение различных элементов Markdown для "
-"форматирования внешний вид. Это позволяет скрыть символы форматирования "
-"(например, **текст**) или отобразить изображения вместо их ссылок"
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Спрятать симоволы заголовков"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Отображать выделение"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Проверьте Markdown на наличие проблем со стилем"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Редактор таблиц"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"Редактор таблиц - это интерактивный интерфейс, который упрощает создание и "
-"редактирование таблиц. Он предоставляет кнопки для общей функциональности и "
-"заботится о форматировании Markdown."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Приглушать строки вне курсора в режиме фокусировки внимания"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Счетчик слов"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Число заменяемых символов в словах (в том числе для китайского языка)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Режим читаемости"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Алгоритм"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Максимальная ширина изображений (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Максимальная высота изображений (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Другие настройки"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Размер шрифта"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Размер отступа (количество пробелов)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Отступы с использованием табуляции вместо пробелов"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Выделите пробелы"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Предлагайте emojis во время автозаполнения"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Показать превью ссылок"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Автодополнение парных символов"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Расписание"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Выкл"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Система слежения"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Вкл"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Конец"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Тема"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Параметры панели инструментов"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Статус бар"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Открыть редактор CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Строгость"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Стандартный"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Придирчивый"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Родной язык"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Не установлено"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Предпочтительные варианты"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool не может различить некоторые варианты языка. Эти настройки "
-"подтолкнут LanguageTool к автоматическому определению предпочтительного для "
-"вас варианта этих языков."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Переведите английский язык как"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Переведите немецкий язык как"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Переведите португальский язык как"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Переведите на каталанский как"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Поставщик LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Пользовательский сервер"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Пользовательский адрес сервера"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr будет игнорировать настройки \"LanguageTool provider\", если вы "
-"введете какие-либо учетные данные здесь."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Имя пользователя LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "Ключ API LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Действие"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Язык"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Выберите языки для проверки орфорграфии."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Словарь пользователя (слова можно удалять, кликая по ним)."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Элемент словаря"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Поиск элементов …"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Режим отображения"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Тонкий"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Расширенный"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Комбинированный"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"Тонкий режим показывает каталоги и файлы по отдельности. Выберите каталог, "
-"чтобы его содержимое отобразилось в списке файлов. Переключайтесь между "
-"списком файлов и деревом каталогов, щелкая по каталогам или кнопке со "
-"стрелкой которая находится в левом верхнем углу списка файлов."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Информация о файле"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Показывать папки перед файлами"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Отображение имени документа в формате Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Только имя файла"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Название (если есть)"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Первый заголовок 1-го уровня (если есть)"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Название или заголовок 1-го уровня (если есть)"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Отобрадать расширения для файлов Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Отображение времени"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Дата последнего изменения"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Время создания файлы"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Сортировка"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "При сортировке документов…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Используйте естественный порядок (2 идет перед 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Используйте порядок ASCII (2 идет после 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Импорт и экспорт профилей"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Откройте редактор профилей импорта"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Откройте редактор профилей экспорта"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Настройки экспорта"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Используйте внутренний Pandoc от Zettlr для экспорта."
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Удаление тегов из файлов при экспорте"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Удалить внутренние ссылки полностью"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Расцепить внутренние ссылки"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Не трогать внутренние ссылки"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Папка назначения для экспортированных файлов"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Временная папка"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "То же, что и расположение файла"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Запрос папки при экспорте"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Внимание! Файлы во временной папке регулярно удаляются. Выбор то же место, "
-"что и файл, перезаписывает файлы с идентичными именами, если они уже "
-"существуют."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Пользовательские команды экспорта"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Отображаемое имя"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Комманда"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Введите пользовательские команды для запуска экспортера. Каждая команда "
-"получает в качестве первого аргумента файл или каталог проекта, который "
-"необходимо экспортировать."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Шаблон для новых имен файлов"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Определите шаблон для имен новых файлов"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Доступные переменные: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Не запрашивать имя файла при его создании"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Использовать вид окна по умолчанию"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
-"Доступно только в Linux; для macOS и Windows оно используется по умолчанию."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Обеспечение вибрации окон"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Доступно только в macOS; делает фон окна непрозрачным."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Показывать в области уведомлений"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Показывать в области уведомлений вместо закрытия"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Масштабирование"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Изменение размеров всего графического интерфейса"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Изменение размера шрифта редактора"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Боковая панель вложений"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "Расширения файлов должны быть видны на боковой панели Вложения"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Белый список Iframe"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Имя компьютера"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Время ожидания до момента, когда запись файла будет считаться оконченной "
-"(мс)."
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Удаление элементов"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Режим отладки"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Включить режим отладки"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Бета-версии"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Сообщать о выходе бета-версий"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Откройте редактор фрагментов"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Язык приложения"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Автосохранение"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Сохранить изменения"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Немедленно"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "После короткой задержки"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Папка для изображений по умолчанию"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Нажмите кнопку \"Выбрать папку...\" или введите абсолютный или относительный "
-"путь непосредственно в поле ввода."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Поведение"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "По возможности, избегайте открытия файлов в новых вкладках"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Обновления"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Автоматически проверять обновления"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Как автозавершение должно вставлять цитаты?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Путь к файлу"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+msgid "Last checked: %s"
+msgstr "Последняя проверка: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Запуск обновления …"
 
 #~ msgid "Open Link"
 #~ msgstr "Открыть ссылку"

--- a/static/lang/sv-SV.po
+++ b/static/lang/sv-SV.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Hänvisningsdatabasen kunde inte laddas"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Ändringar i biblioteksfilen upptäcktes. Laddar om …"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Arbetsytor"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,143 +82,6 @@ msgstr "Alternativet %s måste vara minst %s (tecken långt)."
 msgid "Option %s is required."
 msgstr "Alternativ %s krävs."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Visa Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Avsluta"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "En uppdatering till version %s är tillgänglig!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Kunde inte leta efter uppdateringar: Serverfel (Statuskod: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Kunde inte söka efter uppdateringar: Klientfel (Statuskod: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Det gick inte att söka efter uppdateringar: Servern försökte omdirigera "
-"(Statuskod: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Kunde inte söka efter uppdateringar: Kunde inte upprätta anslutning"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Det gick inte att söka efter uppdateringar. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr ""
-"Kunde inte leta efter uppdateringar: Servern har inte skickat någon data"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Det gick inte att skapa filen"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Referensen med nyckel %s verkar inte ha bilagor."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Det gick inte att öppna bilagan. Körs Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -222,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "system.ok"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Avbryt"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Vill du verkligen ta bort?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Vill du verkligen ta bort %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Referensen med nyckel %s verkar inte ha bilagor."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Det gick inte att öppna bilagan. Körs Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Felformat textpaket: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Exportera projekt"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Exportera…"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -295,48 +246,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Exporten misslyckades"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Exportera projekt"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "system.ok"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Exportera…"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Det går inte att flytta katalogen"
@@ -354,28 +263,49 @@ msgstr "Kan inte flytta katalog eller fil"
 msgid "The file/directory %s already exists in target."
 msgstr "Filen/katalogen %s finns redan i målet."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Obetitlad"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Det angivna namnet innehöll inga tillåtna bokstäver."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Kunde inte skapa katalog"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Den begärda katalogen hittades inte."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Vill du verkligen ta bort?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Exporten misslyckades"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Ett fel uppstod vid export: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Spara"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Vill du verkligen ta bort %s?"
+msgid "Exporting to %s"
+msgstr "Exporterar till %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Ett fel uppstod vid export: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -400,10 +330,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -417,128 +349,34 @@ msgstr "Språk fil importerad: %s"
 msgid "Could not import language file %s!"
 msgstr "Kunde inte importera språk filen %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Exporten misslyckades"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Det gick inte att skapa filen"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Ett fel uppstod vid export: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
+#, javascript-format
+msgid "Copy of %s"
 msgstr ""
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Spara"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Obetitlad"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Kunde inte skapa katalog"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Exporterar till %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Ett fel uppstod vid export: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Det angivna namnet innehöll inga tillåtna bokstäver."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Den begärda katalogen hittades inte."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Felformat textpaket: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Ladda alltid externa ändringar till den aktuella filen"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Skriv över befintlig fil"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Filen %s finns redan i den här katalogen. Skriva över?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Öppna fil"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Osparade ändringar"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Det finns ändringar som inte har sparats i den aktuella filen. Vill du "
-"utelämna dem eller spara?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Spara fil"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Öppna projektmappen"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Hänvisningsdatabasen kunde inte laddas"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Ändringar i biblioteksfilen upptäcktes. Laddar om …"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -650,6 +488,12 @@ msgstr "Döp om fil"
 msgid "Delete file"
 msgstr "Ta bort fil"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Avsluta"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -668,15 +512,15 @@ msgstr "Göra om"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Klipp ut"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopiera"
 
@@ -688,8 +532,8 @@ msgstr "Kopiera som HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "infoga"
 
@@ -701,8 +545,8 @@ msgstr "Infoga utan stil"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Välj alla"
 
@@ -945,10 +789,166 @@ msgstr "Sluta tala"
 msgid "Bring All to Front"
 msgstr "Ta fram alla"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Arbetsytor"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Öppna projektmappen"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Ladda alltid externa ändringar till den aktuella filen"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Osparade ändringar"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Det finns ändringar som inte har sparats i den aktuella filen. Vill du "
+"utelämna dem eller spara?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Öppna fil"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Spara fil"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Skriv över befintlig fil"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Filen %s finns redan i den här katalogen. Skriva över?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Visa Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "En uppdatering till version %s är tillgänglig!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Kunde inte leta efter uppdateringar: Serverfel (Statuskod: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Kunde inte söka efter uppdateringar: Klientfel (Statuskod: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Det gick inte att söka efter uppdateringar: Servern försökte omdirigera "
+"(Statuskod: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Kunde inte söka efter uppdateringar: Kunde inte upprätta anslutning"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Det gick inte att söka efter uppdateringar. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr ""
+"Kunde inte leta efter uppdateringar: Servern har inte skickat någon data"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -967,143 +967,1196 @@ msgstr ""
 "Det finns ändringar som inte har sparats i den aktuella filen. Vill du "
 "utelämna dem eller spara?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Fil hanterarläge"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Slå på Autokorrigering"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Egenskaper"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Duplicera fil"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "Kopiera hela sök vägen"
+msgid "Double Quotes"
+msgstr "Ingen"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Kopiera filnamn"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Ingen"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Ingen"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Byt ut fil"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Filtrera..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Schema"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Av"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Följ operativsystemet"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Start"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Visa Zettlr"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Anpassad CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Öppna mapp"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Exporterar till %s"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Använd den interna Pandoc för export"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Ta bort taggar från filer"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Ta bort interna länkar"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Ta bort interna länkar helt"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Ta bort interna länkar"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Rör inte interna länkar"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Visa fil information"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Visa bild"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Kommentar"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Mönster för nya filnamn"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Mönster för nya filnamn"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Fråga inte efter filnamn när du skapar nya filer"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Använd inbyggt fönsterutseende"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Använd inbyggt fönsterutseende"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Visa appen i meddelandefältet"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Låt appen köras i meddelandefältet"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Zoombeteende"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Zoom ändrar storlek på hela GUI"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Zoom ändrar editorns teckensnittsstorlek"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "iFrame återgivningsvitlista"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Värdnamn"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Aktivera Watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Dags att vänta innan du skriver en fil anses vara klar (i ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Ta bort fil"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Aktivera felsökningsläge"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Aktivera felsökningsläge"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Informera mig om betaversioner"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Inmatningsläge för redigering"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Sök i katalogen"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Dölj rubriker"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Framge betoning"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Fet"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Kursiv"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Aktivera tabellredigeraren"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Stäng av icke-fokuserade linjer i distraktionsfritt läge"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Antal ord"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Räkna tecken istället för ord (t.ex. för kinesiska)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Bild"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Maximal bredd på bilder (procent)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Maximal höjd på bilder (procent)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Övriga filer"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Editor teckenstorlek"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Dra in med följande antal blanksteg"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Indrag med flikar"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Acceptera blanksteg under autokomplettering"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Stäng matchande teckenpar automatiskt"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Visa bild"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Visa fil information"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Visa mappar ovanför filer"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Endast filnamn"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Rubrik om tillämpligt"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Första rubrik nivå 1 om tillämpligt"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Titel eller första rubrik nivå 1 om tillämpligt"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Visa Markdown fil tillägg"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Senaste ändringstid"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Tid för att skapa fil"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Exportera…"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Senaste dokument"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Naturlig ordning (10 efter 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII-ordning (2 efter 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Återge hänvisningar"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Hur vill du att autoslutförande ska infoga dina citat?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Lägg till i fil"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Mönster som används för att generera nya ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID reguljärt uttryck"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Mönster som används för att generera nya ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Endast filnamn"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "När du länkar filer, lägg till filnamnet ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "Alltid"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "endast vid länkning med ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "Aldrig"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Starta en sökning när du följer Zettelkasten-länkar"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Skapa automatiskt icke-existerande filer när du följer interna länkar"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr ""
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Kalender"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Anpassad CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Anpassad CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Handling"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kod"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Välj de språk som du vill aktivera automatisk stavningskontroll för."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Användarordbok. Ta bort ord genom att klicka på dem."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Ordboksinlägg"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Söker efter inlägg…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Automatisk sparning"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Senaste ändringstid"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Omedelbart"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Efter en kort fördröjning"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Zoombeteende"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Undvik att öppna filer i nya flikar om möjligt"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Uppdaterare"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Sök efter uppdateringar automatiskt"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s tecken"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s ord"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr ""
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr ""
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Anpassad CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Det gick inte att skapa filen"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr ""
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Antal ord"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Ändrad"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Öppna…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Öppna i en ny flik"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Länk"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Bild"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Kommentar"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Kopiera ekvations koden"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Kopiera bilden till urklipp"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Öppna fil"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Öppna i webbläsaren"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Inga förslag"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Lägg till i katalog"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Kursiv"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Infoga länk"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Infoga oordnad lista"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Infoga numrerad lista"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Stäng fil"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Byt namn på mappen"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Ta bort katalog"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Sök efter mappen..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Exportera projekt"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
 msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Stäng andra flikar"
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Stäng alla flikar"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1535,326 +2588,322 @@ msgstr "Kinesiska (Kina)"
 msgid "Chinese"
 msgstr "Kinesiska (Kina)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
+
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
+
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Egenskaper"
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Duplicera fil"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Anpassad CSS"
+msgid "Copy path"
+msgstr "Kopiera hela sök vägen"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s ord"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Kopiera filnamn"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s tecken"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Stäng fil"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Byt namn på mappen"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Ta bort katalog"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Sök efter mappen..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Exportera projekt"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Stäng andra flikar"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Stäng alla flikar"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Fet"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Kursiv"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Länk"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Bild"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Kommentar"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kod"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Diagram"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Antal ord"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Ändrad"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Öppna…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Öppna i en ny flik"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Januari"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Februari"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Mars"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "April"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Maj"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Juni"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Juli"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Augusti"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "September"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Oktober"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "November"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "December"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Under månadsgenomsnittet"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Över det månatliga genomsnittet"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Mer än dubbelt så mycket som månadsgenomsnittet"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Kopiera bilden till urklipp"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Öppna fil"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Öppna i webbläsaren"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Inga förslag"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Lägg till i katalog"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Kursiv"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Infoga länk"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Infoga oordnad lista"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Infoga numrerad lista"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Kopiera ekvations koden"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Det gick inte att skapa filen"
-
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Uppdaterare"
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Ny uppdatering tillgänglig"
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Din version"
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Det finns en ny version av Zettlr att ladda ner. Läs ändringsloggen nedan."
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Laddar ner din uppdatering"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Ingen uppdatering tillgänglig. Du har den senaste versionen."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Klicka för att starta uppdateringen"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Startar uppdatering..."
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Sök"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Filtrera taggar…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Återställa"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Öppna projektmappen"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Ta bort fil"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Lägg till"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Handling"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Ta bort fil"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Bild"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1871,10 +2920,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1936,45 +2981,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr använder även dessa projekt"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Här kan du åsidosätta stilarna i Zettlr för att anpassa programmet ännu mer. "
-"<strong>Obs: Den här filen åsidosätter alla CSS-direktiv! Ändra aldrig "
-"elementens geometri, då kan programmet ändra beteende!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Byt namn på utdrag"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "Utdrag låter dig definiera återanvändbara textstycken med variabler."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Sparar …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Det gick inte att spara"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Anpassad CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr ""
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Sparad!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1996,39 +3024,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Ändra standardinställningarna för import eller export här."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Sparad!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Byt namn på utdrag"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "Utdrag låter dig definiera återanvändbara textstycken med variabler."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "Ord"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "tecken"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Här kan du åsidosätta stilarna i Zettlr för att anpassa programmet ännu mer. "
+"<strong>Obs: Den här filen åsidosätter alla CSS-direktiv! Ändra aldrig "
+"elementens geometri, då kan programmet ändra beteende!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Inget öppet dokument"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Det gick inte att spara"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Start"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Filtrera taggar…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2054,76 +3120,116 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "ord förra månaden"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Relaterade filer"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "dagligt genomsnitt"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Inga relaterade filer"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "Ord idag"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Du är kanon bra!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Du är nära att nå ditt dagliga genomsnitt!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Skriv för att överträffa ditt dagliga genomsnitt."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Mer statistik..."
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Övriga filer"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Öppna mapp"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Inga andra filer"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr ""
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referenser"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Det finns inga citat i detta dokument."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Taggmoln"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Exportera…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Exportera…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr ""
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2133,8 +3239,8 @@ msgstr "Kataloger"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Filer"
 
@@ -2148,10 +3254,26 @@ msgstr "Tecken"
 msgid "Words"
 msgstr "Ord"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Arbetsytor"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Inga öppna filer eller mappar"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Inga resultat"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Ingen katalog har valts"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Tom katalog"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2181,15 +3303,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Återställa"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2250,13 +3363,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Kalender"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2466,131 +3572,9 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Sätt skrivmål..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Inga resultat"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Ingen katalog har valts"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Tom katalog"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Arbetsytor"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Inga öppna filer eller mappar"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "ord förra månaden"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "dagligt genomsnitt"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "Ord idag"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Du är kanon bra!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Du är nära att nå ditt dagliga genomsnitt!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Skriv för att överträffa ditt dagliga genomsnitt."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Mer statistik..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Exportera…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Exportera…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
+msgid "Table size: %s &times; %s"
 msgstr ""
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
@@ -2613,11 +3597,6 @@ msgstr "Begränsa sökningen till katalog"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Sök"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Rensa sökning"
@@ -2631,1109 +3610,136 @@ msgstr "Växla resultat"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr ""
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Taggmoln"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "Ord"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "tecken"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Inget öppet dokument"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Relaterade filer"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Inga relaterade filer"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr ""
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Lägg till"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Handling"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Ta bort fil"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Öppna projektmappen"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Ta bort fil"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Slå på Autokorrigering"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Återge hänvisningar"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Januari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Februari"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Mars"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "April"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Maj"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Juni"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Juli"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Augusti"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "September"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Oktober"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "November"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "December"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Under månadsgenomsnittet"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Över det månatliga genomsnittet"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Mer än dubbelt så mycket som månadsgenomsnittet"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Diagram"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Mönster som används för att generera nya ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID reguljärt uttryck"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Mönster som används för att generera nya ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Ta bort interna länkar"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Endast filnamn"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "När du länkar filer, lägg till filnamnet ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "Alltid"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "endast vid länkning med ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "Aldrig"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Starta en sökning när du följer Zettelkasten-länkar"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Skapa automatiskt icke-existerande filer när du följer interna länkar"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Ingen"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Byt ut fil"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Filtrera..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Inmatningsläge för redigering"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Sök i katalogen"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Dölj rubriker"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Framge betoning"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Aktivera tabellredigeraren"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Stäng av icke-fokuserade linjer i distraktionsfritt läge"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Antal ord"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Räkna tecken istället för ord (t.ex. för kinesiska)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Maximal bredd på bilder (procent)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Maximal höjd på bilder (procent)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
 msgstr "Övriga filer"
 
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Editor teckenstorlek"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Dra in med följande antal blanksteg"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Indrag med flikar"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Acceptera blanksteg under autokomplettering"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Stäng matchande teckenpar automatiskt"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Schema"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Av"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Följ operativsystemet"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Visa Zettlr"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Öppna mapp"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Inga andra filer"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Kalender"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referenser"
 
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Det finns inga citat i detta dokument."
 
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Anpassad CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Anpassad CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Handling"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Välj de språk som du vill aktivera automatisk stavningskontroll för."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Användarordbok. Ta bort ord genom att klicka på dem."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Ordboksinlägg"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Söker efter inlägg…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Visa bild"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Visa fil information"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Visa mappar ovanför filer"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Endast filnamn"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Rubrik om tillämpligt"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Första rubrik nivå 1 om tillämpligt"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Titel eller första rubrik nivå 1 om tillämpligt"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Visa Markdown fil tillägg"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Senaste ändringstid"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Tid för att skapa fil"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Exportera…"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Senaste dokument"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Naturlig ordning (10 efter 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII-ordning (2 efter 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Exporterar till %s"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Använd den interna Pandoc för export"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Ta bort taggar från filer"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Ta bort interna länkar helt"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Ta bort interna länkar"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Rör inte interna länkar"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Visa fil information"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Visa bild"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Kommentar"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Mönster för nya filnamn"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Mönster för nya filnamn"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Fråga inte efter filnamn när du skapar nya filer"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Använd inbyggt fönsterutseende"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Använd inbyggt fönsterutseende"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Visa appen i meddelandefältet"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Låt appen köras i meddelandefältet"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Zoombeteende"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Zoom ändrar storlek på hela GUI"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Zoom ändrar editorns teckensnittsstorlek"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "iFrame återgivningsvitlista"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Värdnamn"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Aktivera Watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Dags att vänta innan du skriver en fil anses vara klar (i ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Ta bort fil"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Aktivera felsökningsläge"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Aktivera felsökningsläge"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Informera mig om betaversioner"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Automatisk sparning"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Senaste ändringstid"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Omedelbart"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Efter en kort fördröjning"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Zoombeteende"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Undvik att öppna filer i nya flikar om möjligt"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Uppdaterare"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Sök efter uppdateringar automatiskt"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Ny uppdatering tillgänglig"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Hur vill du att autoslutförande ska infoga dina citat?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Din version"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Det finns en ny version av Zettlr att ladda ner. Läs ändringsloggen nedan."
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Laddar ner din uppdatering"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Ingen uppdatering tillgänglig. Du har den senaste versionen."
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Klicka för att starta uppdateringen"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Lägg till i fil"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Startar uppdatering..."
 
 #~ msgid "Open Link"
 #~ msgstr "Öppna länk"

--- a/static/lang/ta-IN.po
+++ b/static/lang/ta-IN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 3.0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: தமிழ்நேரம் <https://TamilNeram.github.io>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "மேற்கோள் தரவுத்தளத்தை ஏற்ற முடியவில்லை"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "கண்டறியப்பட்ட நூலகக் கோப்பில் மாற்றங்கள். மீண்டும் ஏற்றுதல்…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "பணியிடத்தை ஏற்றுகிறது %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -66,142 +80,6 @@ msgstr "விருப்பம் %s குறைந்தது %s (எழு
 msgid "Option %s is required."
 msgstr "விருப்பம் %s தேவை."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "செட்லரைக் காட்டு"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "வெளியேறு"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "செட்லர்"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "பதிப்பு %s க்கான புதுப்பிப்பு கிடைக்கிறது!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையக பிழை (நிலை குறியீடு: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: வாடிக்கையாளர் பிழை (நிலை குறியீடு: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையகம் திருப்பிவிட முயற்சித்தது (நிலை "
-"குறியீடு: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: இணைப்பை நிறுவ முடியவில்லை"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையகம் எந்த தரவையும் அனுப்பவில்லை"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "ஆவணம் மிக நீளமானது"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "இணையமில்லாமல்"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "கோப்பை உருவாக்க முடியவில்லை"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "திறவுகோல் %s கொண்ட குறிப்பு இணைப்புகளைக் கொண்டிருப்பதாகத் தெரியவில்லை."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "இணைப்பைத் திறக்க முடியவில்லை. சோட்டெரோ இயங்குகிறதா?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +97,96 @@ msgstr "ஆம்"
 msgid "No"
 msgstr "இல்லை"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "குறிச்சொல்லை \"%s\" ஐ \"%s\" உடன் %s கோப்புகளில் மாற்றவா?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "சரி"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "விலக்கு"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "உண்மையில் நீக்கவா?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "நீங்கள் உண்மையில் %s ஐ அகற்ற விரும்புகிறீர்களா?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "திறவுகோல் %s கொண்ட குறிப்பு இணைப்புகளைக் கொண்டிருப்பதாகத் தெரியவில்லை."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "இணைப்பைத் திறக்க முடியவில்லை. சோட்டெரோ இயங்குகிறதா?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "தவறான உரைப்பாடு: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "இறக்குமதி தன்வயவிவரத்தைத் தேர்ந்தெடு"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "%s ஐ இறக்குமதி செய்யக்கூடிய பல தன்வயவிவரங்கள் உள்ளன. ஒன்றைத் தேர்வுசெய்க."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "திட்டத்தை ஏற்றுமதி செய்ய முடியாது"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "திட்டம் \"%s\" வெற்றிகரமாக ஏற்றுமதி செய்யப்பட்டது. காண்பிக்க சொடுக்கு."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "திட்ட ஏற்றுமதி"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -292,46 +242,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "ஏற்றுமதி தோல்வியடைந்தது"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "திட்டத்தை ஏற்றுமதி செய்ய முடியாது"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "சரி"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "திட்டம் \"%s\" வெற்றிகரமாக ஏற்றுமதி செய்யப்பட்டது. காண்பிக்க சொடுக்கு."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "திட்ட ஏற்றுமதி"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "கோப்பகத்தை நகர்த்த முடியாது"
@@ -349,28 +259,49 @@ msgstr "அடைவு அல்லது கோப்பை நகர்த்
 msgid "The file/directory %s already exists in target."
 msgstr "கோப்பு/அடைவு %s ஏற்கனவே இலக்கில் உள்ளன."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "தலைப்பில்லாத்து"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "வழங்கப்பட்ட பெயரில் அனுமதிக்கப்பட்ட எழுத்துகள் இல்லை."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "கோப்பகத்தை உருவாக்க முடியவில்லை"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "கோரப்பட்ட அடைவு காணப்படவில்லை."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "உண்மையில் நீக்கவா?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "ஏற்றுமதி தோல்வியடைந்தது"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "நீங்கள் உண்மையில் %s ஐ அகற்ற விரும்புகிறீர்களா?"
+msgid "An error occurred during export: %s"
+msgstr "ஏற்றுமதியின் போது பிழை ஏற்பட்டது: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "ஏற்றுமதி இலக்கைத் தேர்வுசெய்க"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "சேமி"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "%sக்கு ஏற்றுமதி"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "ஏற்றுமதியில் பிழை ஏற்பட்டது: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -395,11 +326,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "%s நகல்"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "ஆவணம் மிக நீளமானது"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "இணையமில்லாமல்"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -412,127 +345,34 @@ msgstr "மொழி கோப்பு இறக்குமதி செய்
 msgid "Could not import language file %s!"
 msgstr "மொழி கோப்பு %s ஐ இறக்குமதி செய்ய முடியவில்லை!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "ஏற்றுமதி தோல்வியடைந்தது"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "கோப்பை உருவாக்க முடியவில்லை"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "ஏற்றுமதியின் போது பிழை ஏற்பட்டது: %s"
+msgid "Copy of %s"
+msgstr "%s நகல்"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "ஏற்றுமதி இலக்கைத் தேர்வுசெய்க"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "தலைப்பில்லாத்து"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "சேமி"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "கோப்பகத்தை உருவாக்க முடியவில்லை"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "%sக்கு ஏற்றுமதி"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "ஏற்றுமதியில் பிழை ஏற்பட்டது: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "வழங்கப்பட்ட பெயரில் அனுமதிக்கப்பட்ட எழுத்துகள் இல்லை."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "கோரப்பட்ட அடைவு காணப்படவில்லை."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "இறக்குமதி தன்வயவிவரத்தைத் தேர்ந்தெடு"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "%s ஐ இறக்குமதி செய்யக்கூடிய பல தன்வயவிவரங்கள் உள்ளன. ஒன்றைத் தேர்வுசெய்க."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "தவறான உரைப்பாடு: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "கோப்பை மாற்று"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"கோப்பு %s தொலைதூரத்தில் மாற்றியமைக்கப்பட்டது. ஏற்றப்பட்ட பதிப்பை வட்டில் இருந்து புதிய "
-"ஒன்றைக் கொண்டு மாற்றவா?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "தற்போதைய கோப்பில் எப்போதும் தொலை மாற்றங்களை ஏற்று"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "இருக்கும் கோப்பை மேலெழுது"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "இந்த கோப்பகத்தில் %s ஏற்கனவே உள்ளன. மேலெழுதவா?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "கோப்பை திற"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "சேமிக்கப்படாத மாற்றங்கள்"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "சேமிக்கப்படாத மாற்றங்கள் உள்ளன. முதலில் அவற்றைக் சேமிக்க விரும்புகிறீர்களா?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "கோப்பை சேமி"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "திட்டக் கோப்புறை திற"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "மேற்கோள் தரவுத்தளத்தை ஏற்ற முடியவில்லை"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "கண்டறியப்பட்ட நூலகக் கோப்பில் மாற்றங்கள். மீண்டும் ஏற்றுதல்…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "குறிச்சொல்லை \"%s\" ஐ \"%s\" உடன் %s கோப்புகளில் மாற்றவா?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -644,6 +484,12 @@ msgstr "கோப்பை மறுபெயரிடு"
 msgid "Delete file"
 msgstr "கோப்பை நீக்கு"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "வெளியேறு"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -662,15 +508,15 @@ msgstr "மீண்டும்செய்"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "வெட்டு"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "நகலெடு"
 
@@ -682,8 +528,8 @@ msgstr "உஉகுமொ ஆக நகலெடு"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "ஒட்டு"
 
@@ -695,8 +541,8 @@ msgstr "பாணி இல்லாமல் ஒட்டு"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "அனைத்தையும் தெரிவுசெய்"
 
@@ -939,10 +785,164 @@ msgstr "பேசுவதை நிறுத்து"
 msgid "Bring All to Front"
 msgstr "அனைத்தையும் முன்னால் கொண்டு வா"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "திட்டக் கோப்புறை திற"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "கோப்பை மாற்று"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "பணியிடத்தை ஏற்றுகிறது %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"கோப்பு %s தொலைதூரத்தில் மாற்றியமைக்கப்பட்டது. ஏற்றப்பட்ட பதிப்பை வட்டில் இருந்து புதிய "
+"ஒன்றைக் கொண்டு மாற்றவா?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "தற்போதைய கோப்பில் எப்போதும் தொலை மாற்றங்களை ஏற்று"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "சேமிக்கப்படாத மாற்றங்கள்"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "சேமிக்கப்படாத மாற்றங்கள் உள்ளன. முதலில் அவற்றைக் சேமிக்க விரும்புகிறீர்களா?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "கோப்பை திற"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "கோப்பை சேமி"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "இருக்கும் கோப்பை மேலெழுது"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "இந்த கோப்பகத்தில் %s ஏற்கனவே உள்ளன. மேலெழுதவா?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "செட்லரைக் காட்டு"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "செட்லர்"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "பதிப்பு %s க்கான புதுப்பிப்பு கிடைக்கிறது!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையக பிழை (நிலை குறியீடு: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: வாடிக்கையாளர் பிழை (நிலை குறியீடு: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையகம் திருப்பிவிட முயற்சித்தது (நிலை "
+"குறியீடு: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: இணைப்பை நிறுவ முடியவில்லை"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "புதுப்பிப்புகளை சரிபார்க்க முடியவில்லை: சேவையகம் எந்த தரவையும் அனுப்பவில்லை"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -957,16 +957,16 @@ msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr ""
 "சேமிக்கப்படாத மாற்றங்கள் உள்ளன. முதலில் அவற்றைக் சேமிக்க அல்லது நிராகரி விரும்புகிறீர்களா?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "வட்டில் கோப்பு மாற்றப்பட்டது"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s வட்டில் மாற்றப்பட்டது"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -976,128 +976,1146 @@ msgstr ""
 "திருத்தி உள்ளடக்கங்களை வைத்திருக்க விரும்புகிறீர்களா அல்லது வட்டில் இருந்து கோப்பை ஏற்ற "
 "விரும்புகிறீர்களா?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "தற்போதைய திருத்தி உள்ளடக்கங்களை வைத்திருக்க விரும்புகிறீர்களா அல்லது வட்டில் இருந்து கோப்பை "
 "ஏற்ற விரும்புகிறீர்களா?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "திருத்தி உள்ளடக்கங்களை வைத்திரு"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "வட்டில் இருந்து மாற்றங்களை ஏற்று"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "திருத்தியில் சேமிக்கப்படாத மாற்றங்கள் இல்லாவிட்டால் எப்போதும் வட்டில் இருந்து மாற்றங்களை ஏற்று"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "கோப்பை சேமிக்க முடியவில்லை"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "கோப்பை சேமிக்க முடியவில்லை %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "தானாகதிருத்து"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "அறிவு மேற்கோள்கள்"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "இரட்டை மேற்கோள்கள்"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "மந்திர மேற்கோள்களை முடக்கு"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "ஒற்றை மேற்கோள்கள்"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "உரை-மாற்று வடிவங்கள்"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "முழு சொற்களையும் பொருத்து"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+"சரிபார்க்கும்போது, தன்னியக்கக் கட்டுப்பாடு ஒருபோதும் சொற்களின் சில பகுதிகளை மாற்றாது"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "மாற்று"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "உடன்"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "வடிகட்டி"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "அட்டவணை"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "அணை"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "முறைமையைப் பின்பற்று"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "மேல்"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "தொடங்கு"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "முடிவு"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "கருபொருள்"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "கருவிப்பட்டி விருப்பங்கள்"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "பண்புகள்"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "நகல் கோப்பு"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "நகல் பாதை"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "கோப்பு பெயரை நகலெடு"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "நிலைப்பட்டி"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "தனிப்பயன் சிஎச்எச்"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "சிஎச்எச் திருத்தி திற"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "இறக்குமதி மற்றும் ஏற்றுமதி தன்வயவிவரங்கள்"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "இறக்குமதி தன்வயவிவரங்கள் திருத்தி திற"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "ஏற்றுமதி தன்வயவிவரங்கள் திருத்தி திற"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "ஏற்றுமதி அமைப்புகள்"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "ஏற்றுமதிக்கு செட்லரின் உள் பாண்ஆவணம் பயன்படுத்து"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "ஏற்றுமதிமதியின் போது கோப்புகளிலிருந்து குறிச்சொற்களை அகற்று"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "உள் இணைப்புகள்"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "உள் இணைப்புகளை முழுவதுமாக அகற்று"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "உள் இணைப்புகளை அவிழ்த்து விடு"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "உள் இணைப்புகளைத் தொட வேண்டாம்"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "ஏற்றுமதி செய்யப்பட்ட கோப்புகளுக்கான இலக்கு கோப்புறை"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "தற்காலிக கோப்புறை"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "கோப்பு இருப்பிடம் போன்றது"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "ஏற்றுமதி செய்யும் போது கோப்புறையைக் கேள்"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"எச்சரிக்கை! தற்காலிக கோப்புறையில் உள்ள கோப்புகள் தொடர்ந்து நீக்கப்படும். கோப்பு இருக்கும் அதே "
+"இடத்தைத் தேர்ந்தெடுப்பது, ஏற்கனவே இருந்தால், ஒரே மாதிரியான கோப்புப்பெயர்களைக் கொண்ட "
+"கோப்புகளை மேலெழுதும்."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "தனிப்பயன் ஏற்றுமதி கட்டளைகள்"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "காட்சி பெயர்"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "கட்டளை"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"ஏற்றுமதியாளரை இயக்க தனிப்பயன் கட்டளைகளை உள்ளிடவும். ஒவ்வொரு கட்டளையும் அதன் முதல் வாதமாக "
+"ஏற்றுமதி செய்ய வேண்டிய கோப்பு அல்லது திட்ட கோப்புறையைப் பெறுகிறது."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "புதிய கோப்பு பெயர்களுக்கான முறை"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "புதிய கோப்பு பெயர்களுக்கான முறை வரையறை"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "கிடைக்கக்கூடிய மாறிகள்: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "புதிய கோப்புகளை உருவாக்கும்போது கோப்பு பெயருக்கு கேட்க வேண்டாம்"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "தோற்றம்"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "சொந்த சாளர தோற்றத்தைப் பயன்படுத்து"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "லினக்சில் மட்டுமே கிடைக்கும்; இது மேக்இமு மற்றும் சாளரங்களுக்கான இயல்புநிலை."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "சாளர அதிர்வுகளை இயக்கு"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "மேக்இமு இல் மட்டுமே கிடைக்கும்; சாளர பின்னணியை ஒளிபுகா செய்கிறது."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "அறிவிப்பு பகுதியில் பயன்பாட்டைக் காட்டு"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "அறிவிப்பு பகுதியில் பயன்பாட்டை இயக்கு"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "பெரிதாக்கு நடத்தை"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "முழு இடைமுகத்தை மாற்றியமைக்கிறது"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "திருத்தி எழுத்துரு அளவை மாற்றுகிறது"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "இணைப்புகள் பக்கப்பட்டி"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "கோப்பு நீட்டிப்புகள் இணைப்புகள் பக்கப்பட்டியில் தெரியும்"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "இசட்டம் வழங்கும் அனுமதிப்பட்டியல்"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "புரவலன்பெயர்"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "கண்காணிப்பு பதிவு"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"ஒரு கோப்பை எழுதியதாகக் கருதப்படுவதற்கு முன் காத்திருக்க வேண்டிய நேரம் (மி.நொடியில்) "
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "உருப்படிகளை நீக்குதல்"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "பிழைத்திருத்த பயன்முறை"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "பிழைத்திருத்த பயன்முறையை இயக்கு"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "ஆவண்னா வெளியீடுகள்"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "ஆவண்னா வெளியீடுகள் பற்றி எனக்குத் தெரிவி"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "உள்ளீட்டு முறை"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"நீங்கள் திருத்தியுடன் எவ்வாறு தொடர்பு கொள்கிறீர்கள் என்பதை உள்ளீட்டு முறை தீர்மானிக்கிறது. இந்த "
+"அமைப்பை \"இயல்பான\" இல் வைக்க பரிந்துரைக்கிறோம். இது எதைக் குறிக்கிறது என்று உங்களுக்குத் "
+"தெரிந்தால் மட்டுமே \"விம்\" அல்லது \"இமேக்சு\" என்பதைத் தேர்ந்தெடு."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "எழுதும் திசை"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "குறிகீழ் வழங்குதல்"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"வடிவமைக்கப்பட்ட தோற்றத்திற்கு பல்வேறு குறிகீழ் கூறுகளின் நேரடி வழங்குதலை இயக்க சரிபார். "
+"இது வடிவமைத்தல் எழுத்துக்களை (**உரை** போன்றவை) மறைக்கிறது அல்லது அவற்றின் இணைப்பிற்குப் "
+"பதிலாக படங்களை வழங்குகிறது."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "தலைப்பு எழுத்துக்களை மறை"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "முக்கியத்துவம் அளி"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "தடிமான"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "சாய்வு"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "பாணி சிக்கல்களுக்கு கீழ்குறி சரிபார்"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "அட்டவணை திருத்தி"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"அட்டவணை திருத்தி என்பது ஒரு ஊடாடும் இடைமுகமாகும், இது அட்டவணைகளை உருவாக்குவதையும் "
+"திருத்துவதையும் எளிதாக்குகிறது. இது பொதுவான செயல்பாட்டிற்கான பொத்தான்களை வழங்குகிறது, "
+"மேலும் குறிகீழ் வடிவமைப்பை கவனித்துக்கொள்கிறது."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "கவனச்சிதறல் இல்லாத பயன்முறையில் கவனம்செலுத்தாத வரிகளை முடக்கு"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "சொல் எண்ணி"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "சொற்களுக்கு பதிலாக எழுத்துக்களை எண்ணு (எ.கா., சீனருக்கு)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "வாசிப்பு முறை"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "படிமுறை"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "பட அளவு"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "படங்களின் அதிகபட்ச அகலம் (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "படங்களின் அதிகபட்ச உயரம் (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "பிற அமைப்புகள்"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "எழுத்துரு அளவு"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "உள்தள்ளல் அளவு (இடைவெளி எண்ணிக்கை)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "இடைவெளிகளுக்கு பதிலாக தாவல்களைப் பயன்படுத்தி உள்தள்ளல்"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "தானாக நிறைவு செய்யும் போது உணர்வுகளைப் பரிந்துரை"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "இணைப்பு முன்னோட்டங்களைக் காட்டு"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "பொருந்தக்கூடிய எழுத்து இணைகளை தானாக மூடு"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "காட்சி முறை"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "மெல்லிய"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "விரிவாகப்பட்ட"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "இணைந்தது"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"மெல்லிய பயன்முறை உங்கள் கோப்பகங்களையும் கோப்புகளையும் தனித்தனியாகக் காட்டுகிறது. கோப்பு "
+"பட்டியலில் அதன் உள்ளடக்கங்களைக் காட்ட ஒரு கோப்பகத்தைத் தேர்ந்தெடுக்கவும். கோப்பகங்கள் அல்லது "
+"கோப்பு பட்டியலின் மேல் இடது மூலையில்தோன்றும் அம்புக்குறி பொத்தானைக் கிளிக் செய்வதன் மூலம் "
+"கோப்பு பட்டியல் மற்றும் அடைவு மரத்திற்கு இடையில் மாறவும்."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "கோப்பு தகவலைக் காட்டு"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "கோப்புகளுக்கு மேலே உள்ள கோப்புறைகளைக் காட்டு"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "கீழ்குறி ஆவணத்தின் பெயர் காட்சி"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "கோப்பு பெயர் மட்டும்"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "பொருந்தினால் தலைப்பு"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "பொருந்தினால் முதல் தலைப்பு நிலை 1"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "பொருந்தினால் தலைப்பு அல்லது முதல் தலைப்பு நிலை 1"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "கீழ்குறி கோப்பு நீட்டிப்புகளைக் காண்பி"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "நேரக்  காட்சி"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "கடைசியாக மாற்றிய நேரம்"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "கோப்பு உருவாக்கிய நேரம்"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "வரிசைப்படுத்துதல்"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "ஆவணங்களை வரிசைப்படுத்தும்போது"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "இயற்கை ஒழுங்கு பயன்படுத்து(2 க்குப் பிறகு 10 வரும்)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "தபஅஇகு ஒழுங்கு பயன்படுத்து(10 க்குப் பிறகு 2 வரும்)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "மேற்கோள்கள்"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "உங்கள் மேற்கோள்களைச் செருக தன்னியக்க ஒப்பனை எப்படி விரும்புகிறீர்கள்?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "கோப்பு பாதை"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "செட்டல்காச்டன் அடையாளங்கள்"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "செட்டல்காச்டன் அடையாளங்கள் ஒழுங்குமுறை"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "இசிஎம்எகைஉரை வழக்க வெளிப்பாடு பயன்படுத்து"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "புதிய அடையாளங்களை உருவாக்க பயன்படுத்தப்படும் முறை"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "கிடைக்கக்கூடிய மாறிகள்: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "கோப்பு பெயருடன் மட்டும் இணை"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "கோப்புகளை இணைக்கும்போது, ஆவண பெயரைச் சேர்…"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "எப்போதும்"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "அடையாளத்தைப் பயன்படுத்தி இணைக்கும்போது மட்டும்"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "ஒருபோதும்"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "இணைப்பு வடிவம்"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"உண்மையான இணைப்பு இலக்கிலிருந்து செங்குத்து பட்டை எழுத்தால் பிரிக்கப்பட்ட விருப்பத் தலைப்பைச் "
+"சேர்க்க உள் இணைப்புகள் உங்களை அனுமதிக்கின்றன. இங்கே நீங்கள் இரண்டின் வரிசையை வரையறுக்கலாம்."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[இணைப்பு|தலைப்பு]]: இணைப்பு முதலில் (பரிந்துரைக்கப்பட்டது)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[தலைப்பு|இணைப்பு]]: தலைப்பு முதலில்"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "உள் இணைப்புகளைப் பின்பற்றும்போது ஒரு முழு-உரை தேடலைத் தொடங்கு"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "தேடல் சரமானது அடைப்புக்குறிகளுக்கு இடையே உள்ள உள்ளடக்கத்துடன் பொருந்தும்: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"உள் இணைப்புகளைப் பின்பற்றும்போது தானாகவே இந்த கோப்புறையில் இல்லாத கோப்புகளை உருவாக்கு"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr "இது வேலை செய்ய, கோப்புறை செட்லரில் பணியிடமாக திறக்கப்பட வேண்டும்."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "கோப்புறைக்கான பாதை"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "துணுக்குகள்"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "துணுக்குகள் திருத்தியைத் திற"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "மொழிகருவி"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "கண்டிப்பு"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "தரநிலை"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "எடுத்துரை"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "தாய்மொழி"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "அமைக்கப்படவில்லை"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "மொழிகருவி வழங்குநர்"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "தனிப்பயன் சேவையகம்"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "தனிப்பயன் சேவையக முகவரி"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "மொழிகருவி உயர்மதிப்பு"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"செட்லர் \"மொழிகருவி வழங்குநர்\" அமைப்புகளை நீங்கள் இங்கு ஏதேனும் நற்சான்றிதழ்களை உள்ளிட்டால் "
+"புறக்கணிக்கும்."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "மொழிகருவி பயனர்பெயர்"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "மொழிகருவி பநிஇ திறவுகோல்"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "எழுத்துகள்சரிபார்ப்பு"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "செயலில்"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "மொழி"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "குறியீடு"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "தானியங்கி எழுத்துப்பிழை சரிபார்ப்பை இயக்க விரும்பும் மொழிகளைத் தேர்ந்தெடு."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "பயனர் அகராதி. சொற்களைக் சொடுக்குவதன் மூலம் அவற்றை அகற்று."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "அகராதி பதிவு"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "உள்ளீடுகளைத் தேடு…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "பயன்பாட்டு மொழி"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "தானிசேமி"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "மாற்றங்களை சேமி"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "உடனடியாக"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "குறுகிய தாமதத்திற்குப் பிறகு"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "இயல்புநிலை பட கோப்புறை"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"\"கோப்புறையைத் தேர்ந்தெடு...\" என்பதைக் சொடுக்கவும் அல்லது உள்ளீட்டு புலத்தில் நேரடியாக "
+"ஒரு முழுமையான அல்லது தொடர்புடைய பாதையைத் தட்டச்சு செய்யவும்."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "நடத்தை"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "முடிந்தால் புதிய தாவல்களில் கோப்புகளைத் திறப்பதைத் தவிர்"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "புதுப்பிகள்"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "புதுப்பிப்புகளை தானாக சரிபார்"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s எழுத்துக்கள்"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s சொற்கள்"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "அடிக்குறிப்பு குறிப்புக்குச் செல்"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "முன்னிலைப்படுத்துதல் இல்லை"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "கண்டறியும் பலகம் திற"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "முடக்கப்பட்டது"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "தனிப்பயன்"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "தானாகவே கண்டறி"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "தேவதை வரைபடத்தை வழங்குதல்…"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "வரைபடத்தை வழங்க முடியவில்லை:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "படிக்கக்கூடிய முறை (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "படம் காணப்படவில்லை: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "எழுத்துப்பிழை"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "கோப்பு %s இல்லை."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "சொல் எண்ணிக்கை"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "மாற்றப்பட்ட"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "திற…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "புதிய தாவலில் திற"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "இணைப்பு முன்னோட்டங்களை எடுக்கிறது"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "இணைப்பு"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "படம்"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "கருத்து"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "அடிக்குறிப்பு உரை எதுவும் கிடைக்கவில்லை."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "சமன்பாடு குறியீட்டை நகலெடு"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "இடைநிலைப் பலகைக்கு படத்தை நகலெடு"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "படத்தை திற"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "கண்டுபிடிப்பாளரில் வெளிப்படுத்து"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "உலாவியில் வெளிப்படுத்து"
-
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr "கோப்பு உலாவியில் வெளிப்படுத்து"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "கோப்பை மூடு"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "பரிந்துரைகள் இல்லை"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "கோப்பகத்தை மறுபெயரிடு"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "அகராதியில் சேர்"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "கோப்பகத்தை நீக்கு"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "சாய்வு"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "கோப்பகத்தை சரிபார்…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "இணைப்பைச் செருகு"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "ஏற்றுமதி திட்டம்"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "வரிசைப்படுத்தப்படாத பட்டியலைச் செருகு"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "எண்ணிடப்பட்ட பட்டியலைச் செருகு"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "மற்ற தாவல்களை மூடு"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "எல்லா தாவல்களையும் மூடு"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "பின்நீக்கு தாவல்"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "முள் தாவல்"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "இந்த இணைப்பைப் பின்பற்ற கட்டளை/கட்டுபாடு-சொடுக்கு"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1505,320 +2523,318 @@ msgstr "சீன (தைவான்)"
 msgid "Chinese"
 msgstr "சீன"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "தானாகவே கண்டறி"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "முடக்கப்பட்டது"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "தனிப்பயன்"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s சொற்கள்"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s எழுத்துக்கள்"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "கண்டறியும் பலகம் திற"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "எழுத்துப்பிழை"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "அடிக்குறிப்பு குறிப்புக்குச் செல்"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "பண்புகள்"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "இணைப்பு முன்னோட்டங்களை எடுக்கிறது"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "நகல் கோப்பு"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "தடிமான"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "நகல் பாதை"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "சாய்வு"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "கோப்பு பெயரை நகலெடு"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "இணைப்பு"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "உலாவியில் வெளிப்படுத்து"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "படம்"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "கருத்து"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "குறியீடு"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "அடிக்குறிப்பு உரை எதுவும் கிடைக்கவில்லை."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "கோப்பு %s இல்லை."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "சொல் எண்ணிக்கை"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "மாற்றப்பட்ட"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "திற…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "புதிய தாவலில் திற"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "முன்னிலைப்படுத்துதல் இல்லை"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "இடைநிலைப் பலகைக்கு படத்தை நகலெடு"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "படத்தை திற"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr "கோப்பு உலாவியில் வெளிப்படுத்து"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "பரிந்துரைகள் இல்லை"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "கோப்பை மூடு"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "அகராதியில் சேர்"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "கோப்பகத்தை மறுபெயரிடு"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "சாய்வு"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "கோப்பகத்தை நீக்கு"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "இணைப்பைச் செருகு"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "கோப்பகத்தை சரிபார்…"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "வரிசைப்படுத்தப்படாத பட்டியலைச் செருகு"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "ஏற்றுமதி திட்டம்"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "எண்ணிடப்பட்ட பட்டியலைச் செருகு"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "மற்ற தாவல்களை மூடு"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "எல்லா தாவல்களையும் மூடு"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "பின்நீக்கு தாவல்"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "முள் தாவல்"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "நாட்காட்டி"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "விளக்கப்படங்கள்"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "சமன்பாடு குறியீட்டை நகலெடு"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "படிக்கக்கூடிய முறை (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "படம் காணப்படவில்லை: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "தேவதை வரைபடத்தை வழங்குதல்…"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "தை"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "வரைபடத்தை வழங்க முடியவில்லை:"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "மாசி"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "இந்த இணைப்பைப் பின்பற்ற கட்டளை/கட்டுபாடு-சொடுக்கு"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "பங்குனி"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "புதுப்பிப்பவர்"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "சித்திரை"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "புதிய புதுப்பிப்பு கிடைக்கிறது"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "வைகாசி"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "உங்கள் பதிப்பு"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "ஆனி"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "ஆடி"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "ஆவணி"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "புரட்டாசி"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "ஐப்பசி"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "கார்த்திகை"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "மார்கழி"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "திங்கள் சராசரிக்கு விட குறைவு"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "திங்கள் சராசரியை விட அதிகம்"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "திங்கள் சராசரியை விட இரண்டு மடங்கு அதிகமாகும்"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "பதிவிறக்கம் செய்ய செட்லரின் புதிய பதிப்பு உள்ளது. கீழே உள்ள மாற்றங்களை படி."
+"Some files are selected for export but no longer exist in the directory."
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "உங்கள் புதுப்பிப்பைப் பதிவிறக்குகிறது"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "புதுப்பிப்பு எதுவும் கிடைக்கவில்லை. உங்களிடம் மிக அண்மைக் கால பதிப்பு உள்ளது."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "புதுப்பிப்பைத் தொடங்க சொடுக்கு"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "ஒருபோதும்"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "கடைசியாக சரிப்பார்த்தது: %s"
-
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "புதுப்பிப்பு தொடங்குகிறது …"
-
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "தேடல்"
+
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "எண்ணிக்கை"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "குறிச்சொற்களை வடிகட்டி…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "மீட்டமை"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "கோப்புறை தேர்ந்தெடு..."
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "கோப்பை தேர்ந்தெடு..."
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "சேர்"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "செயல்கள்"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "நீக்கு"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "பட அளவு"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1835,10 +2851,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1905,45 +2917,29 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "இந்த திட்டங்களையும் செட்லர் பயன்படுத்துகிறது:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"அதை மேலும் தனிப்பயனாக்க செட்லர் இன் பாணிகளை இங்கே மேலெழுதலாம். <strong> கவனம்: இந்த "
-"கோப்பு அனைத்து சிஎச்எச் வழிமுறைகளையும் மீறுகிறது! உறுப்புகளின் வடிவவியலை ஒருபோதும் "
-"மாற்ற வேண்டாம், இல்லையெனில் பயன்பாடு தேவையற்ற நடத்தையை வெளிப்படுத்தக்கூடும்! </strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "துணுக்கை மறுபெயரிடு"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"துணுக்குகள் மீண்டும் பயன்படுத்தக்கூடிய உரையின் துண்டுகளை மாறிகள் வரையறுக்க அனுமதிக்கின்றன."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "துணுக்குக் கோப்புறை திற"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "சேமிப்பு…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "சேமிப்பு தோல்வியடைந்தது"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "தனிப்பயன் சிஎச்எச்"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "துணுக்குகள்"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "சேமிக்கப்பட்டது!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1969,40 +2965,77 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "இறக்குமதி அல்லது ஏற்றுமதிக்கான இயல்புநிலை அமைப்புகளை இங்கே திருத்து."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "சேமிக்கப்பட்டது!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "துணுக்கை மறுபெயரிடு"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
-"துணுக்குகள் மீண்டும் பயன்படுத்தக்கூடிய உரையின் துண்டுகளை மாறிகள் வரையறுக்க அனுமதிக்கின்றன."
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "துணுக்குக் கோப்புறை திற"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "சொற்கள்"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"அதை மேலும் தனிப்பயனாக்க செட்லர் இன் பாணிகளை இங்கே மேலெழுதலாம். <strong> கவனம்: இந்த "
+"கோப்பு அனைத்து சிஎச்எச் வழிமுறைகளையும் மீறுகிறது! உறுப்புகளின் வடிவவியலை ஒருபோதும் "
+"மாற்ற வேண்டாம், இல்லையெனில் பயன்பாடு தேவையற்ற நடத்தையை வெளிப்படுத்தக்கூடும்! </strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "எழுத்துக்கள்"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "சேமிப்பு தோல்வியடைந்தது"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "திறந்த ஆவணம் இல்லை"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "தொடங்கு"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "எண்ணிக்கை"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "குறிச்சொற்களை வடிகட்டி…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2028,76 +3061,114 @@ msgstr "ஒலி விளைவு"
 msgid "Volume"
 msgstr "தொகுதி"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "கடந்த திங்கள் சொற்கள்"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "தொடர்புடைய கோப்புகள்"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "அன்றாடம் சராசரி"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "தொடர்புடைய கோப்புகள் இல்லை"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "இன்று சொற்கள்"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "இந்த உறவு ஒரு இருதரப்பு இணைப்பை அடிப்படையாகக் கொண்டது."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 நீங்கள் தீயில்!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "இந்த உறவு வெளிச்செல்லும் இணைப்பை அடிப்படையாகக் கொண்டது."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 உங்கள் அன்றாட சராசரியைத் தாக்க நீங்கள் நெருக்கமாக இருக்கிறீர்கள்!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "இந்த உறவு ஒரு பின்னிணைப்பை அடிப்படையாகக் கொண்டது."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 உங்கள் அன்றாட சராசரியை மிஞ்சும் எழுத்தைப் பெறு."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "மேலும் புள்ளிவிவரங்கள்…"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "இந்த உறவு %s பகிரப்பட்ட குறிச்சொற்களை அடிப்படையாகக் கொண்டது: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "பிற கோப்புகள்"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "அடைவு திற"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "வேறு கோப்புகள் இல்லை"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "குறிப்புகள்"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "இந்த ஆவணத்தில் மேற்கோள்கள் எதுவும் இல்லை."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "பெயர்"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "குறிச்சொல் முகில்"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "ஏற்றுமதி செய்கிறது…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "ஏற்றுமதி"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "கட்டளை"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2107,8 +3178,8 @@ msgstr "கோப்பகங்கள்"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "கோப்புகள்"
 
@@ -2122,10 +3193,26 @@ msgstr "எழுத்துக்கள்"
 msgid "Words"
 msgstr "சொற்கள்"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "பணியிடங்கள்"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "திறந்த கோப்புகள் அல்லது கோப்புறைகள் இல்லை"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "முடிவுகள் இல்லை"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "எந்த கோப்பகமும் தேர்ந்தெடுக்கப்படவில்லை"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "வெற்று அடைவு"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2155,15 +3242,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "மீட்டமை"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2224,13 +3302,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "நாட்காட்டி"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2440,130 +3511,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "எழுதும் இலக்கை அமை…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "முடிவுகள் இல்லை"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "எந்த கோப்பகமும் தேர்ந்தெடுக்கப்படவில்லை"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "வெற்று அடைவு"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "பணியிடங்கள்"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "திறந்த கோப்புகள் அல்லது கோப்புறைகள் இல்லை"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "கடந்த திங்கள் சொற்கள்"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "அன்றாடம் சராசரி"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "இன்று சொற்கள்"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 நீங்கள் தீயில்!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 உங்கள் அன்றாட சராசரியைத் தாக்க நீங்கள் நெருக்கமாக இருக்கிறீர்கள்!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 உங்கள் அன்றாட சராசரியை மிஞ்சும் எழுத்தைப் பெறு."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "மேலும் புள்ளிவிவரங்கள்…"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "ஏற்றுமதி செய்கிறது…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "ஏற்றுமதி"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "கட்டளை"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2585,11 +3536,6 @@ msgstr "கோப்பகத்திற்கு தேடலை கட்ட�
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "தேடல்"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "தேடலை அழி"
@@ -2603,1075 +3549,135 @@ msgstr "முடிவுகளை மாற்று"
 msgid "%s matches across %s files"
 msgstr "குறிச்சொல்லை \"%s\" ஐ \"%s\" உடன் %s கோப்புகளில் மாற்றவா?"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "பெயர்"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "குறிச்சொல் முகில்"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "சொற்கள்"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "எழுத்துக்கள்"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "திறந்த ஆவணம் இல்லை"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "தொடர்புடைய கோப்புகள்"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "தொடர்புடைய கோப்புகள் இல்லை"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "இந்த உறவு ஒரு இருதரப்பு இணைப்பை அடிப்படையாகக் கொண்டது."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "இந்த உறவு வெளிச்செல்லும் இணைப்பை அடிப்படையாகக் கொண்டது."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "இந்த உறவு ஒரு பின்னிணைப்பை அடிப்படையாகக் கொண்டது."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "இந்த உறவு %s பகிரப்பட்ட குறிச்சொற்களை அடிப்படையாகக் கொண்டது: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "பிற கோப்புகள்"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "அடைவு திற"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "வேறு கோப்புகள் இல்லை"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "சேர்"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "செயல்கள்"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "நீக்கு"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "கோப்புறை தேர்ந்தெடு..."
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "கோப்பை தேர்ந்தெடு..."
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "குறிப்புகள்"
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "இந்த ஆவணத்தில் மேற்கோள்கள் எதுவும் இல்லை."
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#, javascript-format
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "புதுப்பிப்பவர்"
 
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "புதிய புதுப்பிப்பு கிடைக்கிறது"
 
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "உங்கள் பதிப்பு"
 
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "பதிவிறக்கம் செய்ய செட்லரின் புதிய பதிப்பு உள்ளது. கீழே உள்ள மாற்றங்களை படி."
 
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "உங்கள் புதுப்பிப்பைப் பதிவிறக்குகிறது"
 
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "புதுப்பிப்பு எதுவும் கிடைக்கவில்லை. உங்களிடம் மிக அண்மைக் கால பதிப்பு உள்ளது."
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "தோற்றம்"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "புதுப்பிப்பைத் தொடங்க சொடுக்கு"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "எழுத்துகள்சரிபார்ப்பு"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "தானாகதிருத்து"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "மேற்கோள்கள்"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "தை"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "மாசி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "பங்குனி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "சித்திரை"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "வைகாசி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "ஆனி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "ஆடி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "ஆவணி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "புரட்டாசி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "ஐப்பசி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "கார்த்திகை"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "மார்கழி"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "திங்கள் சராசரிக்கு விட குறைவு"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "திங்கள் சராசரியை விட அதிகம்"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "திங்கள் சராசரியை விட இரண்டு மடங்கு அதிகமாகும்"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "விளக்கப்படங்கள்"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "செட்டல்காச்டன் அடையாளங்கள்"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "செட்டல்காச்டன் அடையாளங்கள் ஒழுங்குமுறை"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "இசிஎம்எகைஉரை வழக்க வெளிப்பாடு பயன்படுத்து"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "புதிய அடையாளங்களை உருவாக்க பயன்படுத்தப்படும் முறை"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "கிடைக்கக்கூடிய மாறிகள்: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "உள் இணைப்புகள்"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "கோப்பு பெயருடன் மட்டும் இணை"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "கோப்புகளை இணைக்கும்போது, ஆவண பெயரைச் சேர்…"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "எப்போதும்"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "அடையாளத்தைப் பயன்படுத்தி இணைக்கும்போது மட்டும்"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr "ஒருபோதும்"
 
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "இணைப்பு வடிவம்"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"உண்மையான இணைப்பு இலக்கிலிருந்து செங்குத்து பட்டை எழுத்தால் பிரிக்கப்பட்ட விருப்பத் தலைப்பைச் "
-"சேர்க்க உள் இணைப்புகள் உங்களை அனுமதிக்கின்றன. இங்கே நீங்கள் இரண்டின் வரிசையை வரையறுக்கலாம்."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[இணைப்பு|தலைப்பு]]: இணைப்பு முதலில் (பரிந்துரைக்கப்பட்டது)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[தலைப்பு|இணைப்பு]]: தலைப்பு முதலில்"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "உள் இணைப்புகளைப் பின்பற்றும்போது ஒரு முழு-உரை தேடலைத் தொடங்கு"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "தேடல் சரமானது அடைப்புக்குறிகளுக்கு இடையே உள்ள உள்ளடக்கத்துடன் பொருந்தும்: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"உள் இணைப்புகளைப் பின்பற்றும்போது தானாகவே இந்த கோப்புறையில் இல்லாத கோப்புகளை உருவாக்கு"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr "இது வேலை செய்ய, கோப்புறை செட்லரில் பணியிடமாக திறக்கப்பட வேண்டும்."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "கோப்புறைக்கான பாதை"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "அறிவு மேற்கோள்கள்"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "இரட்டை மேற்கோள்கள்"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "மந்திர மேற்கோள்களை முடக்கு"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "ஒற்றை மேற்கோள்கள்"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "உரை-மாற்று வடிவங்கள்"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "முழு சொற்களையும் பொருத்து"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-"சரிபார்க்கும்போது, தன்னியக்கக் கட்டுப்பாடு ஒருபோதும் சொற்களின் சில பகுதிகளை மாற்றாது"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "மாற்று"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "உடன்"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "வடிகட்டி"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "உள்ளீட்டு முறை"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"நீங்கள் திருத்தியுடன் எவ்வாறு தொடர்பு கொள்கிறீர்கள் என்பதை உள்ளீட்டு முறை தீர்மானிக்கிறது. இந்த "
-"அமைப்பை \"இயல்பான\" இல் வைக்க பரிந்துரைக்கிறோம். இது எதைக் குறிக்கிறது என்று உங்களுக்குத் "
-"தெரிந்தால் மட்டுமே \"விம்\" அல்லது \"இமேக்சு\" என்பதைத் தேர்ந்தெடு."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "எழுதும் திசை"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "குறிகீழ் வழங்குதல்"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"வடிவமைக்கப்பட்ட தோற்றத்திற்கு பல்வேறு குறிகீழ் கூறுகளின் நேரடி வழங்குதலை இயக்க சரிபார். "
-"இது வடிவமைத்தல் எழுத்துக்களை (**உரை** போன்றவை) மறைக்கிறது அல்லது அவற்றின் இணைப்பிற்குப் "
-"பதிலாக படங்களை வழங்குகிறது."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "தலைப்பு எழுத்துக்களை மறை"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "முக்கியத்துவம் அளி"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "பாணி சிக்கல்களுக்கு கீழ்குறி சரிபார்"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "அட்டவணை திருத்தி"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"அட்டவணை திருத்தி என்பது ஒரு ஊடாடும் இடைமுகமாகும், இது அட்டவணைகளை உருவாக்குவதையும் "
-"திருத்துவதையும் எளிதாக்குகிறது. இது பொதுவான செயல்பாட்டிற்கான பொத்தான்களை வழங்குகிறது, "
-"மேலும் குறிகீழ் வடிவமைப்பை கவனித்துக்கொள்கிறது."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "கவனச்சிதறல் இல்லாத பயன்முறையில் கவனம்செலுத்தாத வரிகளை முடக்கு"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "சொல் எண்ணி"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "சொற்களுக்கு பதிலாக எழுத்துக்களை எண்ணு (எ.கா., சீனருக்கு)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "வாசிப்பு முறை"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "படிமுறை"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "படங்களின் அதிகபட்ச அகலம் (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "படங்களின் அதிகபட்ச உயரம் (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "பிற அமைப்புகள்"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "எழுத்துரு அளவு"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "உள்தள்ளல் அளவு (இடைவெளி எண்ணிக்கை)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "இடைவெளிகளுக்கு பதிலாக தாவல்களைப் பயன்படுத்தி உள்தள்ளல்"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "தானாக நிறைவு செய்யும் போது உணர்வுகளைப் பரிந்துரை"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "இணைப்பு முன்னோட்டங்களைக் காட்டு"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "பொருந்தக்கூடிய எழுத்து இணைகளை தானாக மூடு"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "அட்டவணை"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "அணை"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "முறைமையைப் பின்பற்று"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "மேல்"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "முடிவு"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "கருபொருள்"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "கருவிப்பட்டி விருப்பங்கள்"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "நிலைப்பட்டி"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "சிஎச்எச் திருத்தி திற"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "மொழிகருவி"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "கண்டிப்பு"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "தரநிலை"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "எடுத்துரை"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "தாய்மொழி"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "அமைக்கப்படவில்லை"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "மொழிகருவி வழங்குநர்"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "தனிப்பயன் சேவையகம்"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "தனிப்பயன் சேவையக முகவரி"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "மொழிகருவி உயர்மதிப்பு"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"செட்லர் \"மொழிகருவி வழங்குநர்\" அமைப்புகளை நீங்கள் இங்கு ஏதேனும் நற்சான்றிதழ்களை உள்ளிட்டால் "
-"புறக்கணிக்கும்."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "மொழிகருவி பயனர்பெயர்"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "மொழிகருவி பநிஇ திறவுகோல்"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "செயலில்"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "மொழி"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "தானியங்கி எழுத்துப்பிழை சரிபார்ப்பை இயக்க விரும்பும் மொழிகளைத் தேர்ந்தெடு."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "பயனர் அகராதி. சொற்களைக் சொடுக்குவதன் மூலம் அவற்றை அகற்று."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "அகராதி பதிவு"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "உள்ளீடுகளைத் தேடு…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "காட்சி முறை"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "மெல்லிய"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "விரிவாகப்பட்ட"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "இணைந்தது"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"மெல்லிய பயன்முறை உங்கள் கோப்பகங்களையும் கோப்புகளையும் தனித்தனியாகக் காட்டுகிறது. கோப்பு "
-"பட்டியலில் அதன் உள்ளடக்கங்களைக் காட்ட ஒரு கோப்பகத்தைத் தேர்ந்தெடுக்கவும். கோப்பகங்கள் அல்லது "
-"கோப்பு பட்டியலின் மேல் இடது மூலையில்தோன்றும் அம்புக்குறி பொத்தானைக் கிளிக் செய்வதன் மூலம் "
-"கோப்பு பட்டியல் மற்றும் அடைவு மரத்திற்கு இடையில் மாறவும்."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "கோப்பு தகவலைக் காட்டு"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "கோப்புகளுக்கு மேலே உள்ள கோப்புறைகளைக் காட்டு"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "கீழ்குறி ஆவணத்தின் பெயர் காட்சி"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "கோப்பு பெயர் மட்டும்"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "பொருந்தினால் தலைப்பு"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "பொருந்தினால் முதல் தலைப்பு நிலை 1"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "பொருந்தினால் தலைப்பு அல்லது முதல் தலைப்பு நிலை 1"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "கீழ்குறி கோப்பு நீட்டிப்புகளைக் காண்பி"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "நேரக்  காட்சி"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "கடைசியாக மாற்றிய நேரம்"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "கோப்பு உருவாக்கிய நேரம்"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "வரிசைப்படுத்துதல்"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "ஆவணங்களை வரிசைப்படுத்தும்போது"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "இயற்கை ஒழுங்கு பயன்படுத்து(2 க்குப் பிறகு 10 வரும்)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "தபஅஇகு ஒழுங்கு பயன்படுத்து(10 க்குப் பிறகு 2 வரும்)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "இறக்குமதி மற்றும் ஏற்றுமதி தன்வயவிவரங்கள்"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "இறக்குமதி தன்வயவிவரங்கள் திருத்தி திற"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "ஏற்றுமதி தன்வயவிவரங்கள் திருத்தி திற"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "ஏற்றுமதி அமைப்புகள்"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "ஏற்றுமதிக்கு செட்லரின் உள் பாண்ஆவணம் பயன்படுத்து"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "ஏற்றுமதிமதியின் போது கோப்புகளிலிருந்து குறிச்சொற்களை அகற்று"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "உள் இணைப்புகளை முழுவதுமாக அகற்று"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "உள் இணைப்புகளை அவிழ்த்து விடு"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "உள் இணைப்புகளைத் தொட வேண்டாம்"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "ஏற்றுமதி செய்யப்பட்ட கோப்புகளுக்கான இலக்கு கோப்புறை"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "தற்காலிக கோப்புறை"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "கோப்பு இருப்பிடம் போன்றது"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "ஏற்றுமதி செய்யும் போது கோப்புறையைக் கேள்"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"எச்சரிக்கை! தற்காலிக கோப்புறையில் உள்ள கோப்புகள் தொடர்ந்து நீக்கப்படும். கோப்பு இருக்கும் அதே "
-"இடத்தைத் தேர்ந்தெடுப்பது, ஏற்கனவே இருந்தால், ஒரே மாதிரியான கோப்புப்பெயர்களைக் கொண்ட "
-"கோப்புகளை மேலெழுதும்."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "தனிப்பயன் ஏற்றுமதி கட்டளைகள்"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "காட்சி பெயர்"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "கட்டளை"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"ஏற்றுமதியாளரை இயக்க தனிப்பயன் கட்டளைகளை உள்ளிடவும். ஒவ்வொரு கட்டளையும் அதன் முதல் வாதமாக "
-"ஏற்றுமதி செய்ய வேண்டிய கோப்பு அல்லது திட்ட கோப்புறையைப் பெறுகிறது."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "புதிய கோப்பு பெயர்களுக்கான முறை"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "புதிய கோப்பு பெயர்களுக்கான முறை வரையறை"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Available variables: %s"
-msgstr "கிடைக்கக்கூடிய மாறிகள்: %s"
+msgid "Last checked: %s"
+msgstr "கடைசியாக சரிப்பார்த்தது: %s"
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "புதிய கோப்புகளை உருவாக்கும்போது கோப்பு பெயருக்கு கேட்க வேண்டாம்"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "சொந்த சாளர தோற்றத்தைப் பயன்படுத்து"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "லினக்சில் மட்டுமே கிடைக்கும்; இது மேக்இமு மற்றும் சாளரங்களுக்கான இயல்புநிலை."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "சாளர அதிர்வுகளை இயக்கு"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "மேக்இமு இல் மட்டுமே கிடைக்கும்; சாளர பின்னணியை ஒளிபுகா செய்கிறது."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "அறிவிப்பு பகுதியில் பயன்பாட்டைக் காட்டு"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "அறிவிப்பு பகுதியில் பயன்பாட்டை இயக்கு"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "பெரிதாக்கு நடத்தை"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "முழு இடைமுகத்தை மாற்றியமைக்கிறது"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "திருத்தி எழுத்துரு அளவை மாற்றுகிறது"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "இணைப்புகள் பக்கப்பட்டி"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "கோப்பு நீட்டிப்புகள் இணைப்புகள் பக்கப்பட்டியில் தெரியும்"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "இசட்டம் வழங்கும் அனுமதிப்பட்டியல்"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "புரவலன்பெயர்"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "கண்காணிப்பு பதிவு"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"ஒரு கோப்பை எழுதியதாகக் கருதப்படுவதற்கு முன் காத்திருக்க வேண்டிய நேரம் (மி.நொடியில்) "
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "உருப்படிகளை நீக்குதல்"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "பிழைத்திருத்த பயன்முறை"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "பிழைத்திருத்த பயன்முறையை இயக்கு"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "ஆவண்னா வெளியீடுகள்"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "ஆவண்னா வெளியீடுகள் பற்றி எனக்குத் தெரிவி"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "துணுக்குகள் திருத்தியைத் திற"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "பயன்பாட்டு மொழி"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "தானிசேமி"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "மாற்றங்களை சேமி"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "உடனடியாக"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "குறுகிய தாமதத்திற்குப் பிறகு"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "இயல்புநிலை பட கோப்புறை"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"\"கோப்புறையைத் தேர்ந்தெடு...\" என்பதைக் சொடுக்கவும் அல்லது உள்ளீட்டு புலத்தில் நேரடியாக "
-"ஒரு முழுமையான அல்லது தொடர்புடைய பாதையைத் தட்டச்சு செய்யவும்."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "நடத்தை"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "முடிந்தால் புதிய தாவல்களில் கோப்புகளைத் திறப்பதைத் தவிர்"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "புதுப்பிகள்"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "புதுப்பிப்புகளை தானாக சரிபார்"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "உங்கள் மேற்கோள்களைச் செருக தன்னியக்க ஒப்பனை எப்படி விரும்புகிறீர்கள்?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "கோப்பு பாதை"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "புதுப்பிப்பு தொடங்குகிறது …"
 
 #~ msgid "Open Link"
 #~ msgstr "இணைப்பை திற"

--- a/static/lang/tr-TR.po
+++ b/static/lang/tr-TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,21 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Atıf veri tabanı yüklenemedi"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr ""
+"Kütüphane dosyasında değişiklikler tespit edildi. Yeniden yükleniyor ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Çalışma alanları"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -67,142 +82,6 @@ msgstr "%s ayarı en az %s (karakter uzunluğu)'nda olmalı."
 msgid "Option %s is required."
 msgstr "%s ayarı gereklidir."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Zettlr'ı Göster"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Çık"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Güncelleme mevcut"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Güncellemeler kontrol edilemedi: Sunucu hatası (Durum kodu: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Güncellemeler kontrol edilemedi: Alıcı Hatası (Durum kodu: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Güncellemeler kontrol edilemedi: Sunucu yeniden yönlendirmeye çalıştı (Durum "
-"kodu: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Güncellemeler kontrol edilemedi: Bağlantı kurulamadı"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Güncellemeler kontrol edilemedi: Sunucu herhangi bir veri göndermedi"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr ""
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Dosya oluşturulamadı"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "%s içeren referans herhangi bir eke sahip görünmüyor."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Ek açılamadı. Zotero çalışıyor mu?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -220,24 +99,98 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr ""
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Tamam"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "İptal"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Gerçekten silinsin mi?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "%s silinsin istiyor musunuz?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "%s içeren referans herhangi bir eke sahip görünmüyor."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Ek açılamadı. Zotero çalışıyor mu?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Hatalı Biçimlendirilmiş Metin Paketi: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr ""
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Projeyi Dışarı Aktar"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Dışarı aktar..."
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -292,48 +245,6 @@ msgstr "%s dosyaları içeri aktarılamadı, çünkü dosya uzantıları bilinmi
 msgid "Import failed"
 msgstr "Dışa aktarma başarısız"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Projeyi Dışarı Aktar"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Tamam"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Dışarı aktar..."
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Dizin taşınamadı"
@@ -351,28 +262,49 @@ msgstr "Dizin veya dosya taşınamıyor."
 msgid "The file/directory %s already exists in target."
 msgstr "%s dosyası/dizini hedefte zaten mevcut."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "İsimsiz"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Girilen isim, izin verilen harfler içermiyor."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Dizin oluşturulamadı"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "İstenen dizin bulunamadı."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Gerçekten silinsin mi?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Dışa aktarma başarısız"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Dışa aktarmada hata oluştu: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr ""
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Kaydet"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "%s silinsin istiyor musunuz?"
+msgid "Exporting to %s"
+msgstr "%s içine aktarılıyor."
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Dışa aktarmada hata oluştu: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -397,10 +329,12 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr ""
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
 msgstr ""
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
@@ -414,129 +348,34 @@ msgstr "Dil dosyası içeri aktarıldı: %s"
 msgid "Could not import language file %s!"
 msgstr "Dil dosyası %s içeri aktarılamadı."
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Dışa aktarma başarısız"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Dosya oluşturulamadı"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Dışa aktarmada hata oluştu: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr ""
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Kaydet"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "%s içine aktarılıyor."
+msgid "Copy of %s"
+msgstr ""
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "İsimsiz"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Dizin oluşturulamadı"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Dışa aktarmada hata oluştu: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Girilen isim, izin verilen harfler içermiyor."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "İstenen dizin bulunamadı."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
 msgstr ""
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr ""
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Hatalı Biçimlendirilmiş Metin Paketi: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Her zaman mevcut dosyaya dışarıdan yapılan değişikleri ekle"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Mevcut dosyanın üzerine yaz"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "%s dosyası zaten bu dizinde mevcut. Üzerine yazılsın mı?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Dosyayı aç"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Kaydedilmemiş değişiklikler"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr ""
-"Mevcut dosyada kaydedilmemiş değişiklikler var. Değişiklikler atlansın mı "
-"yoksa kaydetmek mi istersiniz?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr ""
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Proje klasörünü aç"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Atıf veri tabanı yüklenemedi"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr ""
-"Kütüphane dosyasında değişiklikler tespit edildi. Yeniden yükleniyor ..."
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -648,6 +487,12 @@ msgstr "Dosyayı yeniden adlandır"
 msgid "Delete file"
 msgstr "Dosyayı sil"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Çık"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -666,15 +511,15 @@ msgstr "Yinele"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Kes"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -686,8 +531,8 @@ msgstr "HTML olarak kopyala"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Yapıştır"
 
@@ -699,8 +544,8 @@ msgstr "Stilsiz yapıştır"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Tümünü seç"
 
@@ -942,10 +787,165 @@ msgstr "Konuşmayı durdur"
 msgid "Bring All to Front"
 msgstr "Hepsini öne getir"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Çalışma alanları"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Proje klasörünü aç"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Her zaman mevcut dosyaya dışarıdan yapılan değişikleri ekle"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Kaydedilmemiş değişiklikler"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr ""
+"Mevcut dosyada kaydedilmemiş değişiklikler var. Değişiklikler atlansın mı "
+"yoksa kaydetmek mi istersiniz?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Dosyayı aç"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Mevcut dosyanın üzerine yaz"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "%s dosyası zaten bu dizinde mevcut. Üzerine yazılsın mı?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Zettlr'ı Göster"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Güncelleme mevcut"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Güncellemeler kontrol edilemedi: Sunucu hatası (Durum kodu: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Güncellemeler kontrol edilemedi: Alıcı Hatası (Durum kodu: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Güncellemeler kontrol edilemedi: Sunucu yeniden yönlendirmeye çalıştı (Durum "
+"kodu: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Güncellemeler kontrol edilemedi: Bağlantı kurulamadı"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Güncellemeler kontrol edilemedi: Sunucu herhangi bir veri göndermedi"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -964,143 +964,1206 @@ msgstr ""
 "Mevcut dosyada kaydedilmemiş değişiklikler var. Değişiklikler atlansın mı "
 "yoksa kaydetmek mi istersiniz?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Dosya yöneticisi modu"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
 "to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "OtomatikDüzeltme'yi aç"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Özellikler"
-
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Dosyayı çoğalt"
-
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/autocorrect.ts:45
 #, fuzzy
-msgid "Copy path"
-msgstr "ID'yi kopyala"
+msgid "Double Quotes"
+msgstr "Hiçbiri"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Dosya adını kopyala"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Hiçbiri"
 
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Hiçbiri"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Dosyayı yenisiyle değiştir"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr ""
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Etiketleri filtrele"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Program"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Kapalı"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "İşletim Sistemini Takip Et"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Açık"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Başla"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Son"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Tema"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Araç çubuğu ayarları"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+#, fuzzy
+msgid "Status bar"
+msgstr "Durum alanı"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Özel CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Dizini aç"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Profil içe/dışa aktarma"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "İçe aktarma profili düzenleyicisini aç"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "%s içine aktarılıyor."
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Dışarı aktarma için dahili Pandoc'u kullan"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Dosyalardan etiketleri kaldır"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Dahili bağlantılar"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Dahili bağlantıları tamamen kaldır"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Dahili bağlantıların bağlantılarını kaldır"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Dahili bağlantılara dokunma"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr ""
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Dosya bilgisini göster"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr ""
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Yorum"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Yeni dosya adları için şablon"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Yeni dosya adları için şablon"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Yeni dosya oluştururken dosya adı sorma"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Görünüm"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Dahili pencere görünümün kullan"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Dahili pencere görünümün kullan"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Uygulamayı bildirim alanında çalışır halde bırak"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Editor yazı boyutu"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Zamanlayıcı sorgulama seçeneğini etkinleştir"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Dosyayı yazma işleminin tamamlanmış kabul edilmesi için beklenecek süre "
+"(milisaniye cinsinden)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Dosyayı sil"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Hata ayıklama modunu aktif et"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Hata ayıklama modunu aktif et"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Beta sürümler hakkında beni haberdar et"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Editör 'girdi' yöntemi"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Girdi modu, düzenleyiciyle etkileşiminizi belirler. \"Normal\" modda "
+"kalmanızı öneririz. \"Vim\" veya \"Emacs\" modlarını yalnızca ne olduklarını "
+"biliyorsanız seçin."
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Yazım yönü"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown oluşturma"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Çeşitli Markdown öğelerinin biçimlendirilmiş görünümde canlı olarak "
+"işlenmesini etkinleştirmek için işaretleyin. Bu, biçimlendirme "
+"karakterlerini (örneğin **metin**) gizler veya bağlantıları yerine "
+"görüntüleri işler."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Başlık karakterlerini gizle"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Vurguları oluştur"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Kalın"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Eğik"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Markdown stil hatalarını kontrol et"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Tablo Düzenleyiciyi aktif et"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"Tablo Düzenleyici, tablo oluşturmayı ve düzenlemeyi basitleştiren "
+"etkileşimli bir arayüzdür.  Sık kullanılan işlevler için düğmeler sağlar ve "
+"Markdown biçimlendirmesini halleder."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Odaklanma modunda odaklanılmayan satırları kıs"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Kelime sayacı"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Kelimeler yerine karakterleri say (örn. Çince için)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Okunabilirlik modu"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Algoritma"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Görüntü"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Görsellerin maksimum genişliği (yüzdelik)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Görsellerin maksimum yüksekliği (yüzdelik)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Diğer ayarlar"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Editor yazı boyutu"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Girinti miktarı (boşluk sayısı)"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Girinti için boşluk yerine sekmeleri kullan"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Boşlukları işaretle"
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Otomatik tamamlamada emojiler öner"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Link önizlemelerini göster"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Eşleşen karakter çiftlerini otomatik olarak kapat"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Dosya bilgisini göster"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr ""
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Son düzenleme zamanı"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Dosya oluşturulma zamanı"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Dışarı aktar..."
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Son dosyalar"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Doğal düzen (2den sonra 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "ASCII düzeni (10dan sonra 2)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Atıfları göster"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Dosyayı göster"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten Kimlikleri"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Yeni IDler oluşturmak için kullanılacak şablon"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "ID düzenli ifade"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Yeni IDler oluşturmak için kullanılacak şablon"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Kullanılabilir Değişkenler: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Yalnızca dosya adıyla bağlantı oluştur"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Dosyaları bağlarken dosya ismi ekle ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "her zaman"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "Sadece ID kullanarak bağlandığında"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "hiçbir zaman"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Link biçimi"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Dahili bağlantılara isteğe bağlı bir başlık ekleyebilirsiniz. Bu başlık, "
+"gerçek bağlantı hedefinden dikey bir çubuk karakteri (|) ile ayrılır. Burada "
+"başlık ve bağlantı hedefinin sıralamasını belirleyebilirsiniz."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Başlık]]: Link önce (önerilen)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Başlık|Link]]: Başlık önce"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Zettelkasten bağlantılarını takip ederken aramayı başlat"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr ""
+"Arama dizesi, köşeli parantezler arasındaki içerikle eşleşecektir: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"İç bağlantıları takip ederken var olmayan dosyaları otomatik olarak oluştur"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Bunun çalışması için klasörün Zettlr'da bir Çalışma Alanı olarak açılması "
+"gerekir."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Klasör konumu"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Kod Parçacıkları"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Snippet Düzenleyiciyi Aç"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Özel CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Özel CSS"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Yazım Denetimi"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Kod"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Otomatik yazım denetimini açmak istediğiniz dilleri seçin."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Kullanıcı sözlüğü. Kelimelere tıklayarak silin."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr ""
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Uygulama dili"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Otomatik kaydet"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Son düzenleme zamanı"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Hemen"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Kısa bir süre sonra"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Standart resim klasörü"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Bir klasör seçmek için \"Klasör Seç…\" seçeneğine tıklayın veya giriş "
+"alanına doğrudan bir yol (mutlak veya göreli) girin."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Davranış"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Dosyaları mümkünse yeni sekmelerde açma"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Güncellemeler"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Güncellemeler için otomatik kontrol"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s karakter"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s kelime"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Dipnot referansına git"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "İşaretleme yok"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Teşhis panelini aç"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Devre Dışı"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Özel CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Otomatik olarak algıla"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Mermaid grafiği oluşturuluyor …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Dosya oluşturulamadı"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Okunabilirlik modu (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Resim bulunamadı: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "Resmi harici olarak aç"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Yazım hatası"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "%s dosyası mevcut değil."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Kelime sayısı"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Değiştirilme Tarihi"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Aç..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Yeni sekmede aç"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Link önizlemesi alınıyor…"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Link"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Görüntü"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Yorum"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Dipnot metni bulunamadı."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Denklem kodunu kopyala"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Görseli panoya kopyala"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Dosyayı aç"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Finder'da Göster"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Tarayıcıda aç"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Öneri yok"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Sözlüğe ekle"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Eğik"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Link ekle"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Sırasız liste ekle"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Numaralı liste ekle"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Dosyayı kapat"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Dizini yeniden adlandır"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Dizini sil"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Dizini kontrol et ..."
-
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Projeyi Dışarı Aktar"
-
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Tüm sekmeleri kapat"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr ""
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr ""
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Bağlantıya gitmek için Cmd/Ctrl tuşuyla tıklayın"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1532,328 +2595,323 @@ msgstr "Çince (Tayvan)"
 msgid "Chinese"
 msgstr "Çince (Çin)"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Otomatik olarak algıla"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Devre Dışı"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
+msgstr ""
+
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Özellikler"
+
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Dosyayı çoğalt"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Özel CSS"
+msgid "Copy path"
+msgstr "ID'yi kopyala"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s kelime"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Dosya adını kopyala"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s karakter"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Teşhis panelini aç"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Yazım hatası"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Dipnot referansına git"
-
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Link önizlemesi alınıyor…"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Kalın"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Eğik"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Link"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Görüntü"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Yorum"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Kod"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Dipnot metni bulunamadı."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "%s dosyası mevcut değil."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Kelime sayısı"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Değiştirilme Tarihi"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Aç..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Yeni sekmede aç"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "İşaretleme yok"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Dosyayı kapat"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Dizini yeniden adlandır"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Dizini sil"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Dizini kontrol et ..."
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Projeyi Dışarı Aktar"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Görseli panoya kopyala"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Tüm sekmeleri kapat"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Dosyayı aç"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Tarayıcıda aç"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Öneri yok"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Sözlüğe ekle"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Eğik"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Link ekle"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Sırasız liste ekle"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Numaralı liste ekle"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Takvim"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Grafikler"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "FSAL İstatistikleri"
+
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Yazma istatistikleri"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Ocak"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Şubat"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Mart"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Nisan"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Mayıs"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Haziran"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Temmuz"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Ağustos"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Eylül"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Ekim"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Kasım"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Aralık"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Denklem kodunu kopyala"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Aylık ortalamanın altında"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Okunabilirlik modu (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Aylık ortalamanın iki katından fazla"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Resim bulunamadı: %s"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Projeyi dışa aktar:"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "Resmi harici olarak aç"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Kullan"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Mermaid grafiği oluşturuluyor …"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Biçimlendir"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Dosya oluşturulamadı"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Dönüştürme"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Bağlantıya gitmek için Cmd/Ctrl tuşuyla tıklayın"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Dışa aktarıma dahil edilecek dosyalar"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Güncelleyici"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Lütfen bu projeyi oluşturmak için en az bir profil seçin."
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Yeni güncelleme mevcut"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Proje Başlığı"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Sizdeki sürüm"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "CSL Stil Sayfası"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "LaTeX Şablonu"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "HTML Şablonu"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Dosyayı dışa aktarımdan kaldır"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Dosyayı dışa aktarıma ekle"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Dosyayı yukarı taşı"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Dosyayı aşağı taşı"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Dışa aktarım için herhangi bir dosya seçmediniz."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Yeni bir Zettlr"
+"Some files are selected for export but no longer exist in the directory."
+msgstr ""
+"Bazı dosyalar dışa aktarım için seçili, ancak artık dizinde bulunmuyor."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Güncellemeniz indiriliyor"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Genel"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Güncelleme mevcut değil. En son sürüme sahipsiniz."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Güncellemeye başlamak için tıklayın"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "asla"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Son kontrol: %s"
+msgid "No results for \"%s\""
+msgstr "\"%s\" için sonuç bulunamadı"
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Güncelleme başlatılıyor …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Ara"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Renk ata"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Dosya Yöneticisi"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Rengi kaldır"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Düzenleyici"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Etiket adı"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Renk"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "İçe ve Dışa Aktarma"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Adet"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Gelişmiş"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Kısa bir açıklama"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Aranıyor: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
-msgstr ""
-"Burada farklı etiketlere renkler atayabilirsiniz. Bir dosyada bir etiket "
-"bulunursa, önizleme listesindeki kutucuğu renkli bir gösterge alır. "
-"Açıklama, fareyle üzerine gelindiğinde gösterilecektir."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Tercihler"
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Etiketleri filtrele"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Sıfırla"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
-
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Proje klasörünü aç"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Dosyayı sil"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Ekle"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Eylemler"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Dosyayı sil"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Panodan Resim Ekle"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Görüntü"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1871,10 +2929,6 @@ msgstr "Dosya adı"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Benzersiz bir dosya adı"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Yükleniyor…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1936,46 +2990,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr ayrıca şu projeleri de kullanır:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Burada daha da ileri özelleştirmeler için Zettlr'ın stillerini "
-"düzenleyebilirsiniz. <strong>Dikkat: Bu dosya tüm CSS yönergelerinin "
-"değişmesine sebebiyet verir! Asla elementlerin geometrisini değiştirmeyin, "
-"diğer türlü uygulama beklenmedik davranışlar sergileyebilir!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Kod parçacığını yeniden adlandır"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Kod parçacıkları, değişkenlerle yeniden kullanılabilir metin parçaları "
+"tanımlamanıza olanak tanır."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Kod parçacıkları klasörünü aç"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Kaydediliyor…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Kaydetme başarısız"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Dışa aktarılıyor"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "İçeri aktarılıyor"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Özel CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Kod Parçacıkları"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Kaydedildi!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -2001,41 +3039,81 @@ msgstr "Varsayılanlar klasörünü aç"
 msgid "Edit the default settings for imports or exports here."
 msgstr "İçe veya dışarı aktarmalar için varsayılan ayarları buradan düzenleyin"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Kaydedildi!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Dışa aktarılıyor"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Kod parçacığını yeniden adlandır"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "İçeri aktarılıyor"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Kod parçacıkları, değişkenlerle yeniden kullanılabilir metin parçaları "
-"tanımlamanıza olanak tanır."
+"Burada daha da ileri özelleştirmeler için Zettlr'ın stillerini "
+"düzenleyebilirsiniz. <strong>Dikkat: Bu dosya tüm CSS yönergelerinin "
+"değişmesine sebebiyet verir! Asla elementlerin geometrisini değiştirmeyin, "
+"diğer türlü uygulama beklenmedik davranışlar sergileyebilir!</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Kod parçacıkları klasörünü aç"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Kaydetme başarısız"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "kelime"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Renk ata"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "karakter"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Rengi kaldır"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Açık belge yok"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Etiket adı"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Başla"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Renk"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Adet"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Kısa bir açıklama"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Burada farklı etiketlere renkler atayabilirsiniz. Bir dosyada bir etiket "
+"bulunursa, önizleme listesindeki kutucuğu renkli bir gösterge alır. "
+"Açıklama, fareyle üzerine gelindiğinde gösterilecektir."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Etiketleri filtrele"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2061,76 +3139,116 @@ msgstr "Ses Efekti"
 msgid "Volume"
 msgstr "Ses Düzeyi"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "kelime geçen ay"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "günlük ortalama"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "kelime bugün"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Yanıyorsun!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Günlük ortalamanıza yakınsınız!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Günlük ortalamanızı aşmak için yazmaya başlayın."
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Daha fazla istatistik..."
+
+#: source/tmp/win-main/App.vue.ts:221
+#, javascript-format
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "İlgili dosyalar"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "İlgili dosya yok"
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Bu ilişki, çift yönlü bir bağlantıya dayanmaktadır."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Bu ilişki, giden bir bağlantıya dayanmaktadır."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Bu ilişki, bir geri bağlantıya dayanmaktadır."
-
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Bu ilişki, paylaşılan %s etikete dayanmaktadır: %s"
+msgid "%s selections"
+msgstr "%s seçildi"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Diğer dosyalar"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Dizini aç"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Başka dosya yok"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "Aktif Klasör"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Referanslar"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Bu belgede hiç atıf yok."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Ad"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Etiket Bulutu"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Dışarı aktar..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Dışarı aktar..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "komut"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2140,8 +3258,8 @@ msgstr "Dizinler"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -2155,10 +3273,26 @@ msgstr "Karakter"
 msgid "Words"
 msgstr "Kelime"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Çalışma alanları"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Açık dosya veya dizin yok"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Sonuç yok"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Dizin seçilmedi"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Boş dizin"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2188,15 +3322,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Sıfırla"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2257,13 +3382,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Takvim"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2473,132 +3591,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Yazma hedefi belirle..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Sonuç yok"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Dizin seçilmedi"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Boş dizin"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Çalışma alanları"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Açık dosya veya dizin yok"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "kelime geçen ay"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "günlük ortalama"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "kelime bugün"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Yanıyorsun!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Günlük ortalamanıza yakınsınız!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Günlük ortalamanızı aşmak için yazmaya başlayın."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Daha fazla istatistik..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s seçildi"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Dışarı aktar..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Dışarı aktar..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "komut"
+msgid "Table size: %s &times; %s"
+msgstr "Tablo boyutu: %s &tımes %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2620,11 +3616,6 @@ msgstr "Aramayı yalnızca klasörde yap"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Ara"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Aramayı temizle"
@@ -2638,1120 +3629,135 @@ msgstr "Sonuçları değiştir"
 msgid "%s matches across %s files"
 msgstr "%s dosyada %s eşleşme"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Ad"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Etiket Bulutu"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "kelime"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "karakter"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Açık belge yok"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "İlgili dosyalar"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "İlgili dosya yok"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Bu ilişki, çift yönlü bir bağlantıya dayanmaktadır."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Bu ilişki, giden bir bağlantıya dayanmaktadır."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Bu ilişki, bir geri bağlantıya dayanmaktadır."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Tablo boyutu: %s &tımes %s"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Ekle"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Eylemler"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Dosyayı sil"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Proje klasörünü aç"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Dosyayı sil"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Projeyi dışa aktar:"
-
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Kullan"
-
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Biçimlendir"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Dönüştürme"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Dışa aktarıma dahil edilecek dosyalar"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Lütfen bu projeyi oluşturmak için en az bir profil seçin."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Proje Başlığı"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "CSL Stil Sayfası"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "LaTeX Şablonu"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "HTML Şablonu"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Dosyayı dışa aktarımdan kaldır"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Dosyayı dışa aktarıma ekle"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Dosyayı yukarı taşı"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Dosyayı aşağı taşı"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Dışa aktarım için herhangi bir dosya seçmediniz."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-"Bazı dosyalar dışa aktarım için seçili, ancak artık dizinde bulunmuyor."
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Genel"
-
-#: source/tmp/win-preferences/App.vue.ts:56
-#, javascript-format
-msgid "No results for \"%s\""
-msgstr "\"%s\" için sonuç bulunamadı"
-
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Görünüm"
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Dosya Yöneticisi"
-
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Düzenleyici"
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Yazım Denetimi"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "OtomatikDüzeltme'yi aç"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Atıfları göster"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "İçe ve Dışa Aktarma"
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr "Aranıyor: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Tercihler"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Ocak"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Şubat"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Mart"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Nisan"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Mayıs"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Haziran"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Temmuz"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Ağustos"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Eylül"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Ekim"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Kasım"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Aralık"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Aylık ortalamanın altında"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Aylık ortalamanın iki katından fazla"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Grafikler"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "FSAL İstatistikleri"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Yazma istatistikleri"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten Kimlikleri"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Yeni IDler oluşturmak için kullanılacak şablon"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "ID düzenli ifade"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Yeni IDler oluşturmak için kullanılacak şablon"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Kullanılabilir Değişkenler: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Dahili bağlantılar"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Yalnızca dosya adıyla bağlantı oluştur"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Dosyaları bağlarken dosya ismi ekle ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "her zaman"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "Sadece ID kullanarak bağlandığında"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "hiçbir zaman"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Link biçimi"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Dahili bağlantılara isteğe bağlı bir başlık ekleyebilirsiniz. Bu başlık, "
-"gerçek bağlantı hedefinden dikey bir çubuk karakteri (|) ile ayrılır. Burada "
-"başlık ve bağlantı hedefinin sıralamasını belirleyebilirsiniz."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Başlık]]: Link önce (önerilen)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Başlık|Link]]: Başlık önce"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Zettelkasten bağlantılarını takip ederken aramayı başlat"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr ""
-"Arama dizesi, köşeli parantezler arasındaki içerikle eşleşecektir: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"İç bağlantıları takip ederken var olmayan dosyaları otomatik olarak oluştur"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Bunun çalışması için klasörün Zettlr'da bir Çalışma Alanı olarak açılması "
-"gerekir."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Klasör konumu"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Hiçbiri"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Hiçbiri"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Hiçbiri"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Dosyayı yenisiyle değiştir"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr ""
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Etiketleri filtrele"
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Editör 'girdi' yöntemi"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Girdi modu, düzenleyiciyle etkileşiminizi belirler. \"Normal\" modda "
-"kalmanızı öneririz. \"Vim\" veya \"Emacs\" modlarını yalnızca ne olduklarını "
-"biliyorsanız seçin."
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Yazım yönü"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown oluşturma"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Çeşitli Markdown öğelerinin biçimlendirilmiş görünümde canlı olarak "
-"işlenmesini etkinleştirmek için işaretleyin. Bu, biçimlendirme "
-"karakterlerini (örneğin **metin**) gizler veya bağlantıları yerine "
-"görüntüleri işler."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Başlık karakterlerini gizle"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Vurguları oluştur"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Markdown stil hatalarını kontrol et"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Tablo Düzenleyiciyi aktif et"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"Tablo Düzenleyici, tablo oluşturmayı ve düzenlemeyi basitleştiren "
-"etkileşimli bir arayüzdür.  Sık kullanılan işlevler için düğmeler sağlar ve "
-"Markdown biçimlendirmesini halleder."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Odaklanma modunda odaklanılmayan satırları kıs"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Kelime sayacı"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Kelimeler yerine karakterleri say (örn. Çince için)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Okunabilirlik modu"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Algoritma"
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Görsellerin maksimum genişliği (yüzdelik)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Görsellerin maksimum yüksekliği (yüzdelik)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Diğer ayarlar"
-
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Editor yazı boyutu"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Girinti miktarı (boşluk sayısı)"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Girinti için boşluk yerine sekmeleri kullan"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Boşlukları işaretle"
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Otomatik tamamlamada emojiler öner"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Link önizlemelerini göster"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Eşleşen karakter çiftlerini otomatik olarak kapat"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Program"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Kapalı"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "İşletim Sistemini Takip Et"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Açık"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Son"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Tema"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Araç çubuğu ayarları"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Durum alanı"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Bu ilişki, paylaşılan %s etikete dayanmaktadır: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Diğer dosyalar"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
 msgstr "Dizini aç"
 
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Başka dosya yok"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Aktif Klasör"
+
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Özel CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Özel CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Otomatik yazım denetimini açmak istediğiniz dilleri seçin."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Kullanıcı sözlüğü. Kelimelere tıklayarak silin."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Dosya bilgisini göster"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr ""
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Son düzenleme zamanı"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Dosya oluşturulma zamanı"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Dışarı aktar..."
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Son dosyalar"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Doğal düzen (2den sonra 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "ASCII düzeni (10dan sonra 2)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Profil içe/dışa aktarma"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "İçe aktarma profili düzenleyicisini aç"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "%s içine aktarılıyor."
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Dışarı aktarma için dahili Pandoc'u kullan"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Dosyalardan etiketleri kaldır"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Dahili bağlantıları tamamen kaldır"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Dahili bağlantıların bağlantılarını kaldır"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Dahili bağlantılara dokunma"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr ""
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Dosya bilgisini göster"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr ""
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Yorum"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Yeni dosya adları için şablon"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Yeni dosya adları için şablon"
-
-#: source/win-preferences/schema/advanced.ts:38
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Referanslar"
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Bu belgede hiç atıf yok."
+
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "Available variables: %s"
+msgid "circa %s words"
 msgstr ""
 
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Yeni dosya oluştururken dosya adı sorma"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Yükleniyor…"
 
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Dahili pencere görünümün kullan"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Güncelleyici"
 
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Yeni güncelleme mevcut"
 
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Dahili pencere görünümün kullan"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Sizdeki sürüm"
 
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Uygulamayı bildirim alanında çalışır halde bırak"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Editor yazı boyutu"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Zamanlayıcı sorgulama seçeneğini etkinleştir"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Dosyayı yazma işleminin tamamlanmış kabul edilmesi için beklenecek süre "
-"(milisaniye cinsinden)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Dosyayı sil"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Hata ayıklama modunu aktif et"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Hata ayıklama modunu aktif et"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Beta sürümler hakkında beni haberdar et"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Snippet Düzenleyiciyi Aç"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Uygulama dili"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Otomatik kaydet"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Son düzenleme zamanı"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Hemen"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Kısa bir süre sonra"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Standart resim klasörü"
-
-#: source/win-preferences/schema/general.ts:67
+#: source/tmp/win-update/App.vue.ts:34
 msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Bir klasör seçmek için \"Klasör Seç…\" seçeneğine tıklayın veya giriş "
-"alanına doğrudan bir yol (mutlak veya göreli) girin."
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Yeni bir Zettlr"
 
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Davranış"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Güncellemeniz indiriliyor"
 
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Dosyaları mümkünse yeni sekmelerde açma"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Güncelleme mevcut değil. En son sürüme sahipsiniz."
 
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Güncellemeler"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Güncellemeye başlamak için tıklayın"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Güncellemeler için otomatik kontrol"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "asla"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
+msgstr "Son kontrol: %s"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Dosyayı göster"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Güncelleme başlatılıyor …"
 
 #~ msgid "Open Link"
 #~ msgstr "Link Aç"

--- a/static/lang/uk-UA.po
+++ b/static/lang/uk-UA.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-12-19 13:37+0200\n"
 "Last-Translator: Fedir Zinchuk <fedikw@gmail.com>\n"
 "Language-Team: Ukrainian translators\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Неможливо завантажити базу цитат"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Зміни у файлі бібліотеки. Перезавантаження ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "Завантаження робочого простору %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -69,150 +83,6 @@ msgstr "Опція %s повинна бути щонайменше %s (кіль�
 msgid "Option %s is required."
 msgstr "Опція %s обов'язкова."
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Показати Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Вийти"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr "Неможливо перевірити наявність оновлень"
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr "Сталася помилка під час перевірки на оновлення. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "Доступне оновлення"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Доступне оновлення до версії %s!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-"Будь ласка, оновіть якнайшвидше. Ви можете відкрити програму оновлення зараз "
-"або оновити пізніше."
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr "Відкрити програму оновлення"
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr "Не зараз"
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Неможливо перевірити на оновлення: Помилка сервера (Код помилки: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Неможливо перевірити на оновлення: Помилка клієнта (Код помилки: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr ""
-"Неможливо перевірити на оновлення: Сервер намагається перенаправити (Код "
-"помилки: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Неможливо перевірити на оновлення: Не вдалося встановити з'єднання"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Не вдалося перевірити оновлення. %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Неможливо перевірити на оновлення: Сервер не надсилає даних"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr "Схоже у цьому випуску відсутній файл контрольних сум SHA256."
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr "Не можливо отримати файл контрольних сум SHA256: %s"
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr "Не вдалося записати дані оновлення програми: потік запису зник."
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-"Не вдалося перевірити цілісність завантаженого оновлення. Повторіть спробу "
-"або оновіть вручну."
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-"Контрольна сума завантаженого файлу відрізняється від повідомленої сервером. "
-"Повторіть спробу або оновіть вручну."
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-"Не вдалося розпочати оновлення. Повторіть спробу або оновіть вручну. "
-"Помилка: %s"
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Документ задовгий"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "не в мережі"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Неможливо створити файл"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Посилання з ключем %s не має вкладень."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Не вдається відкрити вкладення. Чи запущено Zotero?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -230,24 +100,101 @@ msgstr "Так"
 msgid "No"
 msgstr "Ні"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Замінити мітку \"%s\" на \"%s\" у файлах %s?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Гаразд"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Скасувати"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Дійсно вилучити?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Дійсно видалити %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Посилання з ключем %s не має вкладень."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Не вдається відкрити вкладення. Чи запущено Zotero?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Неправильний Textbundle: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Обрати профіль імпорту"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "Доступно кілька профілів які можна імпортувати %s. Виберіть один."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "Неможливо експортувати проект"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+"Не обрано файлів для експорту. Оберіть файли які потрібно додати в "
+"налаштування проекту."
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "Невідповідність файлу проекту"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"Один або кілька файлів, указаних у налаштуваннях проекту, не знайдено. "
+"Можливо, їх було переміщено або вилучено. Переконайтеся, що включено всі "
+"файли які ви хочете експортувати."
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Проект \"%s\" успішно експортовано. Натисніть щоб показати."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "Експорт проекту"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -302,51 +249,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Помилка імпорту"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "Неможливо експортувати проект"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-"Не обрано файлів для експорту. Оберіть файли які потрібно додати в "
-"налаштування проекту."
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "Невідповідність файлу проекту"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"Один або кілька файлів, указаних у налаштуваннях проекту, не знайдено. "
-"Можливо, їх було переміщено або вилучено. Переконайтеся, що включено всі "
-"файли які ви хочете експортувати."
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Гаразд"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Проект \"%s\" успішно експортовано. Натисніть щоб показати."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "Експорт проекту"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Неможливо перемістити каталог"
@@ -364,28 +266,49 @@ msgstr "Неможливо перемістити каталог або файл
 msgid "The file/directory %s already exists in target."
 msgstr "Файл/каталог %s вже існує."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Без назви"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Дана назва не містить дозволених символів."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Неможливо створити каталог"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Запитуваний каталог не знайдено."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Дійсно вилучити?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Помилка експорту"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Дійсно видалити %s?"
+msgid "An error occurred during export: %s"
+msgstr "Виникла помилка під час експорту: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Обрати пункт призначення для експорту"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Зберегти"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "Експортування в %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Виникла помилка під час експортування: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -410,11 +333,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Копіювання %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Документ задовгий"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "не в мережі"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -427,126 +352,34 @@ msgstr "Імпортовано мовний файл: %s"
 msgid "Could not import language file %s!"
 msgstr "Не вдалося імпортувати мовний файл %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Помилка експорту"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Неможливо створити файл"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Виникла помилка під час експорту: %s"
+msgid "Copy of %s"
+msgstr "Копіювання %s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Обрати пункт призначення для експорту"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Без назви"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Зберегти"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Неможливо створити каталог"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Експортування в %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Виникла помилка під час експортування: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Дана назва не містить дозволених символів."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Запитуваний каталог не знайдено."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Обрати профіль імпорту"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "Доступно кілька профілів які можна імпортувати %s. Виберіть один."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Неправильний Textbundle: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "Замінити файл"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-"Файл %s змінено віддалено. Замінити завантажену версію на нову з диска?"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Завжди загружати віддалені зміни поточного файлу"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Перезапис існуючого файлу"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Файл %s вже існує в цьому каталозі. Перезаписати?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Відкрити файл"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Незбережені зміни"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Є незбережені зміни. Бажаєте їх зберегти?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Зберегти файл"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Відкрити каталог проєкту"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Неможливо завантажити базу цитат"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Зміни у файлі бібліотеки. Перезавантаження ..."
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Замінити мітку \"%s\" на \"%s\" у файлах %s?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -658,6 +491,12 @@ msgstr "Перейменувати файл"
 msgid "Delete file"
 msgstr "Видалити файл"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Вийти"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -676,15 +515,15 @@ msgstr "Повторити"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Вирізати"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Копіювати"
 
@@ -696,8 +535,8 @@ msgstr "Копіювати як HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Вставити"
 
@@ -709,8 +548,8 @@ msgstr "Вставити без стилів"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Виділити все"
 
@@ -953,10 +792,171 @@ msgstr "Завершити говорити"
 msgid "Bring All to Front"
 msgstr "Перенести все на фронтову частину"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Відкрити каталог проєкту"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "Замінити файл"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "Завантаження робочого простору %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+"Файл %s змінено віддалено. Замінити завантажену версію на нову з диска?"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Завжди загружати віддалені зміни поточного файлу"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Незбережені зміни"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Є незбережені зміни. Бажаєте їх зберегти?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Відкрити файл"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Зберегти файл"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Перезапис існуючого файлу"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Файл %s вже існує в цьому каталозі. Перезаписати?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Показати Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr "Неможливо перевірити наявність оновлень"
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr "Сталася помилка під час перевірки на оновлення. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "Доступне оновлення"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Доступне оновлення до версії %s!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+"Будь ласка, оновіть якнайшвидше. Ви можете відкрити програму оновлення зараз "
+"або оновити пізніше."
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr "Відкрити програму оновлення"
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr "Не зараз"
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Неможливо перевірити на оновлення: Помилка сервера (Код помилки: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Неможливо перевірити на оновлення: Помилка клієнта (Код помилки: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr ""
+"Неможливо перевірити на оновлення: Сервер намагається перенаправити (Код "
+"помилки: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Неможливо перевірити на оновлення: Не вдалося встановити з'єднання"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Не вдалося перевірити оновлення. %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Неможливо перевірити на оновлення: Сервер не надсилає даних"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr "Схоже у цьому випуску відсутній файл контрольних сум SHA256."
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr "Не можливо отримати файл контрольних сум SHA256: %s"
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr "Не вдалося записати дані оновлення програми: потік запису зник."
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+"Не вдалося перевірити цілісність завантаженого оновлення. Повторіть спробу "
+"або оновіть вручну."
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+"Контрольна сума завантаженого файлу відрізняється від повідомленої сервером. "
+"Повторіть спробу або оновіть вручну."
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
+"Не вдалося розпочати оновлення. Повторіть спробу або оновіть вручну. "
+"Помилка: %s"
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -970,16 +970,16 @@ msgstr "Відкинути зміни"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Є незбережені зміни. Бажаєте зберегти чи відкинути зміни?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "Файл змінено на диску"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s змінено на диску"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -988,127 +988,1151 @@ msgstr ""
 "%s змінено на диску, але редактор містить незбережені зміни. Бажаєте "
 "залишити поточний вміст редактора чи завантажити файл із диска?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Бажаєте залишити поточний вміст редактора чи завантажити файл із диска?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Залишити поточний вміст редактора"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Ззавантажити зміни із диска"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Завжди завантажувати зміни з диска, коли в редакторі немає незбережених змін"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "Неможливо зберегти файл"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "Неможливо зберегти файл %s: %s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "Автовиправлення"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Розумні цитати"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "Подвійні лапки"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Вимкнути Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "Одинарні лапки"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Шаблони заміни тексту"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Повний збіг зі словом"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "Коли обрано, автокорекція ніколи не буде заміняти частину слова"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "Замінити"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "На"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "Фільтр"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Запланувати"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Вимкнено"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "Слідувати за системою"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Ввімкнено"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Запуск"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Вимкнено"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Тема"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Параметри панелі інструментів"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Властивості"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Дублювати файл"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "Копіювати шлях"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Копіювати ім'я файлу"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "Рядок стану"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Власний CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "Відкрити редактор CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Імпорт та експорт профілів"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Відкрити редактор профілів імпорту"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Відкрити редактор профілів експорту"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "Експортування налаштування"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Використовувати внутрішній Pandoc для експорту"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "Вилучати мітки з файлів під час експорту"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "Внутрішні посилання"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Видаляти внутрішні посилання повністю"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Вилучати внутрішні посилання"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Не чіпати внутрішні посилання"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Каталог призначення для файлів експорту"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Тимчасовий каталог"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "Те саме як розташування файлу"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Запитувати під час експорту"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Увага! Файли у тимчасовому каталозі регулярно видаляються. Вибір одного й "
+"того самого розташування, що й файл, перезаписує файли з ідентичними назвами "
+"файлів, якщо вони вже існують."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Спеціальні команди експорту"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "Назва для показу"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "Команда"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Введіть спеціальні команди для запуску експортера. Кожна команда отримує як "
+"свій перший аргумент файл або каталог проекту, які потрібно експортувати."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "Шаблон назви для нових файлів"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "Вкажіть шаблон назви для нових файлів"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Доступні змінні: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Не запитувати назву при створенні нових файлів"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Вигляд"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Використовувати нативний зовнішній вигляд вікна"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "Доступно лише в Linux; це типове значення для macOS і Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "Увімкнути яскравість вікна"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Доступно лише в macOS; робить фон вікна непрозорим."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Показати сповіщення"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Залиште програму запущеною в області сповіщень"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Поведінка масштабування"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "Змінює розмір всього інтерфейсу"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "Змінює розмір шрифту редактора"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Бічна панель вкладень"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "Розширення файлів які буде показано на бічній панелі вкладень"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Список дозволених адрес для iFrame"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Hostname"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "Опитування спостерігача"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "Час очікування перед тим, як запис файлу вважається виконаним (в мс)"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "Вилучення елементів"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "Режим налагодження"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Увімкнути режим зневадження"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Бета-версії"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Сповіщати мене про вихід бета-версій"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "Режим введення"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Режим введення визначає, як ви взаємодієте з редактором. Ми рекомендуємо "
+"залишити цей параметр на \"Звичайний\". Вибирайте \"Vim\" або \"Emacs\", "
+"лише якщо знаєте, що це означає."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "Напрям письма"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Візуалізація Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Поставте прапорець, щоб увімкнути показ різних елементів Markdown у "
+"відформатований вигляд. Це приховує символи форматування (наприклад, "
+"**текст**) або показує картинки замість їх посилань."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ховати символи заголовків"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Візуалізація наголосу"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "Жирний"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "Курсив"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Перевіряти Markdown на помилки в розмітці"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "Редактор таблиць"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"Редактор таблиць надає інтерактивний інтерфейс, який спрощує створення та "
+"редагування таблиць. Він надає кнопки для загальних функцій і стежить про "
+"форматування Markdown."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Робити блідими рядки, які не під фокусом (в режимі без відволікання)"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "Лічильник слів"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Рахувати символи замість слів (напр. для китайської)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Режим читабельності"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Алгоритм"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "Розмір зображення"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "Максимальна ширина зображень (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "Максимальна висота зображень (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "Інші налаштування"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "Розмір шрифту"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "Розмір відступу (кількість пробілів)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "Для відступу використовувати табуляцію замість пробілів"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr "Показувати панель форматування, коли вибрано текст"
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "Виділяти пробіли"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "Пропонувати емодзі під час автозаповнення"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Показувати перегляд для посилань"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Автоматично закривати відповідні пари символів"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "Режим показу"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Тонкий"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Розширений"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Змішаний"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"\"Тонкий\" режим показує ваші каталоги та файли окремо. Виберіть каталог, "
+"щоб побачити його вміст у списку файлів. Перемикайтеся між списком файлів і "
+"деревом каталогів, натискаючи на каталоги, або кнопку зі стрілкою, яка "
+"з'являється у верхньому лівому куті списку файлів."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Показувати інформацію про файл"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Показати папки над файлами"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Показ назви документа Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Лише назва файлу"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Заголовок, коли доступно"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Перший доступний заголовок рівня 1"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Заголовок або перший заголовок рівня 1, коли доступно"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Показати розширення файлів Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Показ часу"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Час останньої зміни"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Час створення файлу"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "Сортування"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "Під час сортування документів…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "Натуральне сортування (2 буде попереду 10)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Сортування ASCII (2 буде позаду 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "Цитування"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Як би ви хотіли, щоб автозаповнення вставило ваші цитати?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "Шлях до файлу"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Правило Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "Використовує регулярний вираз ECMAScript"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Шаблон для генерації нових ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Доступні змінні: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "Лише посилання з назвою файлу"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "Під час зв'язування файлів додавати ім'я файлу..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "Завжди"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "Лише при зв'язування з використанням ідентифікатора"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "Ніколи"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "Формат посилання"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"Внутрішні посилання дозволяють додавати необов'язковий заголовок, він "
+"відокремлений вертикальною рискою від фактичної цілі посилання. Тут ви "
+"можете визначити порядок цих двох елементів."
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[Link|Title]]: Посилання перше (рекомендовано)"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[Title|Link]]: Заголовок перший"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr ""
+"Почати повнотекстовий пошук під час переходу за внутрішніми посиланнями"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "Рядок пошуку відповідатиме вмісту в квадратних дужках: [[ ]]."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr ""
+"Автоматично створювати відсутні файли при переході в цей каталог за "
+"внутрішніми посиланнями"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Щоб це працювало, каталог має бути відкрито як робочий простір у Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Шлях до каталогу"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Фрагменти"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Відкрити редактор фрагментів"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "Мовний інструмент"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Строгість"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "Стандартно"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Вимогливо"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Рідна мова"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Не вказано"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "Бажані варіанти"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"Мовний інструмент не може розрізняти певні варіанти мови. Ці налаштування "
+"підштовхнуть Мовний інструмент до автоматичного визначення бажаного варіанту "
+"цих мов."
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "Інтерпретувати англійську як"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "Інтерпретувати німецьку як"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "Інтерпретувати португальську як"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "Інтерпретувати каталонську як"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Постачальник Мовного інструменту"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "Власний сервер"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "Адреса власного серверу"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "Мовний інструмент преміум"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr ігноруватиме налаштування \"Мовний інструмент\" коли вкажете будь які "
+"дані тут."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "\"Мовний інструмент\" користувач"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "\"Мовний інструмент\" ключ API"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Правопис"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "Активно"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Мова"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Код"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr ""
+"Виберіть мови, для яких потрібно включити автоматичну перевірку правопису."
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Словник користувача. Видаляти слова можна клацаючи по них."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Словниковий запис"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Пошук записів ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Мова програми"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Автозбереження"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "Зберегти зміни"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Негайно"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Після невеликої затримки"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Типовий каталог зображень"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Натисніть \"Вибрати каталог…\" або введіть абсолютний або відносний шлях "
+"безпосередньо в поле введення."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "Поведінка"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "По можливості уникайте відкриття файлів у нових вкладках"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "Оновлення"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Автоматично перевіряти оновлення"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s символів"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s слів"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Перейти до посилання на виноску"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Без підсвічування"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Відкрити панель діагностики"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "Власний"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Визначити автоматично"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Побудова діаграми mermaid ..."
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "Неможливо відтворити графік"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Режим читабельності (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Зображення не знайдено: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "Відкрити зображення в зовнішній програмі"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Орфографічна помилка"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Файлу %s не існує."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Лічильник слів"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Змінено"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Відкрити..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Відкрити в новій вкладці"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "Отримання попереднього перегляду для посилання ..."
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Ланка"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Зображення"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Коментар"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Текст виноски не знайдено."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Копіювати код рівняння"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Копіювати зображення до буферу обміну"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "Відкрити зображення"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Відкрити у Файндер"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Розкрити в Провіднику"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "Відкрити в менеджері файлів"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Відкрити в браузері файлів"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Немає пропозицій"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Закрити файл"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Додати в словник"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Перейменувати каталог"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "Курсив"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Видалити каталог"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Вставити посилання"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Перевірити каталог ..."
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Вставити ненумерований список"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Експортувати проект"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Вставити нумерований список"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Закрити інші вкладки"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Закрити всі вкладки"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Відкріпити вкладку"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Закріпити вкладку"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl-клік щоб перейти за посиланням"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1516,323 +2540,318 @@ msgstr "Китайська (Тайвань)"
 msgid "Chinese"
 msgstr "Китайська"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Визначити автоматично"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Вимкнено"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "Власний"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s слів"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s символів"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Відкрити панель діагностики"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Орфографічна помилка"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Перейти до посилання на виноску"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Властивості"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "Отримання попереднього перегляду для посилання ..."
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Дублювати файл"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "Жирний"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "Копіювати шлях"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "Курсив"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Копіювати ім'я файлу"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Ланка"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Розкрити в Провіднику"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Зображення"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Відкрити в браузері файлів"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Коментар"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Закрити файл"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Код"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Перейменувати каталог"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Текст виноски не знайдено."
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Видалити каталог"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Файлу %s не існує."
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Перевірити каталог ..."
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Лічильник слів"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Експортувати проект"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Змінено"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Відкрити..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Відкрити в новій вкладці"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Без підсвічування"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Закрити інші вкладки"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Закрити всі вкладки"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Копіювати зображення до буферу обміну"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Відкріпити вкладку"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "Відкрити зображення"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Закріпити вкладку"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "Відкрити в менеджері файлів"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Календар"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Немає пропозицій"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Графіки"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Додати в словник"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "Статистика FSAL"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "Курсив"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "Запис статистики"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Вставити посилання"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Січень"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Вставити ненумерований список"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Лютий"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Вставити нумерований список"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Березень"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Квітень"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Травень"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr ""
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Червень"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Копіювати код рівняння"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Липень"
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Режим читабельності (%s)"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Серпень"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Зображення не знайдено: %s"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Вересень"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "Відкрити зображення в зовнішній програмі"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Жовтень"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Побудова діаграми mermaid ..."
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Литсопад"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "Неможливо відтворити графік"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Грудень"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl-клік щоб перейти за посиланням"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Нижче середньомісячного"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Програма оновлення"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Понад середньомісячний показник"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Доступне нове оновлення"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Більш ніж у два рази перевищує середньомісячний показник"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Поточна версія"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "Експортувати проект до:"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "Використати"
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "Формат"
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "Перетворення"
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "Файли які буде експортовано"
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "Будь ласка оберіть принаймні один профіль для створення цього проекту."
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "Назва проекту"
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "CSL таблиця стилів"
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "LaTeX шаблон"
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "HTML шаблон"
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "Вилучити файл з експорту"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "Додати файли до експорту"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "Перемістити файл вгору"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "Перемістити файл вниз"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "Ви не обрали жодного файлу для експорту."
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "Нова версія Zettlr готова до завантаження. Прочитайте опис змін нижче."
+"Some files are selected for export but no longer exist in the directory."
+msgstr "Деякі файли вибрано для експорту, але їх більше немає в каталозі."
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Завантаження оновлення"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "Загальне"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Оновлень немає. У вас остання версія програми."
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Натисніть, щоб почати оновлення"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "нікол"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "Востаннє перевірено: %s"
+msgid "No results for \"%s\""
+msgstr "Немає результатів для \"%s\""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Початок оновлення…"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Пошук"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "Призначити колір"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "Менеджер файлів"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "Вилучити колір"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "Редактор"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "Назва мітки"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "Колір"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "Імпорт та експорт"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Кількість"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "Розширені"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "Короткий опис"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "Пошук: %s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Скинути"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
-"Тут ви можете призначити кольори різним міткам. Якщо у файлі знайдено мітку, "
-"його позначка у списку попереднього перегляду отримає кольоровий індикатор. "
-"Опис буде показано при наведенні миші."
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Фільтр міток..."
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "Обрати каталог..."
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr "Нова мітка"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "Обрати файл..."
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr "Перейменувати"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Додати"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr "Перейменувати мітку ..."
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Дії"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "Вилучити"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "Додати зображення з буферу обміну"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "Розмір зображення"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1850,10 +2869,6 @@ msgstr "Назва файлу"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "Унікальна назва файлу"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "Завантаження..."
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1918,46 +2933,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr також використовує проєкти:"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Тут ви можете перевизначити стилі програми, щоб налаштувати її під себе. "
-"<strong>Увага: Цей файл перезаписує усі CSS директиви! Ніколи не змінюйте "
-"геометрію об'єктів, це може призвести до небажаної поведінки програми!</"
-"strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Перейменувати фрагмент"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Фрагменти дозволяють визначати повторювані елементи тексту за допомогою "
+"перемінних.."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "Відкрити каталог фрагментів"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Збереження…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Не вдалося зберегти"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "Експортування"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "Імпортування"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Власний CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Фрагменти"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Збережено!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1983,41 +2982,81 @@ msgstr "Відкрити стандартний каталог"
 msgid "Edit the default settings for imports or exports here."
 msgstr "Змінити налаштування за замовчуванням для імпорту чи експорту."
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Збережено!"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "Експортування"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Перейменувати фрагмент"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "Імпортування"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
 msgstr ""
-"Фрагменти дозволяють визначати повторювані елементи тексту за допомогою "
-"перемінних.."
+"Тут ви можете перевизначити стилі програми, щоб налаштувати її під себе. "
+"<strong>Увага: Цей файл перезаписує усі CSS директиви! Ніколи не змінюйте "
+"геометрію об'єктів, це може призвести до небажаної поведінки програми!</"
+"strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "Відкрити каталог фрагментів"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Не вдалося зберегти"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "слів"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "Призначити колір"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "символів"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "Вилучити колір"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Не відкрито жодного документу"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "Назва мітки"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Запуск"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "Колір"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Кількість"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "Короткий опис"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"Тут ви можете призначити кольори різним міткам. Якщо у файлі знайдено мітку, "
+"його позначка у списку попереднього перегляду отримає кольоровий індикатор. "
+"Опис буде показано при наведенні миші."
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Фільтр міток..."
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr "Нова мітка"
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr "Перейменувати"
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr "Перейменувати мітку ..."
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2043,76 +3082,114 @@ msgstr "Звуковий ефект"
 msgid "Volume"
 msgstr "Гучність"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "слів за минулий місяць"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "в середньому за день"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "слів за сьогодні"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Робота горить!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Ви наближаєтеся до середньодобової позначки!"
+
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Продовжуйте писати, щоб перевершити свій середньодобовий показник."
+
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Більше статистики..."
+
+#: source/tmp/win-main/App.vue.ts:221
+#, javascript-format
+msgid "%s selected"
+msgstr "%s обрано"
+
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
+#, javascript-format
+msgid "%s selections"
+msgstr "%s обрано"
+
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Пов'язані файли"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Непов'язані файли"
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Цей зв'язок заснований на двонаправленому посиланні."
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Цей зв'язок заснований на вихідному посиланні."
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Цей зв'язок заснований на зворотному посиланні."
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "Перемкнути режим читання"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
-#, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Цей зв'язок заснований на %s спільних мітках: %s"
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Інші файли"
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Відкрити каталог"
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Інші фали відсутні"
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr "Тимчасовий каталог"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
 msgstr "Поточний каталог"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Примітки"
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr "Обрати каталог"
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Цей документ не містить цитат."
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "Експортування..."
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
-#, javascript-format
-msgid "circa %s words"
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "Експорт"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "команда"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
 msgstr ""
-
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Назва"
-
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Хмара міток"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2122,8 +3199,8 @@ msgstr "Директорії"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Файли"
 
@@ -2137,10 +3214,26 @@ msgstr "Cимволи"
 msgid "Words"
 msgstr "Слів"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Робочі простори"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Не відкрито жодного файлу чи каталогу"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Немає результатів"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Немає вибраних каталогів"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Пустий каталог"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2170,15 +3263,6 @@ msgstr "висхідний"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr "спадання"
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Скинути"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2239,13 +3323,6 @@ msgstr "Око"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr "Око (закрите)"
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Календар"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2455,130 +3532,10 @@ msgstr "CD/DVD"
 msgid "Set writing target…"
 msgstr "Задати ціль..."
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Немає результатів"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Немає вибраних каталогів"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Пустий каталог"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Робочі простори"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Не відкрито жодного файлу чи каталогу"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "слів за минулий місяць"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "в середньому за день"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "слів за сьогодні"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Робота горить!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Ви наближаєтеся до середньодобової позначки!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Продовжуйте писати, щоб перевершити свій середньодобовий показник."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Більше статистики..."
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s обрано"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s обрано"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "Перемкнути режим читання"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr "Тимчасовий каталог"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr "Поточний каталог"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr "Обрати каталог"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "Експортування..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "Експорт"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "команда"
+msgid "Table size: %s &times; %s"
+msgstr "Розмір таблиці: %s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2600,11 +3557,6 @@ msgstr "Обмежити пошук лиш каталогу"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Пошук"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Очистити пошук"
@@ -2618,1081 +3570,135 @@ msgstr "Переключити результати"
 msgid "%s matches across %s files"
 msgstr "%s збігів з %s файлів"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Назва"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Хмара міток"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "слів"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "символів"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Не відкрито жодного документу"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Пов'язані файли"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Непов'язані файли"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Цей зв'язок заснований на двонаправленому посиланні."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Цей зв'язок заснований на вихідному посиланні."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Цей зв'язок заснований на зворотному посиланні."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "Розмір таблиці: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Цей зв'язок заснований на %s спільних мітках: %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Додати"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Інші файли"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Дії"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Відкрити каталог"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "Вилучити"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Інші фали відсутні"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "Обрати каталог..."
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "Поточний каталог"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "Обрати файл..."
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "Експортувати проект до:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Примітки"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "Використати"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Цей документ не містить цитат."
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "Формат"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "Перетворення"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "Файли які буде експортовано"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "Будь ласка оберіть принаймні один профіль для створення цього проекту."
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "Назва проекту"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "CSL таблиця стилів"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "LaTeX шаблон"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "HTML шаблон"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "Вилучити файл з експорту"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "Додати файли до експорту"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "Перемістити файл вгору"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "Перемістити файл вниз"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "Ви не обрали жодного файлу для експорту."
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr "Деякі файли вибрано для експорту, але їх більше немає в каталозі."
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "Загальне"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "Немає результатів для \"%s\""
+msgid "circa %s words"
+msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Вигляд"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "Завантаження..."
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "Менеджер файлів"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "Програма оновлення"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "Редактор"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Доступне нове оновлення"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Правопис"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Поточна версія"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "Автовиправлення"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "Нова версія Zettlr готова до завантаження. Прочитайте опис змін нижче."
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "Цитування"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Завантаження оновлення"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Оновлень немає. У вас остання версія програми."
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "Імпорт та експорт"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Натисніть, щоб почати оновлення"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "Розширені"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "нікол"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "Пошук: %s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "Налаштування"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Січень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Лютий"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Березень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Квітень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Травень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Червень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Липень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Серпень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Вересень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Жовтень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Литсопад"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Грудень"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Нижче середньомісячного"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Понад середньомісячний показник"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Більш ніж у два рази перевищує середньомісячний показник"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Графіки"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "Статистика FSAL"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "Запис статистики"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Правило Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "Використовує регулярний вираз ECMAScript"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Шаблон для генерації нових ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Доступні змінні: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "Внутрішні посилання"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "Лише посилання з назвою файлу"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "Під час зв'язування файлів додавати ім'я файлу..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "Завжди"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "Лише при зв'язування з використанням ідентифікатора"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "Ніколи"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "Формат посилання"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"Внутрішні посилання дозволяють додавати необов'язковий заголовок, він "
-"відокремлений вертикальною рискою від фактичної цілі посилання. Тут ви "
-"можете визначити порядок цих двох елементів."
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[Link|Title]]: Посилання перше (рекомендовано)"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[Title|Link]]: Заголовок перший"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr ""
-"Почати повнотекстовий пошук під час переходу за внутрішніми посиланнями"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "Рядок пошуку відповідатиме вмісту в квадратних дужках: [[ ]]."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr ""
-"Автоматично створювати відсутні файли при переході в цей каталог за "
-"внутрішніми посиланнями"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Щоб це працювало, каталог має бути відкрито як робочий простір у Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Шлях до каталогу"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Розумні цитати"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "Подвійні лапки"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Вимкнути Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "Одинарні лапки"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Шаблони заміни тексту"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Повний збіг зі словом"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "Коли обрано, автокорекція ніколи не буде заміняти частину слова"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "Замінити"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "На"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "Фільтр"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "Режим введення"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Режим введення визначає, як ви взаємодієте з редактором. Ми рекомендуємо "
-"залишити цей параметр на \"Звичайний\". Вибирайте \"Vim\" або \"Emacs\", "
-"лише якщо знаєте, що це означає."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "Напрям письма"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Візуалізація Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Поставте прапорець, щоб увімкнути показ різних елементів Markdown у "
-"відформатований вигляд. Це приховує символи форматування (наприклад, "
-"**текст**) або показує картинки замість їх посилань."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ховати символи заголовків"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Візуалізація наголосу"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Перевіряти Markdown на помилки в розмітці"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "Редактор таблиць"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"Редактор таблиць надає інтерактивний інтерфейс, який спрощує створення та "
-"редагування таблиць. Він надає кнопки для загальних функцій і стежить про "
-"форматування Markdown."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Робити блідими рядки, які не під фокусом (в режимі без відволікання)"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "Лічильник слів"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Рахувати символи замість слів (напр. для китайської)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Режим читабельності"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Алгоритм"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "Максимальна ширина зображень (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "Максимальна висота зображень (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "Інші налаштування"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "Розмір шрифту"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "Розмір відступу (кількість пробілів)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "Для відступу використовувати табуляцію замість пробілів"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr "Показувати панель форматування, коли вибрано текст"
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "Виділяти пробіли"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "Пропонувати емодзі під час автозаповнення"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Показувати перегляд для посилань"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Автоматично закривати відповідні пари символів"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Запланувати"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Вимкнено"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "Слідувати за системою"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Ввімкнено"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Вимкнено"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Тема"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Параметри панелі інструментів"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "Рядок стану"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "Відкрити редактор CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "Мовний інструмент"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Строгість"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "Стандартно"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Вимогливо"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Рідна мова"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Не вказано"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "Бажані варіанти"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"Мовний інструмент не може розрізняти певні варіанти мови. Ці налаштування "
-"підштовхнуть Мовний інструмент до автоматичного визначення бажаного варіанту "
-"цих мов."
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "Інтерпретувати англійську як"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "Інтерпретувати німецьку як"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "Інтерпретувати португальську як"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "Інтерпретувати каталонську як"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Постачальник Мовного інструменту"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "Власний сервер"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "Адреса власного серверу"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "Мовний інструмент преміум"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr ігноруватиме налаштування \"Мовний інструмент\" коли вкажете будь які "
-"дані тут."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "\"Мовний інструмент\" користувач"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "\"Мовний інструмент\" ключ API"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "Активно"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Мова"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr ""
-"Виберіть мови, для яких потрібно включити автоматичну перевірку правопису."
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Словник користувача. Видаляти слова можна клацаючи по них."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Словниковий запис"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Пошук записів ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "Режим показу"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Тонкий"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Розширений"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Змішаний"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"\"Тонкий\" режим показує ваші каталоги та файли окремо. Виберіть каталог, "
-"щоб побачити його вміст у списку файлів. Перемикайтеся між списком файлів і "
-"деревом каталогів, натискаючи на каталоги, або кнопку зі стрілкою, яка "
-"з'являється у верхньому лівому куті списку файлів."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Показувати інформацію про файл"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Показати папки над файлами"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Показ назви документа Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Лише назва файлу"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Заголовок, коли доступно"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Перший доступний заголовок рівня 1"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Заголовок або перший заголовок рівня 1, коли доступно"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Показати розширення файлів Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Показ часу"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Час останньої зміни"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Час створення файлу"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "Сортування"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "Під час сортування документів…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "Натуральне сортування (2 буде попереду 10)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Сортування ASCII (2 буде позаду 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Імпорт та експорт профілів"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Відкрити редактор профілів імпорту"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Відкрити редактор профілів експорту"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "Експортування налаштування"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Використовувати внутрішній Pandoc для експорту"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "Вилучати мітки з файлів під час експорту"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Видаляти внутрішні посилання повністю"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Вилучати внутрішні посилання"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Не чіпати внутрішні посилання"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Каталог призначення для файлів експорту"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Тимчасовий каталог"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "Те саме як розташування файлу"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Запитувати під час експорту"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Увага! Файли у тимчасовому каталозі регулярно видаляються. Вибір одного й "
-"того самого розташування, що й файл, перезаписує файли з ідентичними назвами "
-"файлів, якщо вони вже існують."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Спеціальні команди експорту"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "Назва для показу"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "Команда"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Введіть спеціальні команди для запуску експортера. Кожна команда отримує як "
-"свій перший аргумент файл або каталог проекту, які потрібно експортувати."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "Шаблон назви для нових файлів"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "Вкажіть шаблон назви для нових файлів"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Доступні змінні: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Не запитувати назву при створенні нових файлів"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Використовувати нативний зовнішній вигляд вікна"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "Доступно лише в Linux; це типове значення для macOS і Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "Увімкнути яскравість вікна"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Доступно лише в macOS; робить фон вікна непрозорим."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Показати сповіщення"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Залиште програму запущеною в області сповіщень"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Поведінка масштабування"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "Змінює розмір всього інтерфейсу"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "Змінює розмір шрифту редактора"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Бічна панель вкладень"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "Розширення файлів які буде показано на бічній панелі вкладень"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Список дозволених адрес для iFrame"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Hostname"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "Опитування спостерігача"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "Час очікування перед тим, як запис файлу вважається виконаним (в мс)"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "Вилучення елементів"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "Режим налагодження"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Увімкнути режим зневадження"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Бета-версії"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Сповіщати мене про вихід бета-версій"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Відкрити редактор фрагментів"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Мова програми"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Автозбереження"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "Зберегти зміни"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Негайно"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Після невеликої затримки"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Типовий каталог зображень"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Натисніть \"Вибрати каталог…\" або введіть абсолютний або відносний шлях "
-"безпосередньо в поле введення."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "Поведінка"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "По можливості уникайте відкриття файлів у нових вкладках"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "Оновлення"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Автоматично перевіряти оновлення"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Як би ви хотіли, щоб автозаповнення вставило ваші цитати?"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "Шлях до файлу"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+msgid "Last checked: %s"
+msgstr "Востаннє перевірено: %s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Початок оновлення…"
 
 #~ msgid "Open Link"
 #~ msgstr "Відкрити посилання"

--- a/static/lang/vi-VI.po
+++ b/static/lang/vi-VI.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-04-03 00:00+UTC\n"
 "Last-Translator: Hung Vu <hung.v.vu.cs@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,20 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "Cơ sở dữ liệu trích dẫn không thể mở được"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "Thay đổi trong tập tin thư viện được phát hiện. Đang tải lại ..."
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, fuzzy, javascript-format
+msgid "Loading workspace %s"
+msgstr "Đang tải workspace %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,140 +82,6 @@ msgstr "Tuỳ chọn %s phải tối thiểu là %s (độ dài kí tự)."
 msgid "Option %s is required."
 msgstr "Tuỳ chọn %s là bắt buộc"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "Hiển thị Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "Thoát"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "Một cập nhật cho phiên bản %s đang khả dụng!"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "Không thể kiểm tra cập nhật: Lỗi Máy Chủ (Mã lỗi: %s)"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "Không thể kiểm tra cập nhật: Lỗi ở máy khách (Mã lỗi: %s)"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr "Không thể kiểm tra cập nhật: Máy chủ cố gắng chuyển hướng (Mã lỗi: %s)"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "Không thể kiểm tra cập nhật: Không thể thiết lập kết nối"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "Không thể kiểm tra cập nhật: %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "Không thể kiểm tra cập nhật: Máy chủ không gửi bất kì dữ liệu nào"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "Văn bản quá dài"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "ngoại tuyến"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "Không thể tạo tập tin"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "Trích dẫn với khoá %s dường như không có đính kèm."
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "Không thể mở tập tin đính kèm. Zotero có đang được mở?"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +99,98 @@ msgstr "Có"
 msgid "No"
 msgstr "Không"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "Thay thế thẻ\"%s\" với \"%s\" trong %s tệp?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "Đồng ý"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "Huỷ"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "Thực sự xoá?"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "Bạn có thực sự muốn xoá %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "Trích dẫn với khoá %s dường như không có đính kèm."
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "Không thể mở tập tin đính kèm. Zotero có đang được mở?"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "Textbundle sai định dạng: %s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "Chọn tùy chỉnh tích hợp"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "Có nhiều tùy chỉnh có thể tích hợp %s. Vui lòng chọn một."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+#, fuzzy
+msgid "Cannot export project"
+msgstr "Không thể xuất Dự Án"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "Dự án \"%s\" được xuất thành công. Nhấn để hiển thị."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+#, fuzzy
+msgid "Project Export"
+msgstr "Xuất dự án"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -293,48 +247,6 @@ msgstr ""
 msgid "Import failed"
 msgstr "Tích hợp thất bại"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-#, fuzzy
-msgid "Cannot export project"
-msgstr "Không thể xuất Dự Án"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "Đồng ý"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "Dự án \"%s\" được xuất thành công. Nhấn để hiển thị."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-#, fuzzy
-msgid "Project Export"
-msgstr "Xuất dự án"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "Không thể di chuyển thư mục"
@@ -352,28 +264,49 @@ msgstr "Không thể di chuyển thư mục hay tập tin"
 msgid "The file/directory %s already exists in target."
 msgstr "Tập tin/thư mục %s tồn tại trong thư mục đích."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "Chưa đặt tên"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "Tên định dùng không chứa bất kì kí tự nào được cho phép."
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "Không thể tạo thư mục"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "Không thể tìm thấy thư mục được yêu cầu"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "Thực sự xoá?"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "Xuất thất bại"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
+#, fuzzy, javascript-format
+msgid "An error occurred during export: %s"
+msgstr "Lỗi xuất hiện khi xuất: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "Chọn điểm xuất"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "Lưu"
+
+#: source/app/service-providers/commands/export.ts:145
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "Bạn có thực sự muốn xoá %s?"
+msgid "Exporting to %s"
+msgstr "Xuất đến %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "Lỗi xuất hiện khi xuất: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -398,11 +331,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "Bản sao của %s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "Văn bản quá dài"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "ngoại tuyến"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -415,150 +350,34 @@ msgstr "Tập tin ngôn ngữ đã tích hợp: %s"
 msgid "Could not import language file %s!"
 msgstr "Không thể tích hợp tập tin ngôn ngữ %s!"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "Xuất thất bại"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "Không thể tạo tập tin"
 
-#: source/app/service-providers/commands/export.ts:56
-#, fuzzy, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "Lỗi xuất hiện khi xuất: %s"
-
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "Chọn điểm xuất"
-
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "Lưu"
-
-#: source/app/service-providers/commands/export.ts:145
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "Xuất đến %s"
+msgid "Copy of %s"
+msgstr "Bản sao của %s"
 
-#: source/app/service-providers/commands/export.ts:158
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "Chưa đặt tên"
+
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "Không thể tạo thư mục"
+
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "Lỗi xuất hiện khi xuất: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "Tên định dùng không chứa bất kì kí tự nào được cho phép."
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "Không thể tìm thấy thư mục được yêu cầu"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "Chọn tùy chỉnh tích hợp"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "Có nhiều tùy chỉnh có thể tích hợp %s. Vui lòng chọn một."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "Textbundle sai định dạng: %s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "Luôn luôn lấy các thay đổi bên ngoài vào tập tin hiện tại"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "Ghi đè lên tập tin đang có"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "Tập tin %s tồn tại trong thư mục này. Ghi đè?"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "Mở tập tin"
-
-# msgid "Files"
-# msgstr "Các tập tin"
-# msgid "Cannot open directory"
-# msgstr "Không thể mở thư mục"
-# msgid "Directory &quot;%s&quot; cannot be opened by Zettlr."
-# msgstr "Zettlr không thể mở thư mục &quot;%s&quot;"
-# msgid "Cannot move directory"
-# msgstr "Không thể di chuyển thư mục"
-# msgid "You cannot move a directory into one of its subdirectories."
-# msgstr "Bạn không thể di chuyển một thư mục vào trong chính nó."
-# msgid "Cannot move directory or file"
-# msgstr "Không thể di chuyển thư mục hay tập tin"
-# msgid "The file/directory %s already exists in target."
-# msgstr "Tập tin/thư mục %s tồn tại trong thư mục đích."
-# msgid "The requested file was not found."
-# msgstr "Không thể tìm thấy tập tin được yêu cầu."
-# msgid "The provided name did not contain any allowed letters."
-# msgstr "Tên định dùng không chứa bất kì kí tự nào được cho phép."
-# msgid "The requested directory was not found."
-# msgstr "Không thể tìm thấy thư mục được yêu cầu"
-# msgid "Could not save image"
-# msgstr "Không thể lưu hình ảnh"
-# msgid "Copy of %s"
-# msgstr "Sao chép vào %s"
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "Thay đổi chưa được lưu"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-#, fuzzy
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "Có những thay đổi chưa lưu lại. Bạn muốn bỏ qua hay lưu chúng trước?"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "Lưu tập tin"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "Mở thư mục dự án"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "Cơ sở dữ liệu trích dẫn không thể mở được"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "Thay đổi trong tập tin thư viện được phát hiện. Đang tải lại ..."
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "Thay thế thẻ\"%s\" với \"%s\" trong %s tệp?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -670,6 +489,12 @@ msgstr "Đổi tên tập tin"
 msgid "Delete file"
 msgstr "Xoá tập tin"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "Thoát"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -688,15 +513,15 @@ msgstr "Redo"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "Cắt"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "Sao chép"
 
@@ -708,8 +533,8 @@ msgstr "Sao chép dưới dạng HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "Dán"
 
@@ -721,8 +546,8 @@ msgstr "Dán không có định dạng"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "Chọn tất cả"
 
@@ -1017,10 +842,185 @@ msgstr "Ngừng nói"
 msgid "Bring All to Front"
 msgstr "Đưa Tất cả lên Trước"
 
-#: source/app/service-providers/workspaces/index.ts:162
-#, fuzzy, javascript-format
-msgid "Loading workspace %s"
-msgstr "Đang tải workspace %s"
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "Mở thư mục dự án"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
+#, javascript-format
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "Luôn luôn lấy các thay đổi bên ngoài vào tập tin hiện tại"
+
+# msgid "Files"
+# msgstr "Các tập tin"
+# msgid "Cannot open directory"
+# msgstr "Không thể mở thư mục"
+# msgid "Directory &quot;%s&quot; cannot be opened by Zettlr."
+# msgstr "Zettlr không thể mở thư mục &quot;%s&quot;"
+# msgid "Cannot move directory"
+# msgstr "Không thể di chuyển thư mục"
+# msgid "You cannot move a directory into one of its subdirectories."
+# msgstr "Bạn không thể di chuyển một thư mục vào trong chính nó."
+# msgid "Cannot move directory or file"
+# msgstr "Không thể di chuyển thư mục hay tập tin"
+# msgid "The file/directory %s already exists in target."
+# msgstr "Tập tin/thư mục %s tồn tại trong thư mục đích."
+# msgid "The requested file was not found."
+# msgstr "Không thể tìm thấy tập tin được yêu cầu."
+# msgid "The provided name did not contain any allowed letters."
+# msgstr "Tên định dùng không chứa bất kì kí tự nào được cho phép."
+# msgid "The requested directory was not found."
+# msgstr "Không thể tìm thấy thư mục được yêu cầu"
+# msgid "Could not save image"
+# msgstr "Không thể lưu hình ảnh"
+# msgid "Copy of %s"
+# msgstr "Sao chép vào %s"
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "Thay đổi chưa được lưu"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+#, fuzzy
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "Có những thay đổi chưa lưu lại. Bạn muốn bỏ qua hay lưu chúng trước?"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "Mở tập tin"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "Lưu tập tin"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "Ghi đè lên tập tin đang có"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "Tập tin %s tồn tại trong thư mục này. Ghi đè?"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "Hiển thị Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "Một cập nhật cho phiên bản %s đang khả dụng!"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "Không thể kiểm tra cập nhật: Lỗi Máy Chủ (Mã lỗi: %s)"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "Không thể kiểm tra cập nhật: Lỗi ở máy khách (Mã lỗi: %s)"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr "Không thể kiểm tra cập nhật: Máy chủ cố gắng chuyển hướng (Mã lỗi: %s)"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "Không thể kiểm tra cập nhật: Không thể thiết lập kết nối"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "Không thể kiểm tra cập nhật: %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "Không thể kiểm tra cập nhật: Máy chủ không gửi bất kì dữ liệu nào"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 #, fuzzy
@@ -1037,17 +1037,17 @@ msgstr "Thay đổi chưa được lưu"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "Có những thay đổi chưa lưu lại. Bạn muốn lưu hay bỏ qua chúng?"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 #, fuzzy
 msgid "File changed on disk"
 msgstr "Tập tin được thay đổi trên bộ nhớ"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s được thay đổi trên bộ nhớ"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -1057,129 +1057,1207 @@ msgstr ""
 "đượclưu. Bạn muốn giữ nội dung của trình soạn thảo hay tải nội dung được lưu "
 "trên đĩa?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr ""
 "Bạn muốn giữ nội dung của trình soản thảo hay tải nội dung được lưu trên đĩa?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "Giữ nội dung của trình soạn thảo"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "Tải nội dung từ đĩa"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr ""
 "Luôn tải nội dung từ đĩa nếu không có thay đổi chưa được lưu trong trình "
 "soạn thảo"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+#, fuzzy
+msgid "Autocorrect"
+msgstr "Bật Tự Chỉnh Sửa"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "Ngoặc kép/đơn tự động"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+#, fuzzy
+msgid "Double Quotes"
+msgstr "Ngoặc kép"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "Tắt Magic Quotes"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+#, fuzzy
+msgid "Single Quotes"
+msgstr "Ngoặc Đơn"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "Mẫu dùng để thay thế văn bản"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "Khớp nguyên từ"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "Chọn để khiến chế độ tự sửa lỗi không thay thế những phần của từ"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+#, fuzzy
+msgid "Replace"
+msgstr "Thay thế tập tin"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "Với"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+#, fuzzy
+msgid "Filter"
+msgstr "Bộ lọc ..."
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "Theo lịch"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "Tắt"
+
+#: source/win-preferences/schema/appearance.ts:42
+#, fuzzy
+msgid "Follow system"
+msgstr "Theo Hệ Điều Hành"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "Bật"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "Bắt Đầu"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "Kết Thúc"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "Chủ Đề"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "Tùy chọn thanh công cụ"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "Các thuộc tính"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "Tạo tập tin bản sao"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
 #, fuzzy
-msgid "Copy path"
-msgstr "Sao chép đường dẫn đầy đủ"
+msgid "Status bar"
+msgstr "Thanh trạng thái"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "Sao chép tên tập tin"
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "Tuỳ chỉnh CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+#, fuzzy
+msgid "Open CSS editor"
+msgstr "Mở trình chỉnh sửa CSS"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "Các cài đặt nhập và xuất tập tin"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "Mở trình soạn thảo hồ sơ nhập tập tin"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "Mở trình soạn thảo hồ sơ xuất tập tin"
+
+#: source/win-preferences/schema/import-export.ts:59
+#, fuzzy
+msgid "Export settings"
+msgstr "Xuất cài đặt hiện tại"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+#, fuzzy
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "Sử dụng bản Pandoc nhúng kèm để xuất tập tin"
+
+#: source/win-preferences/schema/import-export.ts:71
+#, fuzzy
+msgid "Remove tags from files when exporting"
+msgstr "Xoá các thẻ khi xuất tập tin"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+#, fuzzy
+msgid "Internal links"
+msgstr "Gỡ liên kết các đường dẫn nội bộ"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "Xoá hoàn toàn các đường dẫn nội bộ"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "Gỡ liên kết các đường dẫn nội bộ"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "Đừng đụng vào các đường dẫn nội bộ"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "Danh mục đích dành cho các tập tin được xuất"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "Thư mục tạm"
+
+#: source/win-preferences/schema/import-export.ts:93
+#, fuzzy
+msgid "Same as file location"
+msgstr "Giống với địa điểm lưu tập tin"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "Hỏi địa điểm lưu khi xuất"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"Cảnh báo! Các tập tin trong thư mục tạm thường xuyên được xóa. Nếu chọn địa "
+"điểm lưu trùng với tập tin sẽ lưu đè lên những tập tin cùng tên nếu chúng "
+"tồn tại"
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "Tùy chỉnh lệnh xuất"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Display name"
+msgstr "Hiển thị tên"
+
+#: source/win-preferences/schema/import-export.ts:113
+#, fuzzy
+msgid "Command"
+msgstr "Lệnh"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"Nhập lệnh để tùy chỉnh trình xuất file. Mỗi lệnh sẽ dùng tập tin hoặc dự án "
+"được xuất làm tham số đầu tiên"
+
+#: source/win-preferences/schema/advanced.ts:30
+#, fuzzy
+msgid "Pattern for new file names"
+msgstr "Khuôn mẫu cho tên tập tin mới"
+
+#: source/win-preferences/schema/advanced.ts:36
+#, fuzzy
+msgid "Define a pattern for new file names"
+msgstr "Xác định khuôn mẫu cho tên tập tin mới"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "Các biến khả dụng: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "Không hỏi tên tập tin khi đang tạo tập tin mới"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "Giao diện"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "Dùng giao diện thuần của Window"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "Chỉ khả dụng cho Linux; đây là tùy chọn mặc định cho macOS và Windows."
+
+#: source/win-preferences/schema/advanced.ts:64
+#, fuzzy
+msgid "Enable window vibrancy"
+msgstr "Dùng giao diện thuần của Window"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "Chỉ khả dụng cho macOS; làm mờ phần nền của cửa sổ"
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "Hiển thị ứng dụng trong khu vực thông báo"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "Để ứng dụng chạy trong khu vực thông báo"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "Thiết lập thu phóng"
+
+#: source/win-preferences/schema/advanced.ts:85
+#, fuzzy
+msgid "Resizes the whole GUI"
+msgstr "Thu phóng thay đổi kích thước của cả ứng dụng"
+
+#: source/win-preferences/schema/advanced.ts:86
+#, fuzzy
+msgid "Changes the editor font size"
+msgstr "Thu phóng thay đổi kích thước font của khung soạn thảo"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "Thanh tệp đính kèm"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "Định dạng tập tin được hiển thị ở Thanh tệp đính kèm"
+
+#: source/win-preferences/schema/advanced.ts:104
+#, fuzzy
+msgid "Iframe rendering whitelist"
+msgstr "Danh sách an toàn để iFrame hiển thị"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "Tên máy chủ"
+
+#: source/win-preferences/schema/advanced.ts:120
+#, fuzzy
+msgid "Watchdog polling"
+msgstr "Chế độ Watchdog polling"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr ""
+"Thời gian đợi trước khi cho là việc ghi tập tin đã hoàn tất (đơn vị ms)"
+
+#: source/win-preferences/schema/advanced.ts:138
+#, fuzzy
+msgid "Deleting items"
+msgstr "Xoá tập tin"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+#, fuzzy
+msgid "Debug mode"
+msgstr "Chế độ gỡ lỗi"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "Bật chế độ gỡ lỗi"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Các phiên bản beta"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "Báo tôi biết về các bản cập nhật beta"
+
+#: source/win-preferences/schema/editor.ts:23
+#, fuzzy
+msgid "Input mode"
+msgstr "Chế độ soạn thảo"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"Chế độ soạn thảo quyết định cách bạn tương tác với khung soạn thảo. Chúngtôi "
+"đề xuất giữ tùy chỉnh này ở chế độ \"Bình thường\". Chỉ chọn \"Vim\" "
+"hoặc\"Emacs\" nếu bạn biết chúng là gì."
+
+#: source/win-preferences/schema/editor.ts:44
+#, fuzzy
+msgid "Writing direction"
+msgstr "Hướng viết"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Hiển thị Markdown"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"Chọn để kích hoạt hiện thị trực tiếp các thành phần Markdown thành định dạng "
+"hoàn chỉnh. Chế độ này giấu các ký tự định dạng (như **text**) hoặc hiển thị "
+"hình ảnh trực tiếp thay vì đường dẫn của chúng"
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "Ẩn các kí tự thể hiện đề mục (#)"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "Thể hiện nhấn mạnh"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "In đậm"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "In nghiêng"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "Kiểm tra cú pháp Markdown"
+
+#: source/win-preferences/schema/editor.ts:149
+#, fuzzy
+msgid "Table Editor"
+msgstr "Thiết lập Khung Soạn Thảo Bảng"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"Khung Soạn Thảo Bảng là một giao diện hỗ trợ đơn giản hóa tạo bảng và điều "
+"chỉnh chúng. Công cụ này cung cấp các nút cho những chức năng thông dụng, và "
+"tự điều chỉnh cú pháp Markdown tương ứng."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "Làm mờ các dòng không tập trung, trong chế độ không làm phiền"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+#, fuzzy
+msgid "Word counter"
+msgstr "Số từ"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "Đếm số ký tự thay vì số chữ (Ví dụ: cho tiếng Trung)"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "Chế độ đánh giá dễ đọc"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "Thuật toán"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+#, fuzzy
+msgid "Image size"
+msgstr "Kích cỡ ảnh"
+
+#: source/win-preferences/schema/editor.ts:220
+#, fuzzy
+msgid "Maximum width of images (%s %)"
+msgstr "Chiều ngang tối đa của ảnh (%s %)"
+
+#: source/win-preferences/schema/editor.ts:227
+#, fuzzy
+msgid "Maximum height of images (%s %)"
+msgstr "Chiều cao tối đa của ảnh (%s %)"
+
+#: source/win-preferences/schema/editor.ts:235
+#, fuzzy
+msgid "Other settings"
+msgstr "Các tùy chỉnh khác"
+
+#: source/win-preferences/schema/editor.ts:241
+#, fuzzy
+msgid "Font size"
+msgstr "Kích thước font của trình soạn thảo"
+
+#: source/win-preferences/schema/editor.ts:248
+#, fuzzy
+msgid "Indentation size (number of spaces)"
+msgstr "Thụt đầu dòng với số lượng phím Khoảng Trắng là"
+
+#: source/win-preferences/schema/editor.ts:255
+#, fuzzy
+msgid "Indent using tabs instead of spaces"
+msgstr "Thụt đầu dòng dùng Tabs"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+#, fuzzy
+msgid "Suggest emojis during autocompletion"
+msgstr "Đề xuất emoji trong lúc tự hoàn tất"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "Xem trước kết quả đường dẫn"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "Tự động thêm ký tự kết thúc của cặp kí tự"
+
+#: source/win-preferences/schema/file-manager.ts:23
+#, fuzzy
+msgid "Display mode"
+msgstr "Chế độ hiển thị"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "Mảnh"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "Đầy đủ"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "Kết hợp"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"Chế độ mảnh hiển thị các thư mục và tập tin một cách độc lập. Chọn một thư "
+"mục để hiển thị nội dung của thư mục đó theo một danh sách các tệp. Chuyển "
+"giữa danh sách tệp và cây thư mục bằng cách nhấn vào một thư mục hoặc chọn "
+"dấu mũi tên ở góc trái danh sách tập tin."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "Thể hiện thông tin tập tin"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "Hiển thị các thư mục bên trên tập tin"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Hiển thị tên tài liệu Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "Chỉ tên tập tin"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "Tiêu đề nếu khả dụng"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "Đề mục cấp 1 đầu tiên nếu khả dụng"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "Tiêu đề hay đề mục cấp 1 đầu tiên nếu khả dụng"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "Hiển thị mở rộng của tập tin Markdown"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "Hiển thị thời gian"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "Thời gian thay đổi cuối cùng"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "Thời gian tập tin được tạo"
+
+#: source/win-preferences/schema/file-manager.ts:95
+#, fuzzy
+msgid "Sorting"
+msgstr "Thứ tự"
+
+#: source/win-preferences/schema/file-manager.ts:101
+#, fuzzy
+msgid "When sorting documents…"
+msgstr "Sắp xếp văn bản theo…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+#, fuzzy
+msgid "Use natural order (2 comes before 10)"
+msgstr "Theo thứ tự bình thường (10 hiển thị sau 2)"
+
+#: source/win-preferences/schema/file-manager.ts:105
+#, fuzzy
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "Theo thứ tự ASCII (2 hiển thị sau 10)"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+#, fuzzy
+msgid "Citations"
+msgstr "Hiển thị các trích dẫn"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "Tự động hoàn tất sẽ chèn các trích dẫn của bạn thế nào?"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+#, fuzzy
+msgid "Path to file"
+msgstr "Đường dẫn đến tập tin"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "ID Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+#, fuzzy
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Mẫu định dạng ID Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+#, fuzzy
+msgid "Uses ECMAScript regular expressions"
+msgstr "Dùng ECMAScript regular expression"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "Mẫu dùng để tạo các ID mới"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "Các biến khả dụng: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+#, fuzzy
+msgid "Link with filename only"
+msgstr "Chỉ tên tập tin"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+#, fuzzy
+msgid "When linking files, add the document name …"
+msgstr "Khi liên kết các tập tin với nhau, thêm tên tập tin ..."
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+#, fuzzy
+msgid "Always"
+msgstr "Luôn luôn"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+#, fuzzy
+msgid "Only when linking using the ID"
+msgstr "Chỉ khi liên kết bằng ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+#, fuzzy
+msgid "Never"
+msgstr "không bao giờ"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+#, fuzzy
+msgid "Start a full-text search when following internal links"
+msgstr "Tự động tìm kiếm khi đi theo đường dẫn Zettelkasten"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "Chuỗi tìm kiếm sẽ khớp với nội dung nằm giữa các dấu ngoặc vuông"
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+#, fuzzy
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "Tự động tạo các tập tin chưa tồn tại khi đi theo các đường dẫn nội bộ."
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr ""
+"Để chế độ này có hiệu lực, thư mục mục tiêu phải là một Workspace trong "
+"Zettlr."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "Đường dẫn tập tin"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "Đoạn Mẫu"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "Mở trình soạn thảo đoạn mẫu"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "Công cụ ngôn ngữ"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "Độ nghiêm"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+#, fuzzy
+msgid "Standard"
+msgstr "Tiêu chuẩn"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "Kén chọn"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "Ngôn ngữ mẹ đẻ"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "Không chọn"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "Nhà cung cấp công cụ ngôn ngữ"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+#, fuzzy
+msgid "Custom server"
+msgstr "Máy chủ tùy chỉnh"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+#, fuzzy
+msgid "Custom server address"
+msgstr "Địa chỉ máy chủ"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "Công cụ ngôn ngữ Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr ""
+"Zettlr sẽ bỏ qua phần \"Nhà cung cấp ngôn ngữ\" nếu bạn nhập thông tin vào "
+"phần này."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "Username của công cụ ngôn ngữ"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "API Key của công cụ ngôn ngữ"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "Kiểm tra chính tả"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#, fuzzy
+msgid "Active"
+msgstr "Kích hoạt"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "Ngôn ngữ"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "Mã"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "Chọn các ngôn ngữ bạn muốn dùng cho tự động sửa lỗi chính tả"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "Từ điển người dùng. Xoá từ bằng cách nhấn vào chúng."
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "Mục từ"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "Tìm kiếm từ mục ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "Ngôn ngữ"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "Tự động lưu"
+
+#: source/win-preferences/schema/general.ts:43
+#, fuzzy
+msgid "Save modifications"
+msgstr "Thời gian thay đổi cuối cùng"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "Ngay lập tức"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "Sau một khoảng trễ ngắn"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "Thư mục hình ảnh mặc định"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr ""
+"Nhấn \"Chọn thư mục…\" hoặc nhập đường dẫn tuyệt đối hoặc tương đối vào "
+"trường nhập liệu."
+
+#: source/win-preferences/schema/general.ts:72
+#, fuzzy
+msgid "Behavior"
+msgstr "Thiết lập thu phóng"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "Tránh mở tập tin trong cửa sổ mới nếu có thể"
+
+#: source/win-preferences/schema/general.ts:89
+#, fuzzy
+msgid "Updates"
+msgstr "Trình cập nhật"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "Tự động kiểm tra các bản cập nhât"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s kí tự"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s từ"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "Đi đến chú thích cuối trang"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "Không highlight"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "Mở bảng chẩn đoán"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "Tắt"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#, fuzzy
+msgid "Custom"
+msgstr "Tuỳ chỉnh CSS"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "Tự động phát hiện"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "Đang tạo biểu đồ mermaid …"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+#, fuzzy
+msgid "Could not render Graph:"
+msgstr "Không thể tạo biểu đồ"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "Chế độ đánh giá dễ đọc (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "Không tìm thấy ảnh: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "Lỗi chính tả"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "Tếp %s không tồn tại."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "Số từ"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "Đã chỉnh sửa"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "Mở..."
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "Mở trong một tab mới"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "Đường Dẫn"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "Ảnh"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "Ghi chú"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "Không tìm thấy chú thích."
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "Sao chép mã phương trình"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "Sao chép ảnh vào bảng tạm clipboard"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+#, fuzzy
+msgid "Open image"
+msgstr "Mở ảnh"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "Hiển thị trong Finder"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "Hiển thị trong Explorer"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+#, fuzzy
+msgid "Open in File Browser"
+msgstr "Mở trong File Browser"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "Hiển thị trong File Browser"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "Không có gợi ý"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "Đóng tập tin"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "Thêm vào từ điển"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "Đổi tên thư mục"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "In nghiêng"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "Xoá thư mục"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "Chèn đường dẫn"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "Kiểm tra thư mục…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "Chèn danh sách không có thứ tự"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "Xuất Dự Án"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "Chèn danh sách đánh số"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "Đóng các tab khác"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "Đóng tất cả tab"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "Bỏ ghim tab"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "Ghim tab"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr "."
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr ","
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Giữ Cmd/Ctrl và nhấp để theo đường dẫn"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1611,327 +2689,322 @@ msgstr "Trung Quốc (Đài Loan)"
 msgid "Chinese"
 msgstr "Trung Quốc"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "Tự động phát hiện"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "Tắt"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
+msgstr ""
+
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "Các thuộc tính"
+
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "Tạo tập tin bản sao"
+
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
 #, fuzzy
-msgid "Custom"
-msgstr "Tuỳ chỉnh CSS"
+msgid "Copy path"
+msgstr "Sao chép đường dẫn đầy đủ"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s từ"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "Sao chép tên tập tin"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s kí tự"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "Hiển thị trong Explorer"
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "Mở bảng chẩn đoán"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "Hiển thị trong File Browser"
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "Lỗi chính tả"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "Đóng tập tin"
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "Đổi tên thư mục"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "Xoá thư mục"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "Kiểm tra thư mục…"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "Xuất Dự Án"
+
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "Đi đến chú thích cuối trang"
-
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "In đậm"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "Đóng các tab khác"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "In nghiêng"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "Đóng tất cả tab"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "Đường Dẫn"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "Bỏ ghim tab"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "Ảnh"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "Ghim tab"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "Ghi chú"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "Lịch"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "Mã"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "Các biểu đồ"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "Không tìm thấy chú thích."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "Tếp %s không tồn tại."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "Số từ"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "Đã chỉnh sửa"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "Mở..."
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "Mở trong một tab mới"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "Không highlight"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "Tháng Một"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "Tháng Hai"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "Tháng Ba"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "Tháng Bốn"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "Tháng Năm"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "Tháng Sáu"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "Tháng Bảy"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "Tháng Tám"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "Tháng Chín"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "Tháng Mười"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "Tháng Mười Một"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "Tháng Mười Hai"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "Dưới trung bình tháng"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "Vượt qua trung bình tháng"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "Hơn gấp đôi trung bình tháng"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "Sao chép ảnh vào bảng tạm clipboard"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-#, fuzzy
-msgid "Open image"
-msgstr "Mở ảnh"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-#, fuzzy
-msgid "Open in File Browser"
-msgstr "Mở trong File Browser"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "Không có gợi ý"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "Thêm vào từ điển"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "In nghiêng"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "Chèn đường dẫn"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "Chèn danh sách không có thứ tự"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "Chèn danh sách đánh số"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "Sao chép mã phương trình"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "Chế độ đánh giá dễ đọc (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "Không tìm thấy ảnh: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "Đang tạo biểu đồ mermaid …"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-#, fuzzy
-msgid "Could not render Graph:"
-msgstr "Không thể tạo biểu đồ"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Giữ Cmd/Ctrl và nhấp để theo đường dẫn"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "Trình cập nhật"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "Có bản cập nhật mới"
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "Phiên bản của bạn"
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr ""
-"Có phiên bản mới của Zettlr khả dụng để tải về. Vui lòng đọc các thay đổi "
-"bên dưới"
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "Đang tải cập nhật cho bạn"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "Không có cập nhật mới. Bạn đang dùng phiên bản mới nhất"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "Bấm để cập nhật"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr ""
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "Bắt đầu cập nhật …"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "Tìm kiếm"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "Số từ"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "Bộ lọc thẻ…"
-
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "Đặt lại"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select folder…"
+msgstr "Mở thư mục dự án"
+
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+#, fuzzy
+msgid "Select file…"
+msgstr "Chọn tập tin…"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "Thêm"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Các hành động"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+#, fuzzy
+msgid "Delete"
+msgstr "Xoá tập tin"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-#, fuzzy
-msgid "Image size"
-msgstr "Kích cỡ ảnh"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1948,10 +3021,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -2015,46 +3084,30 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr cũng sử dụng các dự án sau"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"Tại đây bạn có thể ghi đè lên các lớp giao diện của Zettlr để tuỳ biến ứng "
-"dụng nhiều hơn. <strong>Lưu ý: Tập tin này ghi đè lên tất cả các chỉ thị "
-"CSS! Không được thay đổi nội dung thể hiện hình dạng của các phần tử, hoặc "
-"ứng dụng sẽ xuất hiện các hành vi không theo mong đợi!</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "Thay đổi tên snippet"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr ""
+"Snippets cho phép bạn chèn nhanh những đoạn văn bản thường dùng, đi cùng các "
+"biến giá trị (variables) có thể tuỳ chỉnh."
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "Đang lưu …"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "Lưu thất bại"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "Tuỳ chỉnh CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "Đoạn Mẫu"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "Đã Lưu!"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -2080,41 +3133,78 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "Chỉnh sửa các tuỳ chọn mặc định cho việc xuất hay nhập tại đây"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "Đã Lưu!"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "Thay đổi tên snippet"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr ""
-"Snippets cho phép bạn chèn nhanh những đoạn văn bản thường dùng, đi cùng các "
-"biến giá trị (variables) có thể tuỳ chỉnh."
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "từ"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "kí tự"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"Tại đây bạn có thể ghi đè lên các lớp giao diện của Zettlr để tuỳ biến ứng "
+"dụng nhiều hơn. <strong>Lưu ý: Tập tin này ghi đè lên tất cả các chỉ thị "
+"CSS! Không được thay đổi nội dung thể hiện hình dạng của các phần tử, hoặc "
+"ứng dụng sẽ xuất hiện các hành vi không theo mong đợi!</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "Không có văn bản được mở"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "Lưu thất bại"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "Bắt Đầu"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "Số từ"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "Bộ lọc thẻ…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2140,76 +3230,116 @@ msgstr "Hiệu Ứng Âm Thanh"
 msgid "Volume"
 msgstr "Âm Lượng"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "số từ trong tháng trước"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "Các tập tin liên quan"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "trung bình ngày"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "Không có tập tin liên quan"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "số từ hôm nay"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "Quan hệ này được dựa trên liên kết hai chiều."
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 Bạn đang rực cháy!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "Quan hệ này được dựa trên liên kết đi."
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 Bạn sắp đạt mức trung bình ngày rồi!"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "Quan hệ này được dựa trên liên kết tới."
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 Tiếp tục viết để vượt qua thành tích thường ngày của bạn nào."
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "Thêm thống kê …"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "Quan hệ này được dựa trên %s thẻ chung: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "Các tập tin khác"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "Mở thư mục"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "Không có tập tin khác"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "Tài liệu tham khảo"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "Không có trích dẫn trong tài liệu này."
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "Tên"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "Đám mây thẻ"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Exporting…"
+msgstr "Xuất..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+#, fuzzy
+msgid "Export"
+msgstr "Xuất..."
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "lệnh"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2219,8 +3349,8 @@ msgstr "Các thư mục"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "Các tập tin"
 
@@ -2234,10 +3364,26 @@ msgstr "Các kí tự"
 msgid "Words"
 msgstr "Các từ"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "Vùng Làm Việc"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "Không có tập tin hay thư mục được mở"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "Không có kết quả"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "Không có thư mục nào được chọn"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "Thư mục trống"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2267,15 +3413,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "Đặt lại"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2336,13 +3473,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "Lịch"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2552,132 +3682,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "Đặt mục tiêu viết…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "Không có kết quả"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "Không có thư mục nào được chọn"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "Thư mục trống"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "Vùng Làm Việc"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "Không có tập tin hay thư mục được mở"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "số từ trong tháng trước"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "trung bình ngày"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "số từ hôm nay"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 Bạn đang rực cháy!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 Bạn sắp đạt mức trung bình ngày rồi!"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 Tiếp tục viết để vượt qua thành tích thường ngày của bạn nào."
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "Thêm thống kê …"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Exporting…"
-msgstr "Xuất..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-#, fuzzy
-msgid "Export"
-msgstr "Xuất..."
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "lệnh"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2699,11 +3707,6 @@ msgstr "Giới hạn tìm kiếm trong thư mục"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "Tìm kiếm"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "Xoá tìm kiếm"
@@ -2717,1134 +3720,137 @@ msgstr "Ẩn/hiện các kết quả"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "Tên"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "Đám mây thẻ"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "từ"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "kí tự"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "Không có văn bản được mở"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "Các tập tin liên quan"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "Không có tập tin liên quan"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "Quan hệ này được dựa trên liên kết hai chiều."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "Quan hệ này được dựa trên liên kết đi."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "Quan hệ này được dựa trên liên kết tới."
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "Quan hệ này được dựa trên %s thẻ chung: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "Các tập tin khác"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "Mở thư mục"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "Không có tập tin khác"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "Thêm"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Các hành động"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-#, fuzzy
-msgid "Delete"
-msgstr "Xoá tập tin"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select folder…"
-msgstr "Mở thư mục dự án"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-#, fuzzy
-msgid "Select file…"
-msgstr "Chọn tập tin…"
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "Tài liệu tham khảo"
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "Không có trích dẫn trong tài liệu này."
 
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "Giao diện"
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "Kiểm tra chính tả"
-
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-#, fuzzy
-msgid "Autocorrect"
-msgstr "Bật Tự Chỉnh Sửa"
-
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-#, fuzzy
-msgid "Citations"
-msgstr "Hiển thị các trích dẫn"
-
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:199
-#, javascript-format
-msgid "Searching: %s"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "Tháng Một"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "Tháng Hai"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "Tháng Ba"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "Tháng Bốn"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "Tháng Năm"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "Tháng Sáu"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "Tháng Bảy"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "Tháng Tám"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "Tháng Chín"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "Tháng Mười"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "Tháng Mười Một"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "Tháng Mười Hai"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "Dưới trung bình tháng"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "Vượt qua trung bình tháng"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "Hơn gấp đôi trung bình tháng"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "Các biểu đồ"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "ID Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-#, fuzzy
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Mẫu định dạng ID Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-#, fuzzy
-msgid "Uses ECMAScript regular expressions"
-msgstr "Dùng ECMAScript regular expression"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "Mẫu dùng để tạo các ID mới"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "Các biến khả dụng: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-#, fuzzy
-msgid "Internal links"
-msgstr "Gỡ liên kết các đường dẫn nội bộ"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-#, fuzzy
-msgid "Link with filename only"
-msgstr "Chỉ tên tập tin"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-#, fuzzy
-msgid "When linking files, add the document name …"
-msgstr "Khi liên kết các tập tin với nhau, thêm tên tập tin ..."
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-#, fuzzy
-msgid "Always"
-msgstr "Luôn luôn"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-#, fuzzy
-msgid "Only when linking using the ID"
-msgstr "Chỉ khi liên kết bằng ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-#, fuzzy
-msgid "Never"
-msgstr "không bao giờ"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-#, fuzzy
-msgid "Start a full-text search when following internal links"
-msgstr "Tự động tìm kiếm khi đi theo đường dẫn Zettelkasten"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "Chuỗi tìm kiếm sẽ khớp với nội dung nằm giữa các dấu ngoặc vuông"
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-#, fuzzy
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "Tự động tạo các tập tin chưa tồn tại khi đi theo các đường dẫn nội bộ."
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr ""
-"Để chế độ này có hiệu lực, thư mục mục tiêu phải là một Workspace trong "
-"Zettlr."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "Đường dẫn tập tin"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "Ngoặc kép/đơn tự động"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-#, fuzzy
-msgid "Double Quotes"
-msgstr "Ngoặc kép"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "Tắt Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-#, fuzzy
-msgid "Single Quotes"
-msgstr "Ngoặc Đơn"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "Mẫu dùng để thay thế văn bản"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "Khớp nguyên từ"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "Chọn để khiến chế độ tự sửa lỗi không thay thế những phần của từ"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-#, fuzzy
-msgid "Replace"
-msgstr "Thay thế tập tin"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "Với"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-#, fuzzy
-msgid "Filter"
-msgstr "Bộ lọc ..."
-
-#: source/win-preferences/schema/editor.ts:23
-#, fuzzy
-msgid "Input mode"
-msgstr "Chế độ soạn thảo"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"Chế độ soạn thảo quyết định cách bạn tương tác với khung soạn thảo. Chúngtôi "
-"đề xuất giữ tùy chỉnh này ở chế độ \"Bình thường\". Chỉ chọn \"Vim\" "
-"hoặc\"Emacs\" nếu bạn biết chúng là gì."
-
-#: source/win-preferences/schema/editor.ts:44
-#, fuzzy
-msgid "Writing direction"
-msgstr "Hướng viết"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Hiển thị Markdown"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"Chọn để kích hoạt hiện thị trực tiếp các thành phần Markdown thành định dạng "
-"hoàn chỉnh. Chế độ này giấu các ký tự định dạng (như **text**) hoặc hiển thị "
-"hình ảnh trực tiếp thay vì đường dẫn của chúng"
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "Ẩn các kí tự thể hiện đề mục (#)"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "Thể hiện nhấn mạnh"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "Kiểm tra cú pháp Markdown"
-
-#: source/win-preferences/schema/editor.ts:149
-#, fuzzy
-msgid "Table Editor"
-msgstr "Thiết lập Khung Soạn Thảo Bảng"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"Khung Soạn Thảo Bảng là một giao diện hỗ trợ đơn giản hóa tạo bảng và điều "
-"chỉnh chúng. Công cụ này cung cấp các nút cho những chức năng thông dụng, và "
-"tự điều chỉnh cú pháp Markdown tương ứng."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "Làm mờ các dòng không tập trung, trong chế độ không làm phiền"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-#, fuzzy
-msgid "Word counter"
-msgstr "Số từ"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "Đếm số ký tự thay vì số chữ (Ví dụ: cho tiếng Trung)"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "Chế độ đánh giá dễ đọc"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "Thuật toán"
-
-#: source/win-preferences/schema/editor.ts:220
-#, fuzzy
-msgid "Maximum width of images (%s %)"
-msgstr "Chiều ngang tối đa của ảnh (%s %)"
-
-#: source/win-preferences/schema/editor.ts:227
-#, fuzzy
-msgid "Maximum height of images (%s %)"
-msgstr "Chiều cao tối đa của ảnh (%s %)"
-
-#: source/win-preferences/schema/editor.ts:235
-#, fuzzy
-msgid "Other settings"
-msgstr "Các tùy chỉnh khác"
-
-#: source/win-preferences/schema/editor.ts:241
-#, fuzzy
-msgid "Font size"
-msgstr "Kích thước font của trình soạn thảo"
-
-#: source/win-preferences/schema/editor.ts:248
-#, fuzzy
-msgid "Indentation size (number of spaces)"
-msgstr "Thụt đầu dòng với số lượng phím Khoảng Trắng là"
-
-#: source/win-preferences/schema/editor.ts:255
-#, fuzzy
-msgid "Indent using tabs instead of spaces"
-msgstr "Thụt đầu dòng dùng Tabs"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-#, fuzzy
-msgid "Suggest emojis during autocompletion"
-msgstr "Đề xuất emoji trong lúc tự hoàn tất"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "Xem trước kết quả đường dẫn"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "Tự động thêm ký tự kết thúc của cặp kí tự"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "Theo lịch"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "Tắt"
-
-#: source/win-preferences/schema/appearance.ts:42
-#, fuzzy
-msgid "Follow system"
-msgstr "Theo Hệ Điều Hành"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "Bật"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "Kết Thúc"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "Chủ Đề"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "Tùy chọn thanh công cụ"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-#, fuzzy
-msgid "Status bar"
-msgstr "Thanh trạng thái"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-#, fuzzy
-msgid "Open CSS editor"
-msgstr "Mở trình chỉnh sửa CSS"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "Công cụ ngôn ngữ"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "Độ nghiêm"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-#, fuzzy
-msgid "Standard"
-msgstr "Tiêu chuẩn"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "Kén chọn"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "Ngôn ngữ mẹ đẻ"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "Không chọn"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "Nhà cung cấp công cụ ngôn ngữ"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-#, fuzzy
-msgid "Custom server"
-msgstr "Máy chủ tùy chỉnh"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-#, fuzzy
-msgid "Custom server address"
-msgstr "Địa chỉ máy chủ"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "Công cụ ngôn ngữ Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr ""
-"Zettlr sẽ bỏ qua phần \"Nhà cung cấp ngôn ngữ\" nếu bạn nhập thông tin vào "
-"phần này."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "Username của công cụ ngôn ngữ"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "API Key của công cụ ngôn ngữ"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-#, fuzzy
-msgid "Active"
-msgstr "Kích hoạt"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "Ngôn ngữ"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "Chọn các ngôn ngữ bạn muốn dùng cho tự động sửa lỗi chính tả"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "Từ điển người dùng. Xoá từ bằng cách nhấn vào chúng."
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "Mục từ"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "Tìm kiếm từ mục ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-#, fuzzy
-msgid "Display mode"
-msgstr "Chế độ hiển thị"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "Mảnh"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "Đầy đủ"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "Kết hợp"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"Chế độ mảnh hiển thị các thư mục và tập tin một cách độc lập. Chọn một thư "
-"mục để hiển thị nội dung của thư mục đó theo một danh sách các tệp. Chuyển "
-"giữa danh sách tệp và cây thư mục bằng cách nhấn vào một thư mục hoặc chọn "
-"dấu mũi tên ở góc trái danh sách tập tin."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "Thể hiện thông tin tập tin"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "Hiển thị các thư mục bên trên tập tin"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Hiển thị tên tài liệu Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "Chỉ tên tập tin"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "Tiêu đề nếu khả dụng"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "Đề mục cấp 1 đầu tiên nếu khả dụng"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "Tiêu đề hay đề mục cấp 1 đầu tiên nếu khả dụng"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "Hiển thị mở rộng của tập tin Markdown"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "Hiển thị thời gian"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "Thời gian thay đổi cuối cùng"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "Thời gian tập tin được tạo"
-
-#: source/win-preferences/schema/file-manager.ts:95
-#, fuzzy
-msgid "Sorting"
-msgstr "Thứ tự"
-
-#: source/win-preferences/schema/file-manager.ts:101
-#, fuzzy
-msgid "When sorting documents…"
-msgstr "Sắp xếp văn bản theo…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-#, fuzzy
-msgid "Use natural order (2 comes before 10)"
-msgstr "Theo thứ tự bình thường (10 hiển thị sau 2)"
-
-#: source/win-preferences/schema/file-manager.ts:105
-#, fuzzy
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "Theo thứ tự ASCII (2 hiển thị sau 10)"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "Các cài đặt nhập và xuất tập tin"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "Mở trình soạn thảo hồ sơ nhập tập tin"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "Mở trình soạn thảo hồ sơ xuất tập tin"
-
-#: source/win-preferences/schema/import-export.ts:59
-#, fuzzy
-msgid "Export settings"
-msgstr "Xuất cài đặt hiện tại"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-#, fuzzy
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "Sử dụng bản Pandoc nhúng kèm để xuất tập tin"
-
-#: source/win-preferences/schema/import-export.ts:71
-#, fuzzy
-msgid "Remove tags from files when exporting"
-msgstr "Xoá các thẻ khi xuất tập tin"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "Xoá hoàn toàn các đường dẫn nội bộ"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "Gỡ liên kết các đường dẫn nội bộ"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "Đừng đụng vào các đường dẫn nội bộ"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "Danh mục đích dành cho các tập tin được xuất"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "Thư mục tạm"
-
-#: source/win-preferences/schema/import-export.ts:93
-#, fuzzy
-msgid "Same as file location"
-msgstr "Giống với địa điểm lưu tập tin"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "Hỏi địa điểm lưu khi xuất"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"Cảnh báo! Các tập tin trong thư mục tạm thường xuyên được xóa. Nếu chọn địa "
-"điểm lưu trùng với tập tin sẽ lưu đè lên những tập tin cùng tên nếu chúng "
-"tồn tại"
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "Tùy chỉnh lệnh xuất"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Display name"
-msgstr "Hiển thị tên"
-
-#: source/win-preferences/schema/import-export.ts:113
-#, fuzzy
-msgid "Command"
-msgstr "Lệnh"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"Nhập lệnh để tùy chỉnh trình xuất file. Mỗi lệnh sẽ dùng tập tin hoặc dự án "
-"được xuất làm tham số đầu tiên"
-
-#: source/win-preferences/schema/advanced.ts:30
-#, fuzzy
-msgid "Pattern for new file names"
-msgstr "Khuôn mẫu cho tên tập tin mới"
-
-#: source/win-preferences/schema/advanced.ts:36
-#, fuzzy
-msgid "Define a pattern for new file names"
-msgstr "Xác định khuôn mẫu cho tên tập tin mới"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "Các biến khả dụng: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "Không hỏi tên tập tin khi đang tạo tập tin mới"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "Dùng giao diện thuần của Window"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "Chỉ khả dụng cho Linux; đây là tùy chọn mặc định cho macOS và Windows."
-
-#: source/win-preferences/schema/advanced.ts:64
-#, fuzzy
-msgid "Enable window vibrancy"
-msgstr "Dùng giao diện thuần của Window"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "Chỉ khả dụng cho macOS; làm mờ phần nền của cửa sổ"
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "Hiển thị ứng dụng trong khu vực thông báo"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "Để ứng dụng chạy trong khu vực thông báo"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "Thiết lập thu phóng"
-
-#: source/win-preferences/schema/advanced.ts:85
-#, fuzzy
-msgid "Resizes the whole GUI"
-msgstr "Thu phóng thay đổi kích thước của cả ứng dụng"
-
-#: source/win-preferences/schema/advanced.ts:86
-#, fuzzy
-msgid "Changes the editor font size"
-msgstr "Thu phóng thay đổi kích thước font của khung soạn thảo"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "Thanh tệp đính kèm"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "Định dạng tập tin được hiển thị ở Thanh tệp đính kèm"
-
-#: source/win-preferences/schema/advanced.ts:104
-#, fuzzy
-msgid "Iframe rendering whitelist"
-msgstr "Danh sách an toàn để iFrame hiển thị"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "Tên máy chủ"
-
-#: source/win-preferences/schema/advanced.ts:120
-#, fuzzy
-msgid "Watchdog polling"
-msgstr "Chế độ Watchdog polling"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr ""
-"Thời gian đợi trước khi cho là việc ghi tập tin đã hoàn tất (đơn vị ms)"
-
-#: source/win-preferences/schema/advanced.ts:138
-#, fuzzy
-msgid "Deleting items"
-msgstr "Xoá tập tin"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-#, fuzzy
-msgid "Debug mode"
-msgstr "Chế độ gỡ lỗi"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "Bật chế độ gỡ lỗi"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Các phiên bản beta"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "Báo tôi biết về các bản cập nhật beta"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "Mở trình soạn thảo đoạn mẫu"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "Ngôn ngữ"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "Tự động lưu"
-
-#: source/win-preferences/schema/general.ts:43
-#, fuzzy
-msgid "Save modifications"
-msgstr "Thời gian thay đổi cuối cùng"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "Ngay lập tức"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "Sau một khoảng trễ ngắn"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "Thư mục hình ảnh mặc định"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr ""
-"Nhấn \"Chọn thư mục…\" hoặc nhập đường dẫn tuyệt đối hoặc tương đối vào "
-"trường nhập liệu."
-
-#: source/win-preferences/schema/general.ts:72
-#, fuzzy
-msgid "Behavior"
-msgstr "Thiết lập thu phóng"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "Tránh mở tập tin trong cửa sổ mới nếu có thể"
-
-#: source/win-preferences/schema/general.ts:89
-#, fuzzy
-msgid "Updates"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
 msgstr "Trình cập nhật"
 
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "Tự động kiểm tra các bản cập nhât"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "Có bản cập nhật mới"
 
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "Tự động hoàn tất sẽ chèn các trích dẫn của bạn thế nào?"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "Phiên bản của bạn"
 
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr ""
+"Có phiên bản mới của Zettlr khả dụng để tải về. Vui lòng đọc các thay đổi "
+"bên dưới"
+
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "Đang tải cập nhật cho bạn"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "Không có cập nhật mới. Bạn đang dùng phiên bản mới nhất"
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "Bấm để cập nhật"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-#, fuzzy
-msgid "Path to file"
-msgstr "Đường dẫn đến tập tin"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#, javascript-format
+msgid "Last checked: %s"
 msgstr ""
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "Bắt đầu cập nhật …"
 
 #~ msgid "Open Link"
 #~ msgstr "Mở Đường Dẫn"

--- a/static/lang/zh-CN.po
+++ b/static/lang/zh-CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-04-09 16:13+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2024-04-10 14:00+0800\n"
 "Last-Translator: freesrz93 <srzsrz@126.com>\n"
 "Language-Team: \n"
@@ -17,6 +17,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "无法加载引文数据库"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "检测到库文件更改，重新加载中…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "加载工作区 %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,140 +82,6 @@ msgstr "选项％s必须至少为％s（字符长）。"
 msgid "Option %s is required."
 msgstr "选项％s是必需的。"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "在托盘中显示Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "退出"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "可以更新到最新版本  %s ！"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "无法检查更新：服务器错误（状态代码：%s）"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "无法检查更新：客户端错误（状态代码：%s）"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr "无法检查更新：服务器尝试重定向（状态代码：％s）"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "无法检查更新：无法建立连接"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "无法检查最新版本 %s: %s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "无法检查更新：服务器尚未发送任何数据"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr ""
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr ""
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "文档太长了"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "离线"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "无法新建文档"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "%s 的引用未发现带有附件。"
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "不能打开附件，Zotero 是否正在运行？"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +99,96 @@ msgstr "是的"
 msgid "No"
 msgstr "否"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "将标签 %s 替换为 %s (在%s 个文件中)?"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "好的"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "取消"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "是否删除？"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "你想要移除 %s?"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "%s 的引用未发现带有附件。"
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "不能打开附件，Zotero 是否正在运行？"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "格式错误的Textbundle：％s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "选择导入配置"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "有多个配置可用于导入 %s. 请选择其中之一."
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "无法导出项目"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "项目 %s 已成功导出. 点击显示."
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "导出项目"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -290,46 +242,6 @@ msgstr "以下文件 %s 无法被导入，因为其未知文件类型：%s"
 msgid "Import failed"
 msgstr "导入失败"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "无法导出项目"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "好的"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "项目 %s 已成功导出. 点击显示."
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "导出项目"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "无法移动目录"
@@ -347,28 +259,49 @@ msgstr "无法移动目录或文档"
 msgid "The file/directory %s already exists in target."
 msgstr "目标文件/目录％s已存在."
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "未命名"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "提交的文件名包含不被允许的字符"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "无法创建目录"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "找不到请求的目录。."
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "是否删除？"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "导出失败"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "你想要移除 %s?"
+msgid "An error occurred during export: %s"
+msgstr "导出时发生错误: %s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "选择导出目的位置"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "保存"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "成功导出到％s！"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "错误输出: %s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -393,11 +326,13 @@ msgstr ""
 msgid "Cannot open workspace \"%s\"."
 msgstr ""
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr " %s的副本"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "文档太长了"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "离线"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -410,125 +345,34 @@ msgstr "语言包文件已导入：%s"
 msgid "Could not import language file %s!"
 msgstr "无法导入语言包文件 %s！"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "导出失败"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "无法新建文档"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "导出时发生错误: %s"
+msgid "Copy of %s"
+msgstr " %s的副本"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "选择导出目的位置"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "未命名"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "保存"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "无法创建目录"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "成功导出到％s！"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "错误输出: %s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "提交的文件名包含不被允许的字符"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "找不到请求的目录。."
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "选择导入配置"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "有多个配置可用于导入 %s. 请选择其中之一."
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "格式错误的Textbundle：％s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr ""
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "始终将远程更改加载到当前文件"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "覆盖已存在的文件"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "文件 %s 已存在，是否覆盖？"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "打开文件"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "未保存的修改"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "当前文档有未保存的改动，是否先保存？"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "保存文件"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "打开项目文件夹"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "无法加载引文数据库"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "检测到库文件更改，重新加载中…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "将标签 %s 替换为 %s (在%s 个文件中)?"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -640,6 +484,12 @@ msgstr "重命名文档"
 msgid "Delete file"
 msgstr "删除文件"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "退出"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -658,15 +508,15 @@ msgstr "重做"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "剪切"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "复制"
 
@@ -678,8 +528,8 @@ msgstr "复制为HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "粘贴"
 
@@ -691,8 +541,8 @@ msgstr "粘贴为纯文本"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "全选"
 
@@ -934,10 +784,160 @@ msgstr "结束讲话"
 msgid "Bring All to Front"
 msgstr "前置"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "打开项目文件夹"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "加载工作区 %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr ""
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "始终将远程更改加载到当前文件"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "未保存的修改"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "当前文档有未保存的改动，是否先保存？"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "打开文件"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "保存文件"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "覆盖已存在的文件"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "文件 %s 已存在，是否覆盖？"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "在托盘中显示Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "可以更新到最新版本  %s ！"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "无法检查更新：服务器错误（状态代码：%s）"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "无法检查更新：客户端错误（状态代码：%s）"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr "无法检查更新：服务器尝试重定向（状态代码：％s）"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "无法检查更新：无法建立连接"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "无法检查最新版本 %s: %s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "无法检查更新：服务器尚未发送任何数据"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr ""
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr ""
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -951,16 +951,16 @@ msgstr "放弃更改"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "当前文档有未保存的改动，保存还是丢弃？"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "磁盘上的文件发生变化"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s 在磁盘上发生变更"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -969,125 +969,1126 @@ msgstr ""
 "%s 在磁盘上已改变, 但编辑器中还有未保存的变更. 你想保存编辑器中的内容还是从磁"
 "盘重新加载此文件?"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr "你想保留当前编辑器的内容还是从磁盘重新加载此文件?"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "保持编辑器内容"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "从磁盘加载变更"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr "若编辑器中没有未保存的更改，始终从磁盘加载更改"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr ""
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "自动修正"
+
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "智能引号"
+
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "双引号"
+
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "禁用魔术引号"
+
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "单引号"
+
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "文本替换规则"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "匹配整个单词"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "若勾选则自动修正不会替换单词的一部分"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "原始"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "替换为"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "过滤"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "计划"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "关闭"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "跟随系统"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "开启"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "开始"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "结束"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "主题"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "工具栏设置"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
 msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "属性"
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "创建文件副本"
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "复制路径"
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr ""
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "复制文件名"
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr ""
 
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "状态栏"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr ""
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "自定义CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "打开CSS编辑器"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "导入/导出配置文件"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "导入配置编辑器"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "导出配置编辑器"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "导出设置"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "使用内置的Pandoc导出"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "导出时删除文档中的标签"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "内部链接"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "彻底删除内部链接"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "取消内部链接"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "不改变内部链接"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "导出文件目标目录"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "临时目录"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "原文件位置"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "导出时询问目录"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"警告: 临时目录中的文件将定期删除. 选择原文件位置将覆盖已存在的同名文件."
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "自定义导出命令"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "显示名称"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "命令"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"自定义导出时运行的命令. 每个命令都会收到将要导出的文件或项目文件夹作为第一个"
+"参数."
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "新文件名的模式"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "设置新文件名的模式"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "可用变量: %s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "在创建新文件时不要提示文件名"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "外观"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "使用本机窗口外观"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "仅在 Linux 上可用. 在 macOS 和 Windows 上始终启用."
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "启用窗口磨砂效果"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "仅在 macOS 上可用. 使窗口背景不透明."
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "在消息区显示应用"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "使应用在通知区运行"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "缩放行为"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "缩放整个应用界面"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "更改编辑器字体大小"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "附件侧边栏"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "附件侧边栏中展示的文件扩展名"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "iFrame 渲染白名单"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "主机名"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "看门狗轮询"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "判断一个文件写入完成前的等待时间"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "删除条目"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr ""
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "调试模式"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "启用调试模式"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta 版本"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "当有新Beta版本发布时通知我"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "输入模式"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"输入模式决定了与编辑器的交互方式. 建议使用 Normal, 除非你了解 Vim 或 Emacs."
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "文本方向"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown 渲染"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"选中以启用各种 Markdown 实时渲染. 这会隐藏格式字符（例如**文本**）并且会显示"
+"图像而不是其链接."
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "隐藏标题字符"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "渲染强调"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "黑体"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "斜体"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "检查 Markdown 是否存在样式问题"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "表格编辑器"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"表格编辑器提供了交互式界面以简化表格创建和编辑. 它提供常用功能的按钮, 并处理 "
+"Markdown 格式."
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "隐藏所有非当前行"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "字数统计"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "统计字的数量而不是词语的数量（如: 中文）"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "阅读模式"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "算法"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "图像尺寸"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "最大宽度（%s %）"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "最大高度（%s%）"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "其他设置"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "字体大小"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "缩进 (空格数)"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "使用制表符而非空格缩进"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr ""
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "自动完成时建议 emoji 表情"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "显示链接预览"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "括号自动配对"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "显示模式"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "紧凑"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "展开"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "合并"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"紧凑模式将单独显示目录和文件, 点击目录后将在文件列表内显示其内容, 点击文件列"
+"表左上角的箭头以返回目录视图."
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "显示文件信息"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "在文档上方显示文件夹"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Markdown 文档名显示"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "只显示文件名"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "标题（如可用）"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "第一个1级标题（如可用）"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "标题或第一个1级标题（如可用）"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "显示 Markdown 文件扩展名"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "时间显示"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "最后修改时间"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "文件创建时间"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "排序"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "文档排序"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "使用自然排序（10在2之后）"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "使用 ASCII 顺序（10在2之前）"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "引用"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "自动完成功能如何插入引文？"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr ""
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "文件路径"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten ID"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "ID 模式"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "使用 ECMAScript 正则表达式"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "用于生成新ID的模式"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "可用变量: %s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "仅使用文件名链接"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "当链接文件时，添加文件名"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "总是"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "仅在使用 ID 链接时"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "从不"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr ""
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "追踪内部链接时进行全文搜索"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "搜索关键词将匹配方括号 [[ ]] 间的内容."
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "追踪内部链接时自动创建不存在的文件"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr "欲使此设置有效, 必须将目录作为 Zettlr 工作空间打开."
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "文件夹路径"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "片段"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "打开片段编辑器"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "使用 LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "严格度"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "标准"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "严格"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "母语"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "未设置"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr ""
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageTool 提供方"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "自定义服务器"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "自定义服务器地址"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool Premium"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr "如果在此输入凭证, 将忽略 LanguageTool 提供方 设置."
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "语言工具 用户名"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "语言工具 API密钥"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "拼写检查"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "激活"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "语言"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "语言代码"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "选择要启用自动拼写检查的语言。"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "用户字典. 点击以移除单词"
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "字典词条"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "搜索条目 ..."
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "应用语言"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "自动保存"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "保存修改"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "马上"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "短暂延迟后"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "默认图片目录"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr "点击 \"选择目录 ...\" 或在输入框中输入绝对/相对路径."
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "缩放行为"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "尽量避免在新标签页打开文件"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "更新"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "自动检查更新"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s 字"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s 字数"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr ""
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "转到脚注引用"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "无高亮显示"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "打开诊断面板"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "禁用"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "自定义"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "自动检测"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "渲染 mermaid 图 ..."
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "无法渲染图像:"
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "阅读模式 (%s)"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "未找到图像: %s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr ""
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "拼写错误"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "文件 %s 不存在。"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "词数"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "已修改"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "打开…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "在新标签页中打开"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr ""
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "链接"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "图像"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "注释"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "未找到脚注文本"
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "复制方程代码"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr ""
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "复制图片到剪贴板"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "打开图片"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "在 Finder 中打开"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "在资源管理器中打开"
-
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
 msgstr "在文件管理器中打开"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "关闭文档"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "无建议"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "重命名目录"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "加入字典"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "删除目录"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "斜体"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "选择目录..."
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "插入链接"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "导出项目"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "插入项目列表"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "插入数字列表"
+
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
 msgstr ""
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "关闭其他标签"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr ""
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "关闭所有标签"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "取消固定标签"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "固定标签"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "Cmd/Ctrl+点击 以打开链接 "
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1495,320 +2496,318 @@ msgstr "繁体中文（台湾）"
 msgid "Chinese"
 msgstr "中文"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "自动检测"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "禁用"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "自定义"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s 字数"
-
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s 字"
-
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "打开诊断面板"
-
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "拼写错误"
-
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "转到脚注引用"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "属性"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr ""
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "创建文件副本"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "黑体"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "复制路径"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "斜体"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "复制文件名"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "链接"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "在资源管理器中打开"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "图像"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "注释"
-
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "语言代码"
-
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "未找到脚注文本"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "文件 %s 不存在。"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "词数"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "已修改"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "打开…"
-
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "在新标签页中打开"
-
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "无高亮显示"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr ""
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "复制图片到剪贴板"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "打开图片"
-
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
 msgstr "在文件管理器中打开"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "无建议"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "关闭文档"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "加入字典"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "重命名目录"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "斜体"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "删除目录"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "插入链接"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "选择目录..."
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "插入项目列表"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "导出项目"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "插入数字列表"
-
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "关闭其他标签"
+
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "关闭所有标签"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "取消固定标签"
+
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "固定标签"
+
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "日历"
+
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "图表"
+
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
 msgstr ""
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "复制方程代码"
-
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "阅读模式 (%s)"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "未找到图像: %s"
-
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
 msgstr ""
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "渲染 mermaid 图 ..."
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "一月"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "无法渲染图像:"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "二月"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "Cmd/Ctrl+点击 以打开链接 "
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "三月"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "更新管理"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "四月"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "可用更新"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "五月"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "当前版本"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "六月"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "七月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "八月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "九月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "十月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "十一月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "十二月"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "低于月平均"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "超过月平均"
+
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "月平均两倍以上"
+
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr ""
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "有新版本 Zettlr 可供下载。请阅读下方的更新说明。"
-
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "正在下载更新数据"
-
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "无需更新，当前已是最新版本。"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "点击更新"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
+"Some files are selected for export but no longer exist in the directory."
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "全局"
+
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
+msgid "No results for \"%s\""
 msgstr ""
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "开始更新中"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "搜索"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "编辑"
+
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "高级"
+
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "计数"
-
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "重置"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "过滤标签…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "选择目录 ..."
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr ""
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "选择文件 ..."
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr ""
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "添加"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr ""
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "Actions"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "删除"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr ""
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "图像尺寸"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1825,10 +2824,6 @@ msgstr ""
 #: source/tmp/win-paste-image/App.vue.ts:62
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
-msgstr ""
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
 msgstr ""
 
 #: source/tmp/win-about/App.vue.ts:41
@@ -1890,44 +2885,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr还采用了这些项目："
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"你可以修改Zettlr的样式以自定义自己的样式。<strong>注意: 该文件会覆盖所有的CSS"
-"指令！ 不要随意改动几何参数，应用程序可能会报错！</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "片段重命名"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "片段可以让您可以使用变量定义可重复使用的文本片段"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr ""
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "保存中…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "保存失败"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr ""
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "自定义CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "片段"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "已保存！"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1949,39 +2928,76 @@ msgstr ""
 msgid "Edit the default settings for imports or exports here."
 msgstr "编辑导入或导出的默认设置"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "已保存！"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "片段重命名"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "片段可以让您可以使用变量定义可重复使用的文本片段"
-
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
 msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "字数"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr ""
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "字符"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"你可以修改Zettlr的样式以自定义自己的样式。<strong>注意: 该文件会覆盖所有的CSS"
+"指令！ 不要随意改动几何参数，应用程序可能会报错！</strong>"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "未打开任何文档"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "保存失败"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "开始"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "计数"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "过滤标签…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr ""
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr ""
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2007,76 +3023,114 @@ msgstr "音效"
 msgid "Volume"
 msgstr "音量"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr ""
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "上月的累积字数"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "相关文件"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "日平均"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "相关文件不存在"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "今日字数"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "这种联系基于双向链接"
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 你今天的状态真不错！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "此联系基于出站链接。"
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 你离日平均水平越来越近了！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "这种联系基于反向链接。"
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼继续写作超过你的日平均字数。"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "更多数据"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "此联系基于 %s 共享标签: %s"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "其他文件"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "打开目录"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "其他文件不存在"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
+msgid "%s selected"
 msgstr ""
 
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "参考文献"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "文件中不存在参考文献"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
+msgid "%s selections"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "名称"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr ""
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "标签云"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr ""
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr ""
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "正在导出…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "导出"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "命令"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr ""
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2086,8 +3140,8 @@ msgstr "目录"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "文件"
 
@@ -2101,10 +3155,26 @@ msgstr "字符"
 msgid "Words"
 msgstr "字数"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr ""
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "工作区"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "没有打开文件或文件夹"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "没有结果"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "未选中任何目录"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "空目录"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2134,15 +3204,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr ""
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "重置"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2203,13 +3264,6 @@ msgstr ""
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "日历"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2419,130 +3473,10 @@ msgstr ""
 msgid "Set writing target…"
 msgstr "设置写作目标…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "没有结果"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "未选中任何目录"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "空目录"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "工作区"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "没有打开文件或文件夹"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "上月的累积字数"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "日平均"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "今日字数"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 你今天的状态真不错！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 你离日平均水平越来越近了！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼继续写作超过你的日平均字数。"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "更多数据"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
+msgid "Table size: %s &times; %s"
 msgstr ""
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr ""
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr ""
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "正在导出…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "导出"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "命令"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2564,11 +3498,6 @@ msgstr "只以下搜索目录"
 msgid "Choose directory…"
 msgstr ""
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "搜索"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "清空搜索"
@@ -2582,1058 +3511,135 @@ msgstr "切换搜索结果"
 msgid "%s matches across %s files"
 msgstr ""
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "名称"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "标签云"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "字数"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "字符"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "未打开任何文档"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "相关文件"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "相关文件不存在"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "这种联系基于双向链接"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "此联系基于出站链接。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "这种联系基于反向链接。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "此联系基于 %s 共享标签: %s"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "其他文件"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "打开目录"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "其他文件不存在"
+
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
 msgstr ""
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "添加"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "Actions"
-
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "删除"
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "选择目录 ..."
-
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "选择文件 ..."
-
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
 msgstr ""
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr ""
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "参考文献"
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr ""
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "文件中不存在参考文献"
 
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr ""
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "全局"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
+msgid "circa %s words"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "外观"
-
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "编辑"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "更新管理"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "拼写检查"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "可用更新"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "自动修正"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "当前版本"
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "引用"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "有新版本 Zettlr 可供下载。请阅读下方的更新说明。"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "正在下载更新数据"
+
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "无需更新，当前已是最新版本。"
+
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "点击更新"
+
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr ""
-
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "高级"
-
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
+msgid "Last checked: %s"
 msgstr ""
 
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr ""
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "一月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "二月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "三月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "四月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "五月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "六月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "七月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "八月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "九月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "十月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "十一月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "十二月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "低于月平均"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "超过月平均"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "月平均两倍以上"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "图表"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr ""
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten ID"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "ID 模式"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "使用 ECMAScript 正则表达式"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "用于生成新ID的模式"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "可用变量: %s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "内部链接"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "仅使用文件名链接"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "当链接文件时，添加文件名"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "总是"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "仅在使用 ID 链接时"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "从不"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr ""
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "追踪内部链接时进行全文搜索"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "搜索关键词将匹配方括号 [[ ]] 间的内容."
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "追踪内部链接时自动创建不存在的文件"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr "欲使此设置有效, 必须将目录作为 Zettlr 工作空间打开."
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "文件夹路径"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "智能引号"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "双引号"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "禁用魔术引号"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "单引号"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "文本替换规则"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "匹配整个单词"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "若勾选则自动修正不会替换单词的一部分"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "原始"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "替换为"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "过滤"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "输入模式"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"输入模式决定了与编辑器的交互方式. 建议使用 Normal, 除非你了解 Vim 或 Emacs."
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "文本方向"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown 渲染"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"选中以启用各种 Markdown 实时渲染. 这会隐藏格式字符（例如**文本**）并且会显示"
-"图像而不是其链接."
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "隐藏标题字符"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "渲染强调"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "检查 Markdown 是否存在样式问题"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "表格编辑器"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"表格编辑器提供了交互式界面以简化表格创建和编辑. 它提供常用功能的按钮, 并处理 "
-"Markdown 格式."
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "隐藏所有非当前行"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "字数统计"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "统计字的数量而不是词语的数量（如: 中文）"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "阅读模式"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "算法"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "最大宽度（%s %）"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "最大高度（%s%）"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "其他设置"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "字体大小"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "缩进 (空格数)"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "使用制表符而非空格缩进"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr ""
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "自动完成时建议 emoji 表情"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "显示链接预览"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "括号自动配对"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "计划"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "关闭"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "跟随系统"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "开启"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "结束"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "主题"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "工具栏设置"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "状态栏"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr ""
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "打开CSS编辑器"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "使用 LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "严格度"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "标准"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "严格"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "母语"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "未设置"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr ""
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageTool 提供方"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "自定义服务器"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "自定义服务器地址"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool Premium"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr "如果在此输入凭证, 将忽略 LanguageTool 提供方 设置."
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "语言工具 用户名"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "语言工具 API密钥"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "激活"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "语言"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "选择要启用自动拼写检查的语言。"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "用户字典. 点击以移除单词"
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "字典词条"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "搜索条目 ..."
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "显示模式"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "紧凑"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "展开"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "合并"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"紧凑模式将单独显示目录和文件, 点击目录后将在文件列表内显示其内容, 点击文件列"
-"表左上角的箭头以返回目录视图."
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "显示文件信息"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "在文档上方显示文件夹"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Markdown 文档名显示"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "只显示文件名"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "标题（如可用）"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "第一个1级标题（如可用）"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "标题或第一个1级标题（如可用）"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "显示 Markdown 文件扩展名"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "时间显示"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "最后修改时间"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "文件创建时间"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "排序"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "文档排序"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "使用自然排序（10在2之后）"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "使用 ASCII 顺序（10在2之前）"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "导入/导出配置文件"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "导入配置编辑器"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "导出配置编辑器"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "导出设置"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "使用内置的Pandoc导出"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "导出时删除文档中的标签"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "彻底删除内部链接"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "取消内部链接"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "不改变内部链接"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "导出文件目标目录"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "临时目录"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "原文件位置"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "导出时询问目录"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"警告: 临时目录中的文件将定期删除. 选择原文件位置将覆盖已存在的同名文件."
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "自定义导出命令"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "显示名称"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "命令"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"自定义导出时运行的命令. 每个命令都会收到将要导出的文件或项目文件夹作为第一个"
-"参数."
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "新文件名的模式"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "设置新文件名的模式"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "可用变量: %s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "在创建新文件时不要提示文件名"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "使用本机窗口外观"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "仅在 Linux 上可用. 在 macOS 和 Windows 上始终启用."
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "启用窗口磨砂效果"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "仅在 macOS 上可用. 使窗口背景不透明."
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "在消息区显示应用"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "使应用在通知区运行"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "缩放行为"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "缩放整个应用界面"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "更改编辑器字体大小"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "附件侧边栏"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "附件侧边栏中展示的文件扩展名"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "iFrame 渲染白名单"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "主机名"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "看门狗轮询"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "判断一个文件写入完成前的等待时间"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "删除条目"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr ""
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "调试模式"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "启用调试模式"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta 版本"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "当有新Beta版本发布时通知我"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "打开片段编辑器"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "应用语言"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "自动保存"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "保存修改"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "马上"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "短暂延迟后"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "默认图片目录"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr "点击 \"选择目录 ...\" 或在输入框中输入绝对/相对路径."
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "缩放行为"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "尽量避免在新标签页打开文件"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "更新"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "自动检查更新"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "自动完成功能如何插入引文？"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr ""
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "文件路径"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr ""
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "开始更新中"
 
 #~ msgid "Open Link"
 #~ msgstr "打开链接"

--- a/static/lang/zh-TW.po
+++ b/static/lang/zh-TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zettlr 2.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
-"POT-Creation-Date: 2025-02-28 14:52+0000\n"
+"POT-Creation-Date: 2025-06-21 06:52+0000\n"
 "PO-Revision-Date: 2025-03-04 03:36+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
 "Language-Team: \n"
@@ -17,6 +17,20 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
+
+#: source/app/service-providers/citeproc/index.ts:258
+#: source/app/service-providers/citeproc/index.ts:466
+msgid "The citation database could not be loaded"
+msgstr "無法載入引文資料庫"
+
+#: source/app/service-providers/citeproc/index.ts:453
+msgid "Changes to the library file detected. Reloading …"
+msgstr "偵測到資源庫檔案的變更，正在重新載入…"
+
+#: source/app/service-providers/workspaces/index.ts:162
+#, javascript-format
+msgid "Loading workspace %s"
+msgstr "正在載入工作區 %s"
 
 #: source/app/service-providers/config/index.ts:498
 msgid "Changing this option requires a restart to take effect."
@@ -68,140 +82,6 @@ msgstr "選項 %s 至少要有 %s 字元。"
 msgid "Option %s is required."
 msgstr "選項 %s 是必需的。"
 
-#: source/app/service-providers/tray/index.ts:160
-msgid "Show Zettlr"
-msgstr "顯示 Zettlr"
-
-#: source/app/service-providers/tray/index.ts:166
-#: source/app/service-providers/menu/menu.win32.ts:300
-#: source/app/service-providers/menu/menu.darwin.ts:104
-msgid "Quit"
-msgstr "結束"
-
-#: source/app/service-providers/tray/index.ts:173
-msgid "Zettlr"
-msgstr "Zettlr"
-
-#: source/app/service-providers/updates/index.ts:284
-msgid "Cannot check for update"
-msgstr "無法檢查更新"
-
-#: source/app/service-providers/updates/index.ts:285
-#, javascript-format
-msgid "There was an error while checking for updates. %s: %s"
-msgstr "檢查更新時發生錯誤。%s: %s"
-
-#: source/app/service-providers/updates/index.ts:323
-#: source/tmp/win-main/App.vue.ts:405
-msgid "Update available"
-msgstr "有可用的更新"
-
-#: source/app/service-providers/updates/index.ts:324
-#, javascript-format
-msgid "An update to version %s is available!"
-msgstr "版本 %s 的更新已經推出！"
-
-#: source/app/service-providers/updates/index.ts:325
-msgid ""
-"Please update at your earliest convenience. You can open the updater now, or "
-"update later."
-msgstr "請在方便時儘早更新，你可以現在開啟更新工具，或是稍後更新。"
-
-#: source/app/service-providers/updates/index.ts:327
-msgid "Open updater"
-msgstr "開啟更新工具"
-
-#: source/app/service-providers/updates/index.ts:328
-msgid "Not now"
-msgstr "稍後"
-
-#: source/app/service-providers/updates/index.ts:356
-#, javascript-format
-msgid "Could not check for updates: Server Error (Status code: %s)"
-msgstr "無法檢查更新：伺服器錯誤（狀態碼：%s）"
-
-#: source/app/service-providers/updates/index.ts:359
-#, javascript-format
-msgid "Could not check for updates: Client Error (Status code: %s)"
-msgstr "無法檢查更新：客戶端錯誤（狀態碼：%s）"
-
-#: source/app/service-providers/updates/index.ts:362
-#, javascript-format
-msgid ""
-"Could not check for updates: The server tried to redirect (Status code: %s)"
-msgstr "無法檢查更新：伺服器嘗試重定向（狀態碼：%s）"
-
-#. getaddrinfo has reported that the host has not been found.
-#. This normally only happens if the networking interface is
-#. offline. In this case, no need to inform the user every hour.
-#: source/app/service-providers/updates/index.ts:368
-msgid "Could not check for updates: Could not establish connection"
-msgstr "無法檢查更新：無法建立連線"
-
-#. Something else has occurred. GotError objects have a name property.
-#: source/app/service-providers/updates/index.ts:372
-#, javascript-format
-msgid "Could not check for updates. %s: %s"
-msgstr "無法檢查更新。%s：%s"
-
-#: source/app/service-providers/updates/index.ts:387
-msgid "Could not check for updates: Server hasn't sent any data"
-msgstr "無法檢查更新：伺服器沒有傳送任何資料"
-
-#: source/app/service-providers/updates/index.ts:464
-msgid "The SHA256 checksums file seems to be missing for this release."
-msgstr "這個發布版本似乎沒有 SHA256 雜湊值檔案。"
-
-#: source/app/service-providers/updates/index.ts:486
-#, javascript-format
-msgid "Cannot retrieve SHA256 checksums: %s"
-msgstr "無法取得 SAH256 雜湊值：%s"
-
-#: source/app/service-providers/updates/index.ts:527
-msgid "Could not accept data for application update: Write stream is gone."
-msgstr "無法接收程式更新的資料：寫入資料流消失。"
-
-#: source/app/service-providers/updates/index.ts:582
-msgid ""
-"Could not verify the integrity of the downloaded update. Please retry or "
-"update manually."
-msgstr "無法驗證已下載更新的完整性。請重試或是手動更新。"
-
-#: source/app/service-providers/updates/index.ts:594
-msgid ""
-"The downloaded file has a different checksum than the server reported. "
-"Please retry or update manually."
-msgstr "下載的檔案雜湊值與伺服器回傳的不相同。請重試或是手動更新。"
-
-#: source/app/service-providers/updates/index.ts:612
-#, javascript-format
-msgid "Could not start update. Please retry or update manually. Error was: %s"
-msgstr "無法開始更新。請重試或是手動更新。錯誤為：%s"
-
-#: source/app/service-providers/commands/language-tool.ts:194
-msgid "Document too long"
-msgstr "文件過長"
-
-#: source/app/service-providers/commands/language-tool.ts:199
-msgid "offline"
-msgstr "離線"
-
-#: source/app/service-providers/commands/file-new.ts:167
-#: source/app/service-providers/commands/file-duplicate.ts:39
-#: source/app/service-providers/commands/file-duplicate.ts:56
-msgid "Could not create file"
-msgstr "無法建立檔案"
-
-#. Better error message
-#: source/app/service-providers/commands/open-attachment.ts:119
-#, javascript-format
-msgid "The reference with key %s does not appear to have attachments."
-msgstr "%s 的引用似乎沒有附件。"
-
-#: source/app/service-providers/commands/open-attachment.ts:124
-msgid "Could not open attachment. Is Zotero running?"
-msgstr "無法開啟附件。Zotero 是否正在執行？"
-
 #: source/app/service-providers/commands/file-rename.ts:129
 #, javascript-format
 msgid "Update %s internal links to file %s?"
@@ -219,24 +99,98 @@ msgstr "是"
 msgid "No"
 msgstr "否"
 
-#: source/app/service-providers/commands/rename-tag.ts:44
-#, javascript-format
-msgid "Replace tag \"%s\" with \"%s\" across %s files?"
-msgstr "在 %s 個檔案中將標籤 \"%s\" 取代為 \"%s\"？"
+#: source/app/service-providers/commands/file-delete.ts:36
+#: source/app/service-providers/commands/dir-delete.ts:35
+#: source/app/service-providers/commands/dir-project-export.ts:93
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
+#: source/app/service-providers/windows/dialog/prompt.ts:32
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
+#: source/tmp/win-error/App.vue.ts:43
+msgid "Ok"
+msgstr "OK"
 
 #. 1: Omit all changes
-#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/commands/file-delete.ts:37
 #: source/app/service-providers/commands/dir-delete.ts:36
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/commands/rename-tag.ts:47
 #: source/app/service-providers/menu/menu.win32.ts:677
 #: source/app/service-providers/menu/menu.darwin.ts:703
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:36
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:34
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:32
 #: source/app/service-providers/documents/index.ts:386
 #: source/tmp/win-paste-image/App.vue.ts:67
 msgid "Cancel"
 msgstr "取消"
+
+#: source/app/service-providers/commands/file-delete.ts:41
+#: source/app/service-providers/commands/dir-delete.ts:40
+msgid "Really delete?"
+msgstr "確定要刪除嗎？"
+
+#: source/app/service-providers/commands/file-delete.ts:42
+#: source/app/service-providers/commands/dir-delete.ts:41
+#, javascript-format
+msgid "Do you really want to remove %s?"
+msgstr "您確定要移除 %s 嗎？"
+
+#. Better error message
+#: source/app/service-providers/commands/open-attachment.ts:119
+#, javascript-format
+msgid "The reference with key %s does not appear to have attachments."
+msgstr "%s 的引用似乎沒有附件。"
+
+#: source/app/service-providers/commands/open-attachment.ts:124
+msgid "Could not open attachment. Is Zotero running?"
+msgstr "無法開啟附件。Zotero 是否正在執行？"
+
+#: source/app/service-providers/commands/importer/import-textbundle.ts:63
+#: source/app/service-providers/commands/importer/import-textbundle.ts:69
+#, javascript-format
+msgid "Malformed Textbundle: %s"
+msgstr "格式錯誤的 Textbundle：%s"
+
+#: source/app/service-providers/commands/importer/index.ts:92
+#: source/app/service-providers/commands/importer/index.ts:93
+msgid "Select import profile"
+msgstr "選擇匯入設定檔"
+
+#: source/app/service-providers/commands/importer/index.ts:94
+#, javascript-format
+msgid "There are multiple profiles that can import %s. Please choose one."
+msgstr "有多個設定檔可以匯入 %s，請選擇其中一個設定檔。"
+
+#: source/app/service-providers/commands/dir-project-export.ts:85
+msgid "Cannot export project"
+msgstr "無法匯出專案"
+
+#: source/app/service-providers/commands/dir-project-export.ts:86
+msgid ""
+"There are no files selected for export. Please select files to be included "
+"in the project settings."
+msgstr "沒有選擇要匯出的檔案。請在專案設定中選擇要包含的檔案。"
+
+#: source/app/service-providers/commands/dir-project-export.ts:91
+msgid "Project File Mismatch"
+msgstr "專案檔案不符"
+
+#: source/app/service-providers/commands/dir-project-export.ts:92
+msgid ""
+"One or more files specified in the project settings have not been found. "
+"They may have moved or been deleted. Please verify that all files that you "
+"would like to export are included."
+msgstr ""
+"找不到專案設定中指定的某些檔案，這些檔案可能已經被移動或刪除。請確認您想要匯"
+"出的所有檔案都已包含在內。"
+
+#: source/app/service-providers/commands/dir-project-export.ts:168
+#, javascript-format
+msgid "Project \"%s\" successfully exported. Click to show."
+msgstr "專案 \"%s\" 已成功匯出。點選以顯示。"
+
+#: source/app/service-providers/commands/dir-project-export.ts:169
+msgid "Project Export"
+msgstr "專案匯出"
 
 #: source/app/service-providers/commands/import.ts:34
 msgid "Import directory"
@@ -290,48 +244,6 @@ msgstr "以下 %s 個檔案無法匯入，因為其檔案類型未知：%s"
 msgid "Import failed"
 msgstr "匯入失敗"
 
-#: source/app/service-providers/commands/dir-project-export.ts:85
-msgid "Cannot export project"
-msgstr "無法匯出專案"
-
-#: source/app/service-providers/commands/dir-project-export.ts:86
-msgid ""
-"There are no files selected for export. Please select files to be included "
-"in the project settings."
-msgstr "沒有選擇要匯出的檔案。請在專案設定中選擇要包含的檔案。"
-
-#: source/app/service-providers/commands/dir-project-export.ts:91
-msgid "Project File Mismatch"
-msgstr "專案檔案不符"
-
-#: source/app/service-providers/commands/dir-project-export.ts:92
-msgid ""
-"One or more files specified in the project settings have not been found. "
-"They may have moved or been deleted. Please verify that all files that you "
-"would like to export are included."
-msgstr ""
-"找不到專案設定中指定的某些檔案，這些檔案可能已經被移動或刪除。請確認您想要匯"
-"出的所有檔案都已包含在內。"
-
-#: source/app/service-providers/commands/dir-project-export.ts:93
-#: source/app/service-providers/commands/file-delete.ts:36
-#: source/app/service-providers/commands/dir-delete.ts:35
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:37
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:33
-#: source/app/service-providers/windows/dialog/prompt.ts:32
-#: source/tmp/win-error/App.vue.ts:43
-msgid "Ok"
-msgstr "OK"
-
-#: source/app/service-providers/commands/dir-project-export.ts:168
-#, javascript-format
-msgid "Project \"%s\" successfully exported. Click to show."
-msgstr "專案 \"%s\" 已成功匯出。點選以顯示。"
-
-#: source/app/service-providers/commands/dir-project-export.ts:169
-msgid "Project Export"
-msgstr "專案匯出"
-
 #: source/app/service-providers/commands/request-move.ts:53
 msgid "Cannot move directory"
 msgstr "無法移動目錄"
@@ -349,28 +261,49 @@ msgstr "無法移動目錄或檔案"
 msgid "The file/directory %s already exists in target."
 msgstr "檔案/目錄 %s 已存在於目標位置。"
 
-#. Else standard val for new dirs.
-#: source/app/service-providers/commands/dir-new.ts:31
-#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
-msgid "Untitled"
-msgstr "未命名"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
+msgid "The provided name did not contain any allowed letters."
+msgstr "提供的名稱不包含任何允許的字母。"
 
-#: source/app/service-providers/commands/dir-new.ts:37
-#: source/app/service-providers/commands/dir-new.ts:38
-#: source/app/service-providers/commands/dir-new.ts:50
-msgid "Could not create directory"
-msgstr "無法建立目錄"
+#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
+msgid "The requested directory was not found."
+msgstr "找不到所要求的目錄。"
 
-#: source/app/service-providers/commands/file-delete.ts:41
-#: source/app/service-providers/commands/dir-delete.ts:40
-msgid "Really delete?"
-msgstr "確定要刪除嗎？"
+#: source/app/service-providers/commands/export.ts:55
+#: source/app/service-providers/commands/export.ts:157
+msgid "Export failed"
+msgstr "匯出失敗"
 
-#: source/app/service-providers/commands/file-delete.ts:42
-#: source/app/service-providers/commands/dir-delete.ts:41
+#: source/app/service-providers/commands/export.ts:56
 #, javascript-format
-msgid "Do you really want to remove %s?"
-msgstr "您確定要移除 %s 嗎？"
+msgid "An error occurred during export: %s"
+msgstr "匯出時發生錯誤：%s"
+
+#: source/app/service-providers/commands/export.ts:114
+msgid "Choose export destination"
+msgstr "選擇匯出目的地"
+
+#. primary: true // It's a primary button
+#: source/app/service-providers/commands/export.ts:114
+#: source/app/service-providers/menu/menu.win32.ts:161
+#: source/app/service-providers/menu/menu.darwin.ts:196
+#: source/tmp/win-paste-image/App.vue.ts:66
+#: source/tmp/win-assets/SnippetsTab.vue.ts:28
+#: source/tmp/win-assets/DefaultsTab.vue.ts:61
+#: source/tmp/win-assets/CustomCSS.vue.ts:24
+#: source/tmp/win-tag-manager/App.vue.ts:88
+msgid "Save"
+msgstr "儲存"
+
+#: source/app/service-providers/commands/export.ts:145
+#, javascript-format
+msgid "Exporting to %s"
+msgstr "正在匯出到 %s"
+
+#: source/app/service-providers/commands/export.ts:158
+#, javascript-format
+msgid "An error occurred on export: %s"
+msgstr "匯出時發生錯誤：%s"
 
 #: source/app/service-providers/commands/root-open.ts:59
 msgid "Markdown Files"
@@ -395,11 +328,13 @@ msgstr "無法開啟工作區"
 msgid "Cannot open workspace \"%s\"."
 msgstr "無法開啟工作區「%s」。"
 
-#. We need to generate our own filename. First, attempt to just use 'copy of'
-#: source/app/service-providers/commands/file-duplicate.ts:68
-#, javascript-format
-msgid "Copy of %s"
-msgstr "副本：%s"
+#: source/app/service-providers/commands/language-tool.ts:194
+msgid "Document too long"
+msgstr "文件過長"
+
+#: source/app/service-providers/commands/language-tool.ts:199
+msgid "offline"
+msgstr "離線"
 
 #: source/app/service-providers/commands/import-lang-file.ts:60
 #, javascript-format
@@ -412,125 +347,34 @@ msgstr "語言包 %s 已匯入"
 msgid "Could not import language file %s!"
 msgstr "無法匯入語言包 %s！"
 
-#: source/app/service-providers/commands/export.ts:55
-#: source/app/service-providers/commands/export.ts:157
-msgid "Export failed"
-msgstr "匯出失敗"
+#: source/app/service-providers/commands/file-duplicate.ts:39
+#: source/app/service-providers/commands/file-duplicate.ts:56
+#: source/app/service-providers/commands/file-new.ts:167
+msgid "Could not create file"
+msgstr "無法建立檔案"
 
-#: source/app/service-providers/commands/export.ts:56
+#. We need to generate our own filename. First, attempt to just use 'copy of'
+#: source/app/service-providers/commands/file-duplicate.ts:68
 #, javascript-format
-msgid "An error occurred during export: %s"
-msgstr "匯出時發生錯誤：%s"
+msgid "Copy of %s"
+msgstr "副本：%s"
 
-#: source/app/service-providers/commands/export.ts:114
-msgid "Choose export destination"
-msgstr "選擇匯出目的地"
+#. Else standard val for new dirs.
+#: source/app/service-providers/commands/dir-new.ts:31
+#: source/tmp/win-main/file-manager/TreeItem.vue.ts:258
+msgid "Untitled"
+msgstr "未命名"
 
-#. primary: true // It's a primary button
-#: source/app/service-providers/commands/export.ts:114
-#: source/app/service-providers/menu/menu.win32.ts:161
-#: source/app/service-providers/menu/menu.darwin.ts:196
-#: source/tmp/win-tag-manager/App.vue.ts:88
-#: source/tmp/win-paste-image/App.vue.ts:66
-#: source/tmp/win-assets/CustomCSS.vue.ts:24
-#: source/tmp/win-assets/DefaultsTab.vue.ts:61
-#: source/tmp/win-assets/SnippetsTab.vue.ts:28
-msgid "Save"
-msgstr "儲存"
+#: source/app/service-providers/commands/dir-new.ts:37
+#: source/app/service-providers/commands/dir-new.ts:38
+#: source/app/service-providers/commands/dir-new.ts:50
+msgid "Could not create directory"
+msgstr "無法建立目錄"
 
-#: source/app/service-providers/commands/export.ts:145
+#: source/app/service-providers/commands/rename-tag.ts:44
 #, javascript-format
-msgid "Exporting to %s"
-msgstr "正在匯出到 %s"
-
-#: source/app/service-providers/commands/export.ts:158
-#, javascript-format
-msgid "An error occurred on export: %s"
-msgstr "匯出時發生錯誤：%s"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:103
-msgid "The provided name did not contain any allowed letters."
-msgstr "提供的名稱不包含任何允許的字母。"
-
-#: source/app/service-providers/commands/save-image-from-clipboard.ts:124
-msgid "The requested directory was not found."
-msgstr "找不到所要求的目錄。"
-
-#: source/app/service-providers/commands/importer/index.ts:92
-#: source/app/service-providers/commands/importer/index.ts:93
-msgid "Select import profile"
-msgstr "選擇匯入設定檔"
-
-#: source/app/service-providers/commands/importer/index.ts:94
-#, javascript-format
-msgid "There are multiple profiles that can import %s. Please choose one."
-msgstr "有多個設定檔可以匯入 %s，請選擇其中一個設定檔。"
-
-#: source/app/service-providers/commands/importer/import-textbundle.ts:63
-#: source/app/service-providers/commands/importer/import-textbundle.ts:69
-#, javascript-format
-msgid "Malformed Textbundle: %s"
-msgstr "格式錯誤的 Textbundle：%s"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
-msgid "Replace file"
-msgstr "取代檔案"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
-#, javascript-format
-msgid ""
-"File %s has been modified remotely. Replace the loaded version with the "
-"newer one from disk?"
-msgstr "檔案 %s 已被遠端修改。要用磁碟上的新版本取代已載入的版本嗎？"
-
-#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
-#: source/win-preferences/schema/general.ts:78
-msgid "Always load remote changes to the current file"
-msgstr "總是將遠端的修改載入到目前檔案"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
-msgid "Overwrite existing file"
-msgstr "覆蓋現有檔案"
-
-#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
-#, javascript-format
-msgid "The file %s already exists in this directory. Overwrite?"
-msgstr "檔案 %s 已經存在，要覆蓋嗎？"
-
-#: source/app/service-providers/windows/dialog/ask-file.ts:54
-msgid "Open file"
-msgstr "開啟檔案"
-
-#. If the user cancels, do not omit (the default) but actually cancel
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
-#: source/app/service-providers/documents/index.ts:390
-#: source/tmp/win-tag-manager/App.vue.ts:94
-#: source/tmp/win-assets/CustomCSS.vue.ts:34
-#: source/tmp/win-assets/DefaultsTab.vue.ts:113
-#: source/tmp/win-assets/SnippetsTab.vue.ts:47
-msgid "Unsaved changes"
-msgstr "尚未儲存的修改"
-
-#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
-msgid "There are unsaved changes. Do you want to save them first?"
-msgstr "有些尚未儲存的修改。您要先儲存它們嗎？"
-
-#: source/app/service-providers/windows/dialog/save-dialog.ts:58
-msgid "Save file"
-msgstr "存檔"
-
-#: source/app/service-providers/windows/index.ts:247
-msgid "Open project folder"
-msgstr "開啟專案資料夾"
-
-#: source/app/service-providers/citeproc/index.ts:258
-#: source/app/service-providers/citeproc/index.ts:466
-msgid "The citation database could not be loaded"
-msgstr "無法載入引文資料庫"
-
-#: source/app/service-providers/citeproc/index.ts:453
-msgid "Changes to the library file detected. Reloading …"
-msgstr "偵測到資源庫檔案的變更，正在重新載入…"
+msgid "Replace tag \"%s\" with \"%s\" across %s files?"
+msgstr "在 %s 個檔案中將標籤 \"%s\" 取代為 \"%s\"？"
 
 #: source/app/service-providers/menu/menu.win32.ts:44
 #: source/app/service-providers/menu/menu.win32.ts:56
@@ -642,6 +486,12 @@ msgstr "重新命名檔案"
 msgid "Delete file"
 msgstr "刪除檔案"
 
+#: source/app/service-providers/menu/menu.win32.ts:300
+#: source/app/service-providers/menu/menu.darwin.ts:104
+#: source/app/service-providers/tray/index.ts:166
+msgid "Quit"
+msgstr "結束"
+
 #: source/app/service-providers/menu/menu.win32.ts:310
 #: source/app/service-providers/menu/menu.darwin.ts:308
 #: source/common/modules/markdown-editor/tooltips/footnotes.ts:109
@@ -660,15 +510,15 @@ msgstr "重做"
 
 #: source/app/service-providers/menu/menu.win32.ts:330
 #: source/app/service-providers/menu/menu.darwin.ts:328
-#: source/common/modules/window-register/register-default-context.ts:76
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:210
+#: source/common/modules/window-register/register-default-context.ts:76
 msgid "Cut"
 msgstr "剪下"
 
 #: source/app/service-providers/menu/menu.win32.ts:336
 #: source/app/service-providers/menu/menu.darwin.ts:334
-#: source/common/modules/window-register/register-default-context.ts:83
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:217
+#: source/common/modules/window-register/register-default-context.ts:83
 msgid "Copy"
 msgstr "複製"
 
@@ -680,8 +530,8 @@ msgstr "複製為 HTML"
 
 #: source/app/service-providers/menu/menu.win32.ts:350
 #: source/app/service-providers/menu/menu.darwin.ts:348
-#: source/common/modules/window-register/register-default-context.ts:90
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:231
+#: source/common/modules/window-register/register-default-context.ts:90
 msgid "Paste"
 msgstr "貼上"
 
@@ -693,8 +543,8 @@ msgstr "貼上（不含樣式）"
 
 #: source/app/service-providers/menu/menu.win32.ts:364
 #: source/app/service-providers/menu/menu.darwin.ts:362
-#: source/common/modules/window-register/register-default-context.ts:100
 #: source/common/modules/markdown-editor/context-menu/default-menu.ts:248
+#: source/common/modules/window-register/register-default-context.ts:100
 msgid "Select all"
 msgstr "全選"
 
@@ -936,10 +786,160 @@ msgstr "停止語音"
 msgid "Bring All to Front"
 msgstr "全部移到最前方"
 
-#: source/app/service-providers/workspaces/index.ts:162
+#: source/app/service-providers/windows/index.ts:247
+msgid "Open project folder"
+msgstr "開啟專案資料夾"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:31
+msgid "Replace file"
+msgstr "取代檔案"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:32
 #, javascript-format
-msgid "Loading workspace %s"
-msgstr "正在載入工作區 %s"
+msgid ""
+"File %s has been modified remotely. Replace the loaded version with the "
+"newer one from disk?"
+msgstr "檔案 %s 已被遠端修改。要用磁碟上的新版本取代已載入的版本嗎？"
+
+#: source/app/service-providers/windows/dialog/should-replace-file.ts:33
+#: source/win-preferences/schema/general.ts:78
+msgid "Always load remote changes to the current file"
+msgstr "總是將遠端的修改載入到目前檔案"
+
+#. If the user cancels, do not omit (the default) but actually cancel
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:38
+#: source/app/service-providers/documents/index.ts:390
+#: source/tmp/win-assets/SnippetsTab.vue.ts:47
+#: source/tmp/win-assets/DefaultsTab.vue.ts:113
+#: source/tmp/win-assets/CustomCSS.vue.ts:34
+#: source/tmp/win-tag-manager/App.vue.ts:94
+msgid "Unsaved changes"
+msgstr "尚未儲存的修改"
+
+#: source/app/service-providers/windows/dialog/ask-save-changes.ts:39
+msgid "There are unsaved changes. Do you want to save them first?"
+msgstr "有些尚未儲存的修改。您要先儲存它們嗎？"
+
+#: source/app/service-providers/windows/dialog/ask-file.ts:54
+msgid "Open file"
+msgstr "開啟檔案"
+
+#: source/app/service-providers/windows/dialog/save-dialog.ts:58
+msgid "Save file"
+msgstr "存檔"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:29
+msgid "Overwrite existing file"
+msgstr "覆蓋現有檔案"
+
+#: source/app/service-providers/windows/dialog/should-overwrite-file.ts:30
+#, javascript-format
+msgid "The file %s already exists in this directory. Overwrite?"
+msgstr "檔案 %s 已經存在，要覆蓋嗎？"
+
+#: source/app/service-providers/tray/index.ts:160
+msgid "Show Zettlr"
+msgstr "顯示 Zettlr"
+
+#: source/app/service-providers/tray/index.ts:173
+msgid "Zettlr"
+msgstr "Zettlr"
+
+#: source/app/service-providers/updates/index.ts:284
+msgid "Cannot check for update"
+msgstr "無法檢查更新"
+
+#: source/app/service-providers/updates/index.ts:285
+#, javascript-format
+msgid "There was an error while checking for updates. %s: %s"
+msgstr "檢查更新時發生錯誤。%s: %s"
+
+#: source/app/service-providers/updates/index.ts:323
+#: source/tmp/win-main/App.vue.ts:405
+msgid "Update available"
+msgstr "有可用的更新"
+
+#: source/app/service-providers/updates/index.ts:324
+#, javascript-format
+msgid "An update to version %s is available!"
+msgstr "版本 %s 的更新已經推出！"
+
+#: source/app/service-providers/updates/index.ts:325
+msgid ""
+"Please update at your earliest convenience. You can open the updater now, or "
+"update later."
+msgstr "請在方便時儘早更新，你可以現在開啟更新工具，或是稍後更新。"
+
+#: source/app/service-providers/updates/index.ts:327
+msgid "Open updater"
+msgstr "開啟更新工具"
+
+#: source/app/service-providers/updates/index.ts:328
+msgid "Not now"
+msgstr "稍後"
+
+#: source/app/service-providers/updates/index.ts:356
+#, javascript-format
+msgid "Could not check for updates: Server Error (Status code: %s)"
+msgstr "無法檢查更新：伺服器錯誤（狀態碼：%s）"
+
+#: source/app/service-providers/updates/index.ts:359
+#, javascript-format
+msgid "Could not check for updates: Client Error (Status code: %s)"
+msgstr "無法檢查更新：客戶端錯誤（狀態碼：%s）"
+
+#: source/app/service-providers/updates/index.ts:362
+#, javascript-format
+msgid ""
+"Could not check for updates: The server tried to redirect (Status code: %s)"
+msgstr "無法檢查更新：伺服器嘗試重定向（狀態碼：%s）"
+
+#. getaddrinfo has reported that the host has not been found.
+#. This normally only happens if the networking interface is
+#. offline. In this case, no need to inform the user every hour.
+#: source/app/service-providers/updates/index.ts:368
+msgid "Could not check for updates: Could not establish connection"
+msgstr "無法檢查更新：無法建立連線"
+
+#. Something else has occurred. GotError objects have a name property.
+#: source/app/service-providers/updates/index.ts:372
+#, javascript-format
+msgid "Could not check for updates. %s: %s"
+msgstr "無法檢查更新。%s：%s"
+
+#: source/app/service-providers/updates/index.ts:387
+msgid "Could not check for updates: Server hasn't sent any data"
+msgstr "無法檢查更新：伺服器沒有傳送任何資料"
+
+#: source/app/service-providers/updates/index.ts:464
+msgid "The SHA256 checksums file seems to be missing for this release."
+msgstr "這個發布版本似乎沒有 SHA256 雜湊值檔案。"
+
+#: source/app/service-providers/updates/index.ts:486
+#, javascript-format
+msgid "Cannot retrieve SHA256 checksums: %s"
+msgstr "無法取得 SAH256 雜湊值：%s"
+
+#: source/app/service-providers/updates/index.ts:527
+msgid "Could not accept data for application update: Write stream is gone."
+msgstr "無法接收程式更新的資料：寫入資料流消失。"
+
+#: source/app/service-providers/updates/index.ts:582
+msgid ""
+"Could not verify the integrity of the downloaded update. Please retry or "
+"update manually."
+msgstr "無法驗證已下載更新的完整性。請重試或是手動更新。"
+
+#: source/app/service-providers/updates/index.ts:594
+msgid ""
+"The downloaded file has a different checksum than the server reported. "
+"Please retry or update manually."
+msgstr "下載的檔案雜湊值與伺服器回傳的不相同。請重試或是手動更新。"
+
+#: source/app/service-providers/updates/index.ts:612
+#, javascript-format
+msgid "Could not start update. Please retry or update manually. Error was: %s"
+msgstr "無法開始更新。請重試或是手動更新。錯誤為：%s"
 
 #: source/app/service-providers/documents/index.ts:384
 msgid "Save changes"
@@ -953,16 +953,16 @@ msgstr "放棄變更"
 msgid "There are unsaved changes. Do you want to save or discard them?"
 msgstr "有些尚未儲存的修改。您要放棄它們還是要存檔？"
 
-#: source/app/service-providers/documents/index.ts:1038
+#: source/app/service-providers/documents/index.ts:1039
 msgid "File changed on disk"
 msgstr "檔案在磁碟上已變更"
 
-#: source/app/service-providers/documents/index.ts:1039
+#: source/app/service-providers/documents/index.ts:1040
 #, javascript-format
 msgid "%s changed on disk"
 msgstr "%s 在磁碟上已變更"
 
-#: source/app/service-providers/documents/index.ts:1041
+#: source/app/service-providers/documents/index.ts:1042
 #, javascript-format
 msgid ""
 "%s has changed on disk, but the editor contains unsaved changes. Do you want "
@@ -971,125 +971,1131 @@ msgstr ""
 "%s 在磁碟上已變更，但編輯器中有尚未儲存的修改。您要保留目前的編輯器內容還是從"
 "磁碟載入檔案？"
 
-#: source/app/service-providers/documents/index.ts:1042
+#: source/app/service-providers/documents/index.ts:1043
 msgid ""
 "Do you want to keep the current editor contents or load the file from disk?"
 msgstr "您要保留目前的編輯器內容還是從磁碟載入檔案？"
 
-#: source/app/service-providers/documents/index.ts:1045
+#: source/app/service-providers/documents/index.ts:1046
 msgid "Keep editor contents"
 msgstr "保留編輯器內容"
 
-#: source/app/service-providers/documents/index.ts:1046
+#: source/app/service-providers/documents/index.ts:1047
 msgid "Load changes from disk"
 msgstr "從磁碟載入變更"
 
-#: source/app/service-providers/documents/index.ts:1049
+#: source/app/service-providers/documents/index.ts:1050
 msgid ""
 "Always load changes from disk if there are no unsaved changes in the editor"
 msgstr "如果編輯器中沒有尚未儲存的修改，則總是從磁碟載入變更"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 msgid "Could not save file"
 msgstr "無法儲存檔案"
 
-#: source/app/service-providers/documents/index.ts:1518
+#: source/app/service-providers/documents/index.ts:1519
 #, javascript-format
 msgid "Could not save file %s: %s"
 msgstr "無法儲存檔案 %s：%s"
 
-#: source/win-main/file-manager/util/file-item-context.ts:29
-#: source/tmp/win-main/GlobalSearch.vue.ts:54
-msgid "Open in new tab"
-msgstr "在新標籤中開啟"
+#: source/win-preferences/schema/autocorrect.ts:22
+#: source/tmp/win-preferences/App.vue.ts:165
+msgid "Autocorrect"
+msgstr "自動更正"
 
-#: source/win-main/file-manager/util/file-item-context.ts:35
-#: source/win-main/file-manager/util/dir-item-context.ts:29
-msgid "Properties"
-msgstr "內容"
+#: source/win-preferences/schema/autocorrect.ts:32
+msgid "Smart quotes"
+msgstr "智慧引號"
 
-#: source/win-main/file-manager/util/file-item-context.ts:51
-msgid "Duplicate file"
-msgstr "建立檔案複本"
+#: source/win-preferences/schema/autocorrect.ts:45
+msgid "Double Quotes"
+msgstr "雙引號"
 
-#: source/win-main/file-manager/util/file-item-context.ts:67
-#: source/win-main/file-manager/util/dir-item-context.ts:68
-#: source/win-main/tabs-context.ts:74
-msgid "Copy path"
-msgstr "複製路徑"
+#: source/win-preferences/schema/autocorrect.ts:48
+#: source/win-preferences/schema/autocorrect.ts:70
+msgid "Disable Magic Quotes"
+msgstr "停用 Magic Quotes"
 
-#: source/win-main/file-manager/util/file-item-context.ts:73
-#: source/win-main/tabs-context.ts:68
-msgid "Copy filename"
-msgstr "複製檔案名稱"
+#: source/win-preferences/schema/autocorrect.ts:67
+msgid "Single Quotes"
+msgstr "單引號"
 
+#: source/win-preferences/schema/autocorrect.ts:95
+msgid "Text-replacement patterns"
+msgstr "文字取代模式"
+
+#: source/win-preferences/schema/autocorrect.ts:99
+msgid "Match whole words"
+msgstr "符合整個單字"
+
+#: source/win-preferences/schema/autocorrect.ts:100
+msgid "When checked, AutoCorrect will never replace parts of words"
+msgstr "勾選時，自動更正將不會取代單字的一部分"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "Replace"
+msgstr "取代"
+
+#: source/win-preferences/schema/autocorrect.ts:107
+msgid "With"
+msgstr "取代為"
+
+#: source/win-preferences/schema/autocorrect.ts:112
+#: source/win-preferences/schema/advanced.ts:115
+#: source/win-preferences/schema/spellchecking.ts:173
+msgid "Filter"
+msgstr "篩選"
+
+#: source/win-preferences/schema/appearance.ts:37
+msgid "Schedule"
+msgstr "排程"
+
+#: source/win-preferences/schema/appearance.ts:41
+#: source/win-preferences/schema/general.ts:47
+msgid "Off"
+msgstr "關閉"
+
+#: source/win-preferences/schema/appearance.ts:42
+msgid "Follow system"
+msgstr "依照系統設定"
+
+#: source/win-preferences/schema/appearance.ts:43
+msgid "On"
+msgstr "開啟"
+
+#: source/win-preferences/schema/appearance.ts:52
+#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
+msgid "Start"
+msgstr "開始"
+
+#: source/win-preferences/schema/appearance.ts:59
+msgid "End"
+msgstr "結束"
+
+#: source/win-preferences/schema/appearance.ts:69
+msgid "Theme"
+msgstr "主題"
+
+#: source/win-preferences/schema/appearance.ts:117
+msgid "Toolbar options"
+msgstr "工具列選項"
+
+#: source/win-preferences/schema/appearance.ts:124
+msgid "Left section"
+msgstr "左側區塊"
+
+#: source/win-preferences/schema/appearance.ts:128
+msgid "Display \"Open settings\" button"
+msgstr "顯示「開啟設定」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:133
+msgid "Display \"New file\" button"
+msgstr "顯示「新增檔案」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:138
+msgid "Display \"Previous file\" button"
+msgstr "顯示「上一個檔案」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:143
+msgid "Display \"Next file\" button"
+msgstr "顯示「下一個檔案」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:150
+msgid "Center section"
+msgstr "中間區塊"
+
+#: source/win-preferences/schema/appearance.ts:154
+msgid "Display \"Readability mode\" button"
+msgstr "顯示「可讀性」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:159
+msgid "Display \"Insert comment\" button"
+msgstr "顯示「插入註解」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:164
+msgid "Display \"Insert link\" button"
+msgstr "顯示「插入連結」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:169
+msgid "Display \"Insert image\" button"
+msgstr "顯示「插入圖片」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:174
+msgid "Display \"Insert task list\" button"
+msgstr "顯示「插入任務清單」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:179
+msgid "Display \"Insert table\" button"
+msgstr "顯示「插入表格」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:184
+msgid "Display \"Insert footnote\" button"
+msgstr "顯示「插入註腳」按鈕"
+
+#: source/win-preferences/schema/appearance.ts:191
+msgid "Right section"
+msgstr "右側區塊"
+
+#: source/win-preferences/schema/appearance.ts:195
+msgid "Display word/character counter"
+msgstr "顯示字數/字元統計"
+
+#: source/win-preferences/schema/appearance.ts:200
+msgid "Display Pomodoro timer"
+msgstr "顯示番茄鐘計時器"
+
+#: source/win-preferences/schema/appearance.ts:206
+msgid "Status bar"
+msgstr "狀態列"
+
+#: source/win-preferences/schema/appearance.ts:212
+msgid "Show status bar"
+msgstr "顯示狀態列"
+
+#: source/win-preferences/schema/appearance.ts:218
+#: source/tmp/win-assets/App.vue.ts:33
+msgid "Custom CSS"
+msgstr "自訂 CSS"
+
+#: source/win-preferences/schema/appearance.ts:223
+msgid "Open CSS editor"
+msgstr "開啟 CSS 編輯器"
+
+#: source/win-preferences/schema/import-export.ts:24
+msgid "Import and export profiles"
+msgstr "匯入和匯出設定檔"
+
+#: source/win-preferences/schema/import-export.ts:30
+msgid "Open import profiles editor"
+msgstr "開啟匯入設定檔編輯器"
+
+#: source/win-preferences/schema/import-export.ts:44
+msgid "Open export profiles editor"
+msgstr "開啟匯出設定檔編輯器"
+
+#: source/win-preferences/schema/import-export.ts:59
+msgid "Export settings"
+msgstr "匯出設定"
+
+#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
+#: source/win-preferences/schema/import-export.ts:65
+msgid "Use Zettlr's internal Pandoc for exports"
+msgstr "使用 Zettlr 的內部 Pandoc 進行匯出"
+
+#: source/win-preferences/schema/import-export.ts:71
+msgid "Remove tags from files when exporting"
+msgstr "匯出時從檔案中移除標籤"
+
+#: source/win-preferences/schema/import-export.ts:77
+#: source/win-preferences/schema/zettelkasten.ts:44
+msgid "Internal links"
+msgstr "內部連結"
+
+#: source/win-preferences/schema/import-export.ts:80
+msgid "Remove internal links completely"
+msgstr "徹底移除內部連結"
+
+#: source/win-preferences/schema/import-export.ts:81
+msgid "Unlink internal links"
+msgstr "取消內部連結"
+
+#: source/win-preferences/schema/import-export.ts:82
+msgid "Don't touch internal links"
+msgstr "不要改變內部連結"
+
+#: source/win-preferences/schema/import-export.ts:88
+msgid "Destination folder for exported files"
+msgstr "匯出檔案的目的地資料夾"
+
+#. TODO: Add info-strings
+#: source/win-preferences/schema/import-export.ts:92
+msgid "Temporary folder"
+msgstr "暫存資料夾"
+
+#: source/win-preferences/schema/import-export.ts:93
+msgid "Same as file location"
+msgstr "與檔案位置相同"
+
+#: source/win-preferences/schema/import-export.ts:94
+msgid "Ask for folder when exporting"
+msgstr "匯出時詢問資料夾"
+
+#: source/win-preferences/schema/import-export.ts:100
+msgid ""
+"Warning! Files in the temporary folder are regularly deleted. Choosing the "
+"same location as the file overwrites files with identical filenames if they "
+"already exist."
+msgstr ""
+"警告！暫存資料夾中的檔案會定期刪除。選擇與檔案相同的位置會覆蓋已存在的同名檔"
+"案。"
+
+#: source/win-preferences/schema/import-export.ts:105
+msgid "Custom export commands"
+msgstr "自訂匯出命令"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Display name"
+msgstr "顯示名稱"
+
+#: source/win-preferences/schema/import-export.ts:113
+msgid "Command"
+msgstr "命令"
+
+#: source/win-preferences/schema/import-export.ts:114
+msgid ""
+"Enter custom commands to run the exporter with. Each command receives as its "
+"first argument the file or project folder to be exported."
+msgstr ""
+"輸入自訂命令以執行匯出器。每個命令的第一個參數是要匯出的檔案或專案資料夾。"
+
+#: source/win-preferences/schema/advanced.ts:30
+msgid "Pattern for new file names"
+msgstr "新檔案名稱的模式"
+
+#: source/win-preferences/schema/advanced.ts:36
+msgid "Define a pattern for new file names"
+msgstr "定義新檔案名稱的模式"
+
+#: source/win-preferences/schema/advanced.ts:38
+#, javascript-format
+msgid "Available variables: %s"
+msgstr "可用變數：%s"
+
+#: source/win-preferences/schema/advanced.ts:44
+msgid "Do not prompt for filename when creating new files"
+msgstr "建立新檔案時不提示檔名"
+
+#: source/win-preferences/schema/advanced.ts:51
+#: source/tmp/win-preferences/App.vue.ts:145
+msgid "Appearance"
+msgstr "外觀"
+
+#: source/win-preferences/schema/advanced.ts:57
+msgid "Use native window appearance"
+msgstr "使用原生視窗外觀"
+
+#: source/win-preferences/schema/advanced.ts:58
+msgid "Only available on Linux; this is the default for macOS and Windows."
+msgstr "僅適用於 Linux；這是 macOS 和 Windows 的預設值。"
+
+#: source/win-preferences/schema/advanced.ts:64
+msgid "Enable window vibrancy"
+msgstr "啟用視窗透明效果"
+
+#: source/win-preferences/schema/advanced.ts:65
+msgid "Only available on macOS; makes the window background opaque."
+msgstr "僅適用於 macOS；使視窗背景不透明。"
+
+#: source/win-preferences/schema/advanced.ts:72
+msgid "Show app in the notification area"
+msgstr "在通知區顯示 Zettlr"
+
+#: source/win-preferences/schema/advanced.ts:73
+msgid "Leave app running in the notification area"
+msgstr "讓 Zettlr 在通知區繼續執行"
+
+#: source/win-preferences/schema/advanced.ts:82
+msgid "Zoom behavior"
+msgstr "縮放行為"
+
+#: source/win-preferences/schema/advanced.ts:85
+msgid "Resizes the whole GUI"
+msgstr "調整整個使用者介面的大小"
+
+#: source/win-preferences/schema/advanced.ts:86
+msgid "Changes the editor font size"
+msgstr "更改編輯器字型大小"
+
+#: source/win-preferences/schema/advanced.ts:92
+msgid "Attachments sidebar"
+msgstr "附件側邊欄"
+
+#: source/win-preferences/schema/advanced.ts:98
+msgid "File extensions to be visible in the Attachments sidebar"
+msgstr "在附件側邊欄中可見的檔案副檔名"
+
+#: source/win-preferences/schema/advanced.ts:104
+msgid "Iframe rendering whitelist"
+msgstr "Iframe 顯示白名單"
+
+#: source/win-preferences/schema/advanced.ts:113
+msgid "Hostname"
+msgstr "主機名"
+
+#: source/win-preferences/schema/advanced.ts:120
+msgid "Watchdog polling"
+msgstr "看門狗輪詢"
+
+#: source/win-preferences/schema/advanced.ts:126
+msgid "Activate watchdog polling"
+msgstr "啟用看門狗輪詢"
+
+#: source/win-preferences/schema/advanced.ts:131
+msgid "Time to wait before writing a file is considered done (in ms)"
+msgstr "判斷一個檔案寫入完成前的等待時間（毫秒）"
+
+#: source/win-preferences/schema/advanced.ts:138
+msgid "Deleting items"
+msgstr "刪除項目"
+
+#: source/win-preferences/schema/advanced.ts:144
+msgid "Delete items irreversibly if moving them to trash fails"
+msgstr "如果移動到垃圾桶失敗，就直接刪除檔案"
+
+#: source/win-preferences/schema/advanced.ts:150
+msgid "Debug mode"
+msgstr "除錯模式"
+
+#: source/win-preferences/schema/advanced.ts:156
+msgid "Enable debug mode"
+msgstr "啟用除錯模式"
+
+#: source/win-preferences/schema/advanced.ts:163
+msgid "Beta releases"
+msgstr "Beta 版本"
+
+#: source/win-preferences/schema/advanced.ts:169
+msgid "Notify me about beta releases"
+msgstr "當有新 Beta 版本發布時通知我"
+
+#: source/win-preferences/schema/editor.ts:23
+msgid "Input mode"
+msgstr "輸入模式"
+
+#: source/win-preferences/schema/editor.ts:39
+msgid ""
+"The input mode determines how you interact with the editor. We recommend "
+"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
+"know what this implies."
+msgstr ""
+"輸入模式決定您如何與編輯器互動。我們建議將此設定保持在「普通」模式。只有在您"
+"了解其含義時才選擇「Vim」或「Emacs」。"
+
+#: source/win-preferences/schema/editor.ts:44
+msgid "Writing direction"
+msgstr "書寫方向"
+
+#: source/win-preferences/schema/editor.ts:57
+msgid "Markdown rendering"
+msgstr "Markdown 繪製"
+
+#: source/win-preferences/schema/editor.ts:64
+msgid ""
+"Check to enable live rendering of various Markdown elements to formatted "
+"appearance. This hides formatting characters (such as **text**) or renders "
+"images instead of their link."
+msgstr ""
+"勾選以啟用各種 Markdown 元素的即時繪製為格式化外觀。這會隱藏格式字元（例如 **"
+"文字**）或繪製圖片而非其連結。"
+
+#: source/win-preferences/schema/editor.ts:72
+msgid "Render citations"
+msgstr "繪製引文"
+
+#: source/win-preferences/schema/editor.ts:77
+msgid "Render iframes"
+msgstr "繪製 iframe"
+
+#: source/win-preferences/schema/editor.ts:82
+msgid "Render images"
+msgstr "繪製圖片"
+
+#: source/win-preferences/schema/editor.ts:87
+msgid "Render links"
+msgstr "繪製連結"
+
+#: source/win-preferences/schema/editor.ts:92
+msgid "Render formulae"
+msgstr "繪製方程式"
+
+#: source/win-preferences/schema/editor.ts:97
+msgid "Render tasks"
+msgstr "繪製任務"
+
+#: source/win-preferences/schema/editor.ts:102
+msgid "Hide heading characters"
+msgstr "隱藏標題字元"
+
+#: source/win-preferences/schema/editor.ts:107
+msgid "Render emphasis"
+msgstr "繪製強調部份"
+
+#: source/win-preferences/schema/editor.ts:116
+msgid "Formatting characters for bold and italics"
+msgstr "粗體和斜體的格式字元"
+
+#: source/win-preferences/schema/editor.ts:126
+#: source/win-preferences/schema/editor.ts:127
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
+msgid "Bold"
+msgstr "粗體"
+
+#: source/win-preferences/schema/editor.ts:134
+#: source/win-preferences/schema/editor.ts:135
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
+msgid "Italics"
+msgstr "斜體"
+
+#: source/win-preferences/schema/editor.ts:143
+msgid "Check Markdown for style issues"
+msgstr "檢查 Markdown 的樣式問題"
+
+#: source/win-preferences/schema/editor.ts:149
+msgid "Table Editor"
+msgstr "表格編輯器"
+
+#: source/win-preferences/schema/editor.ts:160
+msgid ""
+"The Table Editor is an interactive interface that simplifies creation and "
+"editing of tables. It provides buttons for common functionality, and takes "
+"care of Markdown formatting."
+msgstr ""
+"表格編輯器是一個互動介面，簡化了表格的建立和編輯。它提供了常用功能的按鈕，並"
+"處理 Markdown 格式。"
+
+#: source/win-preferences/schema/editor.ts:171
+msgid "Mute non-focused lines in distraction-free mode"
+msgstr "在專注模式時，讓周遭的文字顏色變淺"
+
+#: source/win-preferences/schema/editor.ts:176
+msgid "Hide toolbar in distraction-free mode"
+msgstr "在專注模式時隱藏工具列"
+
+#: source/win-preferences/schema/editor.ts:182
+msgid "Word counter"
+msgstr "字數統計"
+
+#: source/win-preferences/schema/editor.ts:189
+msgid "Count characters instead of words (e.g., for Chinese)"
+msgstr "統計字元數，而非字數（例如中文）"
+
+#: source/win-preferences/schema/editor.ts:195
+msgid "Readability mode"
+msgstr "可讀性模式"
+
+#: source/win-preferences/schema/editor.ts:202
+msgid "Algorithm"
+msgstr "演算法"
+
+#: source/win-preferences/schema/editor.ts:214
+#: source/tmp/win-paste-image/App.vue.ts:58
+msgid "Image size"
+msgstr "圖片大小"
+
+#: source/win-preferences/schema/editor.ts:220
+msgid "Maximum width of images (%s %)"
+msgstr "最大圖片寬度（%s %）"
+
+#: source/win-preferences/schema/editor.ts:227
+msgid "Maximum height of images (%s %)"
+msgstr "最大圖片高度（%s %）"
+
+#: source/win-preferences/schema/editor.ts:235
+msgid "Other settings"
+msgstr "其他設定"
+
+#: source/win-preferences/schema/editor.ts:241
+msgid "Font size"
+msgstr "字型大小"
+
+#: source/win-preferences/schema/editor.ts:248
+msgid "Indentation size (number of spaces)"
+msgstr "縮排時使用幾個空格"
+
+#: source/win-preferences/schema/editor.ts:255
+msgid "Indent using tabs instead of spaces"
+msgstr "使用 Tab 縮排而非空格"
+
+#: source/win-preferences/schema/editor.ts:261
+msgid "Show formatting toolbar when text is selected"
+msgstr "當選取文字時顯示格式工作列"
+
+#: source/win-preferences/schema/editor.ts:266
+msgid "Highlight whitespace"
+msgstr "醒目顯示空白"
+
+#: source/win-preferences/schema/editor.ts:272
+msgid "Suggest emojis during autocompletion"
+msgstr "自動完成（AutoComplete）時建議表情符號"
+
+#: source/win-preferences/schema/editor.ts:277
+msgid "Show link previews"
+msgstr "顯示連結預覽"
+
+#: source/win-preferences/schema/editor.ts:283
+msgid "Automatically close matching character pairs"
+msgstr "括號自動配對"
+
+#: source/win-preferences/schema/file-manager.ts:23
+msgid "Display mode"
+msgstr "顯示模式"
+
+#: source/win-preferences/schema/file-manager.ts:32
+msgid "Thin"
+msgstr "精簡"
+
+#: source/win-preferences/schema/file-manager.ts:33
+msgid "Expanded"
+msgstr "展開"
+
+#: source/win-preferences/schema/file-manager.ts:34
+msgid "Combined"
+msgstr "合併"
+
+#: source/win-preferences/schema/file-manager.ts:40
+msgid ""
+"The Thin mode shows your directories and files separately. Select a "
+"directory to have its contents displayed in the file list. Switch between "
+"file list and directory tree by clicking on directories or the arrow button "
+"which appears at the top left corner of the file list."
+msgstr ""
+"精簡模式會將您的目錄和檔案分開顯示。選擇目錄即可在檔案清單中顯示其內容。您可"
+"以透過點選目錄或檔案清單左上角的箭頭按鈕，在檔案清單和目錄樹狀結構之間切換。"
+
+#: source/win-preferences/schema/file-manager.ts:45
+msgid "Show file information"
+msgstr "顯示檔案資訊"
+
+#: source/win-preferences/schema/file-manager.ts:50
+msgid "Show folders above files"
+msgstr "在檔案上方顯示資料夾"
+
+#: source/win-preferences/schema/file-manager.ts:56
+msgid "Markdown document name display"
+msgstr "Markdown 文件名稱顯示"
+
+#: source/win-preferences/schema/file-manager.ts:64
+msgid "Filename only"
+msgstr "僅檔案名稱"
+
+#: source/win-preferences/schema/file-manager.ts:65
+msgid "Title if applicable"
+msgstr "標題（如果適用）"
+
+#: source/win-preferences/schema/file-manager.ts:66
+msgid "First heading level 1 if applicable"
+msgstr "第一個一級標題（如果適用）"
+
+#: source/win-preferences/schema/file-manager.ts:67
+msgid "Title or first heading level 1 if applicable"
+msgstr "標題或第一個一級標題（如果適用）"
+
+#: source/win-preferences/schema/file-manager.ts:73
+msgid "Display Markdown file extensions"
+msgstr "顯示 Markdown 檔案的副檔名"
+
+#: source/win-preferences/schema/file-manager.ts:80
+msgid "Time display"
+msgstr "時間顯示"
+
+#: source/win-preferences/schema/file-manager.ts:88
+msgid "Last modification time"
+msgstr "最後修改時間"
+
+#: source/win-preferences/schema/file-manager.ts:89
+msgid "File creation time"
+msgstr "檔案建立時間"
+
+#: source/win-preferences/schema/file-manager.ts:95
+msgid "Sorting"
+msgstr "排序"
+
+#: source/win-preferences/schema/file-manager.ts:101
+msgid "When sorting documents…"
+msgstr "排序文件時…"
+
+#: source/win-preferences/schema/file-manager.ts:104
+msgid "Use natural order (2 comes before 10)"
+msgstr "使用自然順序（2 在 10 之前）"
+
+#: source/win-preferences/schema/file-manager.ts:105
+msgid "Use ASCII order (2 comes after 10)"
+msgstr "使用 ASCII 順序（2 在 10 之後）"
+
+#: source/win-preferences/schema/citations.ts:22
+#: source/tmp/win-preferences/App.vue.ts:170
+msgid "Citations"
+msgstr "引文"
+
+#: source/win-preferences/schema/citations.ts:28
+msgid "How would you like autocomplete to insert your citations?"
+msgstr "您希望「自動完成」功能如何插入引文？"
+
+#: source/win-preferences/schema/citations.ts:39
+msgid "Citation database (CSL JSON or BibTex)"
+msgstr "引用資料庫（CSL JSON 或 BibTex 格式）"
+
+#: source/win-preferences/schema/citations.ts:41
+#: source/win-preferences/schema/citations.ts:53
+msgid "Path to file"
+msgstr "檔案路徑"
+
+#: source/win-preferences/schema/citations.ts:51
+msgid "CSL style (optional)"
+msgstr "CSL 樣式（選擇性的）"
+
+#: source/win-preferences/schema/zettelkasten.ts:23
+msgid "Zettelkasten IDs"
+msgstr "Zettelkasten IDs"
+
+#: source/win-preferences/schema/zettelkasten.ts:29
+msgid "Pattern for Zettelkasten IDs"
+msgstr "Zettelkasten IDs 的模式"
+
+#: source/win-preferences/schema/zettelkasten.ts:30
+msgid "Uses ECMAScript regular expressions"
+msgstr "使用 ECMAScript 正規表達式"
+
+#: source/win-preferences/schema/zettelkasten.ts:36
+msgid "Pattern used to generate new IDs"
+msgstr "用於產生新 ID 的模式"
+
+#: source/win-preferences/schema/zettelkasten.ts:39
+#, javascript-format
+msgid "Available Variables: %s"
+msgstr "可用變數：%s"
+
+#: source/win-preferences/schema/zettelkasten.ts:50
+msgid "Link with filename only"
+msgstr "僅使用檔案名稱連結"
+
+#: source/win-preferences/schema/zettelkasten.ts:55
+msgid "When linking files, add the document name …"
+msgstr "連結檔案時，加入文件名稱…"
+
+#: source/win-preferences/schema/zettelkasten.ts:58
+msgid "Always"
+msgstr "總是"
+
+#: source/win-preferences/schema/zettelkasten.ts:59
+msgid "Only when linking using the ID"
+msgstr "僅在使用 ID 連結時"
+
+#: source/win-preferences/schema/zettelkasten.ts:60
+msgid "Never"
+msgstr "從不"
+
+#: source/win-preferences/schema/zettelkasten.ts:68
+msgid "Link format"
+msgstr "連結格式"
+
+#: source/win-preferences/schema/zettelkasten.ts:73
+msgid ""
+"Internal links allow you to add an optional title, separated by a vertical "
+"bar character from the actual link target. Here you can define the ordering "
+"of the two."
+msgstr ""
+"內部連結允許您新增一個非必要的標題，並用垂直條分隔符號與實際連結目標分開。在"
+"這裡您可以定義兩者的順序。"
+
+#: source/win-preferences/schema/zettelkasten.ts:79
+msgid "[[Link|Title]]: Link first (recommended)"
+msgstr "[[連結|標題]]：連結優先（推薦）"
+
+#: source/win-preferences/schema/zettelkasten.ts:80
+msgid "[[Title|Link]]: Title first"
+msgstr "[[標題|連結]]：標題優先"
+
+#: source/win-preferences/schema/zettelkasten.ts:88
+msgid "Start a full-text search when following internal links"
+msgstr "追蹤內部連結時啟動全文搜尋"
+
+#: source/win-preferences/schema/zettelkasten.ts:89
+msgid "The search string will match the content between the brackets: [[ ]]."
+msgstr "搜尋字串將對應括號中的內容：[[ ]]。"
+
+#: source/win-preferences/schema/zettelkasten.ts:96
+msgid ""
+"Automatically create non-existing files in this folder when following "
+"internal links"
+msgstr "追蹤內部連結時，自動在此資料夾中建立不存在的檔案"
+
+#: source/win-preferences/schema/zettelkasten.ts:101
+msgid "For this to work, the folder must be open as a Workspace in Zettlr."
+msgstr "要使其生效，資料夾必須以工作區的形式在 Zettlr 中開啟。"
+
+#: source/win-preferences/schema/zettelkasten.ts:106
+msgid "Path to folder"
+msgstr "資料夾路徑"
+
+#: source/win-preferences/schema/snippets.ts:24
+#: source/tmp/win-preferences/App.vue.ts:180
+#: source/tmp/win-assets/App.vue.ts:39
+msgid "Snippets"
+msgstr "小片段"
+
+#: source/win-preferences/schema/snippets.ts:30
+msgid "Open snippets editor"
+msgstr "開啟小片段編輯器"
+
+#: source/win-preferences/schema/spellchecking.ts:24
+msgid "LanguageTool"
+msgstr "LanguageTool"
+
+#: source/win-preferences/schema/spellchecking.ts:34
+msgid "Strictness"
+msgstr "嚴格程度"
+
+#: source/win-preferences/schema/spellchecking.ts:37
+msgid "Standard"
+msgstr "標準"
+
+#: source/win-preferences/schema/spellchecking.ts:38
+msgid "Picky"
+msgstr "挑剔"
+
+#: source/win-preferences/schema/spellchecking.ts:47
+msgid "Mother language"
+msgstr "母語"
+
+#: source/win-preferences/schema/spellchecking.ts:53
+msgid "Not set"
+msgstr "未設定"
+
+#: source/win-preferences/schema/spellchecking.ts:61
+msgid "Preferred Variants"
+msgstr "偏好變體"
+
+#: source/win-preferences/schema/spellchecking.ts:66
+msgid ""
+"LanguageTool cannot distinguish certain language's variants. These settings "
+"will nudge LanguageTool to auto-detect your preferred variant of these "
+"languages."
+msgstr ""
+"LanguageTool 無法區分某些語言的變體。這些設定將促使 LanguageTool 自動偵測您偏"
+"好的語言變體。"
+
+#: source/win-preferences/schema/spellchecking.ts:71
+msgid "Interpret English as"
+msgstr "將英語解釋為"
+
+#: source/win-preferences/schema/spellchecking.ts:84
+msgid "Interpret German as"
+msgstr "將德語解釋為"
+
+#: source/win-preferences/schema/spellchecking.ts:94
+msgid "Interpret Portuguese as"
+msgstr "將葡萄牙語解釋為"
+
+#: source/win-preferences/schema/spellchecking.ts:105
+msgid "Interpret Catalan as"
+msgstr "將加泰羅尼亞語解釋為"
+
+#: source/win-preferences/schema/spellchecking.ts:114
+msgid "LanguageTool Provider"
+msgstr "LanguageTool 提供者"
+
+#: source/win-preferences/schema/spellchecking.ts:118
+msgid "Custom server"
+msgstr "自訂伺服器"
+
+#: source/win-preferences/schema/spellchecking.ts:125
+msgid "Custom server address"
+msgstr "自訂伺服器位址"
+
+#: source/win-preferences/schema/spellchecking.ts:134
+msgid "LanguageTool Premium"
+msgstr "LanguageTool 進階版"
+
+#: source/win-preferences/schema/spellchecking.ts:139
+msgid ""
+"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
+"credentials here."
+msgstr "如果您在此輸入任何憑證，Zettlr 將忽略「LanguageTool 提供者」設定。"
+
+#: source/win-preferences/schema/spellchecking.ts:143
+msgid "LanguageTool Username"
+msgstr "LanguageTool 使用者名稱"
+
+#: source/win-preferences/schema/spellchecking.ts:150
+msgid "LanguageTool API key"
+msgstr "LanguageTool API 金鑰"
+
+#: source/win-preferences/schema/spellchecking.ts:158
+#: source/tmp/win-preferences/App.vue.ts:160
+msgid "Spellchecking"
+msgstr "拼字檢查"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Active"
+msgstr "啟用"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+msgid "Language"
+msgstr "語言"
+
+#: source/win-preferences/schema/spellchecking.ts:167
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
+msgid "Code"
+msgstr "程式碼"
+
+#: source/win-preferences/schema/spellchecking.ts:168
+msgid ""
+"Select the languages for which you want to enable automatic spell checking."
+msgstr "選擇您要啟用自動拼字檢查的語言。"
+
+#: source/win-preferences/schema/spellchecking.ts:180
+msgid "User dictionary. Remove words by clicking them."
+msgstr "使用者字典。點選單字以移除。"
+
+#: source/win-preferences/schema/spellchecking.ts:182
+msgid "Dictionary entry"
+msgstr "字典條目"
+
+#: source/win-preferences/schema/spellchecking.ts:185
+msgid "Search for entries …"
+msgstr "搜尋條目…"
+
+#: source/win-preferences/schema/general.ts:22
+msgid "Application language"
+msgstr "應用程式語言"
+
+#: source/win-preferences/schema/general.ts:33
+msgid "Autosave"
+msgstr "自動存檔"
+
+#: source/win-preferences/schema/general.ts:43
+msgid "Save modifications"
+msgstr "儲存修改"
+
+#: source/win-preferences/schema/general.ts:48
+msgid "Immediately"
+msgstr "立即"
+
+#: source/win-preferences/schema/general.ts:49
+msgid "After a short delay"
+msgstr "短暫延遲後"
+
+#: source/win-preferences/schema/general.ts:55
+msgid "Default image folder"
+msgstr "預設圖片資料夾"
+
+#: source/win-preferences/schema/general.ts:67
+msgid ""
+"Click \"Select folder…\" or type an absolute or relative path directly into "
+"the input field."
+msgstr "點選「選擇資料夾…」或直接在輸入欄中輸入絕對或相對路徑。"
+
+#: source/win-preferences/schema/general.ts:72
+msgid "Behavior"
+msgstr "行為"
+
+#: source/win-preferences/schema/general.ts:83
+msgid "Avoid opening files in new tabs if possible"
+msgstr "盡量避免在新分頁中開啟檔案"
+
+#: source/win-preferences/schema/general.ts:89
+msgid "Updates"
+msgstr "更新"
+
+#: source/win-preferences/schema/general.ts:95
+msgid "Automatically check for updates"
+msgstr "自動檢查更新"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
+#: source/tmp/win-main/App.vue.ts:235
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
+#, javascript-format
+msgid "%s characters"
+msgstr "%s 字元"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
+#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
+#: source/tmp/win-main/App.vue.ts:236
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
+#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
+#, javascript-format
+msgid "%s words"
+msgstr "%s 字"
+
+#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
+#, javascript-format
+msgid "This file is part of project \"%s\""
+msgstr "此檔案是專案「%s」的一部分"
+
+#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
+msgid "Go to footnote reference"
+msgstr "前往註腳參考"
+
+#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
+msgid "No highlighting"
+msgstr "無醒目標示"
+
+#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
+msgid "Open diagnostics panel"
+msgstr "開啟診斷面板"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
+msgid "Disabled"
+msgstr "已停用"
+
+#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
+msgid "Custom"
+msgstr "自訂"
+
+#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
+msgid "Detect automatically"
+msgstr "自動偵測"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:56
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:75
+msgid "Rendering mermaid graph …"
+msgstr "正在繪製 mermaid 圖表…"
+
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:61
+#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:80
+msgid "Could not render Graph:"
+msgstr "無法繪製圖表："
+
+#: source/common/modules/markdown-editor/renderers/readability.ts:39
+#, javascript-format
+msgid "Readability mode (%s)"
+msgstr "可讀性模式（%s）"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:122
+#, javascript-format
+msgid "Image not found: %s"
+msgstr "找不到圖片：%s"
+
+#: source/common/modules/markdown-editor/renderers/render-images.ts:197
+msgid "Open image externally"
+msgstr "在外部開啟圖片"
+
+#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
+msgid "Spelling mistake"
+msgstr "拼字錯誤"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
+#, javascript-format
+msgid "File %s does not exist."
+msgstr "檔案 %s 不存在。"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
+msgid "Word count"
+msgstr "字數統計"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
+msgid "Modified"
+msgstr "已修改"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
+msgid "Open…"
+msgstr "開啟…"
+
+#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
+msgid "Open in a new tab"
+msgstr "在新分頁開啟"
+
+#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
+msgid "Fetching link preview…"
+msgstr "正在取得連結預覽…"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
+msgid "Link"
+msgstr "連結"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
+msgid "Image"
+msgstr "圖片"
+
+#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
+msgid "Comment"
+msgstr "註解"
+
+#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
+msgid "No footnote text found."
+msgstr "找不到註腳文字。"
+
+#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
+msgid "Copy equation code"
+msgstr "複製方程式程式碼"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
+msgid "Open link"
+msgstr "開啟連結"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy email address"
+msgstr "複製 E-mail 信箱"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
+msgid "Copy link"
+msgstr "複製連結"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
+msgid "Remove link"
+msgstr "移除連結"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
+msgid "Copy image to clipboard"
+msgstr "複製圖片到剪貼簿"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
+msgid "Open image"
+msgstr "開啟圖片"
+
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 #: source/win-main/file-manager/util/file-item-context.ts:88
 #: source/win-main/file-manager/util/dir-item-context.ts:77
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
 msgid "Reveal in Finder"
 msgstr "在 Finder 中顯示"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in Explorer"
-msgstr "在 Explorer 中顯示"
+#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
+msgid "Open in File Browser"
+msgstr "在檔案瀏覽器中開啟"
 
-#: source/win-main/file-manager/util/file-item-context.ts:88
-#: source/win-main/file-manager/util/dir-item-context.ts:77
-msgid "Reveal in File Browser"
-msgstr "在檔案瀏覽器中顯示"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
+msgid "No suggestions"
+msgstr "沒有建議"
 
-#: source/win-main/file-manager/util/file-item-context.ts:101
-msgid "Close file"
-msgstr "關閉檔案"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
+msgid "Add to dictionary"
+msgstr "新增到字典"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:53
-msgid "Rename directory"
-msgstr "重新命名目錄"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
+msgid "Italic"
+msgstr "斜體"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:59
-msgid "Delete directory"
-msgstr "刪除目錄"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
+#: source/tmp/win-main/App.vue.ts:343
+msgid "Insert link"
+msgstr "插入連結"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:88
-msgid "Check for directory …"
-msgstr "檢查目錄…"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
+msgid "Insert unordered list"
+msgstr "插入無編號列表"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:105
-msgid "Export Project"
-msgstr "匯出專案"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
+msgid "Insert numbered list"
+msgstr "插入編號列表"
 
-#: source/win-main/file-manager/util/dir-item-context.ts:117
-msgid "Close workspace"
-msgstr "關閉工作區"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
+#: source/tmp/win-main/App.vue.ts:357
+msgid "Insert task list"
+msgstr "插入任務清單"
 
-#: source/win-main/tabs-context.ts:38
-msgid "Close tab"
-msgstr "關閉分頁"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
+msgid "Insert blockquote"
+msgstr "插入引言區塊"
 
-#: source/win-main/tabs-context.ts:44
-msgid "Close other tabs"
-msgstr "關閉其他分頁"
+#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
+#: source/tmp/win-main/App.vue.ts:364
+msgid "Insert table"
+msgstr "插入表格"
 
-#: source/win-main/tabs-context.ts:50
-msgid "Close all tabs"
-msgstr "關閉全部分頁"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Unpin tab"
-msgstr "取消固定分頁"
-
-#: source/win-main/tabs-context.ts:59
-msgid "Pin tab"
-msgstr "固定分頁"
-
-#: source/common/util/localise-number.ts:28
-msgid ","
-msgstr ","
-
-#: source/common/util/localise-number.ts:29
-msgid "."
-msgstr "."
+#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
+msgid "Cmd/Ctrl-click to follow this link"
+msgstr "按下 Cmd/Ctrl 鍵並點選以跟隨連結"
 
 #: source/common/util/format-date.ts:33
 msgid "just now"
@@ -1497,322 +2503,318 @@ msgstr "正體中文（臺灣）"
 msgid "Chinese"
 msgstr "中文"
 
-#: source/common/modules/markdown-editor/statusbar/language-tool.ts:146
-msgid "Detect automatically"
-msgstr "自動偵測"
+#: source/common/util/localise-number.ts:28
+msgid ","
+msgstr ","
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:131
-msgid "Disabled"
-msgstr "已停用"
+#: source/common/util/localise-number.ts:29
+msgid "."
+msgstr "."
 
-#: source/common/modules/markdown-editor/statusbar/magic-quotes.ts:138
-msgid "Custom"
-msgstr "自訂"
+#: source/win-main/file-manager/util/file-item-context.ts:29
+#: source/tmp/win-main/GlobalSearch.vue.ts:54
+msgid "Open in new tab"
+msgstr "在新標籤中開啟"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:54
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:78
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:53
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:124
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:187
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:145
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:56
-#: source/tmp/win-main/App.vue.ts:236
-#, javascript-format
-msgid "%s words"
-msgstr "%s 字"
+#: source/win-main/file-manager/util/file-item-context.ts:35
+#: source/win-main/file-manager/util/dir-item-context.ts:29
+msgid "Properties"
+msgstr "內容"
 
-#: source/common/modules/markdown-editor/statusbar/info-fields.ts:74
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:77
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:51
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:122
-#: source/tmp/win-main/file-manager/FileItem.vue.ts:185
-#: source/tmp/win-main/App.vue.ts:235
-#, javascript-format
-msgid "%s characters"
-msgstr "%s 字元"
+#: source/win-main/file-manager/util/file-item-context.ts:51
+msgid "Duplicate file"
+msgstr "建立檔案複本"
 
-#: source/common/modules/markdown-editor/statusbar/diagnostics.ts:46
-msgid "Open diagnostics panel"
-msgstr "開啟診斷面板"
+#: source/win-main/file-manager/util/file-item-context.ts:67
+#: source/win-main/file-manager/util/dir-item-context.ts:68
+#: source/win-main/tabs-context.ts:74
+msgid "Copy path"
+msgstr "複製路徑"
 
-#: source/common/modules/markdown-editor/linters/spellcheck.ts:148
-msgid "Spelling mistake"
-msgstr "拼字錯誤"
+#: source/win-main/file-manager/util/file-item-context.ts:73
+#: source/win-main/tabs-context.ts:68
+msgid "Copy filename"
+msgstr "複製檔案名稱"
 
-#: source/common/modules/markdown-editor/plugins/project-info-field.ts:83
-#, javascript-format
-msgid "This file is part of project \"%s\""
-msgstr "此檔案是專案「%s」的一部分"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in Explorer"
+msgstr "在 Explorer 中顯示"
 
-#: source/common/modules/markdown-editor/plugins/footnote-gutter.ts:31
-msgid "Go to footnote reference"
-msgstr "前往註腳參考"
+#: source/win-main/file-manager/util/file-item-context.ts:88
+#: source/win-main/file-manager/util/dir-item-context.ts:77
+msgid "Reveal in File Browser"
+msgstr "在檔案瀏覽器中顯示"
 
-#: source/common/modules/markdown-editor/tooltips/hyperlinks.ts:75
-msgid "Fetching link preview…"
-msgstr "正在取得連結預覽…"
+#: source/win-main/file-manager/util/file-item-context.ts:101
+msgid "Close file"
+msgstr "關閉檔案"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:44
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:152
-#: source/win-preferences/schema/editor.ts:126
-#: source/win-preferences/schema/editor.ts:127
-msgid "Bold"
-msgstr "粗體"
+#: source/win-main/file-manager/util/dir-item-context.ts:53
+msgid "Rename directory"
+msgstr "重新命名目錄"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:49
-#: source/win-preferences/schema/editor.ts:134
-#: source/win-preferences/schema/editor.ts:135
-msgid "Italics"
-msgstr "斜體"
+#: source/win-main/file-manager/util/dir-item-context.ts:59
+msgid "Delete directory"
+msgstr "刪除目錄"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:54
-msgid "Link"
-msgstr "連結"
+#: source/win-main/file-manager/util/dir-item-context.ts:88
+msgid "Check for directory …"
+msgstr "檢查目錄…"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:59
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:56
-msgid "Image"
-msgstr "圖片"
+#: source/win-main/file-manager/util/dir-item-context.ts:105
+msgid "Export Project"
+msgstr "匯出專案"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:64
-msgid "Comment"
-msgstr "註解"
+#: source/win-main/file-manager/util/dir-item-context.ts:117
+msgid "Close workspace"
+msgstr "關閉工作區"
 
-#: source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts:69
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Code"
-msgstr "程式碼"
+#: source/win-main/tabs-context.ts:38
+msgid "Close tab"
+msgstr "關閉分頁"
 
-#: source/common/modules/markdown-editor/tooltips/footnotes.ts:91
-msgid "No footnote text found."
-msgstr "找不到註腳文字。"
+#: source/win-main/tabs-context.ts:44
+msgid "Close other tabs"
+msgstr "關閉其他分頁"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:67
-#, javascript-format
-msgid "File %s does not exist."
-msgstr "檔案 %s 不存在。"
+#: source/win-main/tabs-context.ts:50
+msgid "Close all tabs"
+msgstr "關閉全部分頁"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:128
-msgid "Word count"
-msgstr "字數統計"
+#: source/win-main/tabs-context.ts:59
+msgid "Unpin tab"
+msgstr "取消固定分頁"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:130
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:30
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:36
-msgid "Modified"
-msgstr "已修改"
+#: source/win-main/tabs-context.ts:59
+msgid "Pin tab"
+msgstr "固定分頁"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:148
-msgid "Open…"
-msgstr "開啟…"
+#. STATIC VARIABLES
+#: source/tmp/win-stats/App.vue.ts:27
+#: source/tmp/win-stats/CalendarView.vue.ts:26
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
+msgid "Calendar"
+msgstr "日曆"
 
-#: source/common/modules/markdown-editor/tooltips/file-preview.ts:169
-msgid "Open in a new tab"
-msgstr "在新分頁開啟"
+#. Static properties
+#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
+msgid "Charts"
+msgstr "圖表"
 
-#: source/common/modules/markdown-editor/autocomplete/code-blocks.ts:42
-msgid "No highlighting"
-msgstr "無醒目標示"
+#: source/tmp/win-stats/App.vue.ts:39
+msgid "FSAL Stats"
+msgstr "FSAL 統計"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:82
-msgid "Open link"
-msgstr "開啟連結"
+#: source/tmp/win-stats/App.vue.ts:58
+msgid "Writing statistics"
+msgstr "寫作統計"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy email address"
-msgstr "複製 E-mail 信箱"
+#: source/tmp/win-stats/CalendarView.vue.ts:28
+msgid "January"
+msgstr "一月"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:91
-msgid "Copy link"
-msgstr "複製連結"
+#: source/tmp/win-stats/CalendarView.vue.ts:29
+msgid "February"
+msgstr "二月"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:97
-msgid "Remove link"
-msgstr "移除連結"
+#: source/tmp/win-stats/CalendarView.vue.ts:30
+msgid "March"
+msgstr "三月"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:107
-msgid "Copy image to clipboard"
-msgstr "複製圖片到剪貼簿"
+#: source/tmp/win-stats/CalendarView.vue.ts:31
+msgid "April"
+msgstr "四月"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:113
-msgid "Open image"
-msgstr "開啟圖片"
+#: source/tmp/win-stats/CalendarView.vue.ts:32
+msgid "May"
+msgstr "五月"
 
-#: source/common/modules/markdown-editor/context-menu/link-image-menu.ts:119
-msgid "Open in File Browser"
-msgstr "在檔案瀏覽器中開啟"
+#: source/tmp/win-stats/CalendarView.vue.ts:33
+msgid "June"
+msgstr "六月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:133
-msgid "No suggestions"
-msgstr "沒有建議"
+#: source/tmp/win-stats/CalendarView.vue.ts:34
+msgid "July"
+msgstr "七月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:142
-msgid "Add to dictionary"
-msgstr "新增到字典"
+#: source/tmp/win-stats/CalendarView.vue.ts:35
+msgid "August"
+msgstr "八月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:159
-msgid "Italic"
-msgstr "斜體"
+#: source/tmp/win-stats/CalendarView.vue.ts:36
+msgid "September"
+msgstr "九月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:169
-#: source/tmp/win-main/App.vue.ts:343
-msgid "Insert link"
-msgstr "插入連結"
+#: source/tmp/win-stats/CalendarView.vue.ts:37
+msgid "October"
+msgstr "十月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:176
-msgid "Insert unordered list"
-msgstr "插入無編號列表"
+#: source/tmp/win-stats/CalendarView.vue.ts:38
+msgid "November"
+msgstr "十一月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:182
-msgid "Insert numbered list"
-msgstr "插入編號列表"
+#: source/tmp/win-stats/CalendarView.vue.ts:39
+msgid "December"
+msgstr "十二月"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:188
-#: source/tmp/win-main/App.vue.ts:357
-msgid "Insert task list"
-msgstr "插入任務清單"
+#: source/tmp/win-stats/CalendarView.vue.ts:41
+msgid "Below the monthly average"
+msgstr "低於月平均"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:195
-msgid "Insert blockquote"
-msgstr "插入引言區塊"
+#: source/tmp/win-stats/CalendarView.vue.ts:42
+msgid "Over the monthly average"
+msgstr "超過月平均"
 
-#: source/common/modules/markdown-editor/context-menu/default-menu.ts:201
-#: source/tmp/win-main/App.vue.ts:364
-msgid "Insert table"
-msgstr "插入表格"
+#: source/tmp/win-stats/CalendarView.vue.ts:43
+msgid "More than twice the monthly average"
+msgstr "月平均兩倍以上"
 
-#: source/common/modules/markdown-editor/context-menu/equation-menu.ts:31
-msgid "Copy equation code"
-msgstr "複製方程式程式碼"
+#: source/tmp/win-project-properties/App.vue.ts:38
+msgid "Export project to:"
+msgstr "匯出專案到："
 
-#: source/common/modules/markdown-editor/renderers/readability.ts:39
-#, javascript-format
-msgid "Readability mode (%s)"
-msgstr "可讀性模式（%s）"
+#: source/tmp/win-project-properties/App.vue.ts:39
+msgid "Use"
+msgstr "使用"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:122
-#, javascript-format
-msgid "Image not found: %s"
-msgstr "找不到圖片：%s"
+#: source/tmp/win-project-properties/App.vue.ts:40
+msgid "Format"
+msgstr "格式"
 
-#: source/common/modules/markdown-editor/renderers/render-images.ts:197
-msgid "Open image externally"
-msgstr "在外部開啟圖片"
+#: source/tmp/win-project-properties/App.vue.ts:41
+msgid "Conversion"
+msgstr "轉換"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:54
-msgid "Rendering mermaid graph …"
-msgstr "正在繪製 mermaid 圖表…"
+#: source/tmp/win-project-properties/App.vue.ts:42
+msgid "Files to be included in the export"
+msgstr "要匯出的檔案"
 
-#: source/common/modules/markdown-editor/renderers/render-mermaid.ts:59
-msgid "Could not render Graph:"
-msgstr "無法繪製圖表："
+#: source/tmp/win-project-properties/App.vue.ts:43
+msgid "Please select at least one profile to build this project."
+msgstr "請至少選擇一個設定檔來建立此專案。"
 
-#: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
-msgid "Cmd/Ctrl-click to follow this link"
-msgstr "按下 Cmd/Ctrl 鍵並點選以跟隨連結"
+#: source/tmp/win-project-properties/App.vue.ts:44
+msgid "Project Title"
+msgstr "專案標題"
 
-#: source/tmp/win-update/App.vue.ts:31
-msgid "Updater"
-msgstr "更新管理員"
+#: source/tmp/win-project-properties/App.vue.ts:45
+msgid "CSL Stylesheet"
+msgstr "CSL 樣式表"
 
-#: source/tmp/win-update/App.vue.ts:32
-msgid "New update available"
-msgstr "有新的更新可用"
+#: source/tmp/win-project-properties/App.vue.ts:46
+msgid "LaTeX Template"
+msgstr "LaTeX 模板"
 
-#: source/tmp/win-update/App.vue.ts:33
-msgid "Your version"
-msgstr "您的版本"
+#: source/tmp/win-project-properties/App.vue.ts:47
+msgid "HTML Template"
+msgstr "HTML 模板"
 
-#: source/tmp/win-update/App.vue.ts:34
+#: source/tmp/win-project-properties/App.vue.ts:48
+msgid "Remove file from export"
+msgstr "從匯出中移除檔案"
+
+#: source/tmp/win-project-properties/App.vue.ts:49
+msgid "Add file to export"
+msgstr "新增檔案到匯出"
+
+#: source/tmp/win-project-properties/App.vue.ts:50
+msgid "Move file up"
+msgstr "上移檔案"
+
+#: source/tmp/win-project-properties/App.vue.ts:51
+msgid "Move file down"
+msgstr "下移檔案"
+
+#: source/tmp/win-project-properties/App.vue.ts:52
+msgid "You have not selected any files for export."
+msgstr "您尚未選擇任何要匯出的檔案。"
+
+#: source/tmp/win-project-properties/App.vue.ts:53
 msgid ""
-"There is a new version of Zettlr available to download. Please read the "
-"changelog below."
-msgstr "有新版本的 Zettlr 可供下載。請閱讀下方的更新日誌。"
+"Some files are selected for export but no longer exist in the directory."
+msgstr "有些檔案已選擇匯出，但在目錄中已不存在。"
 
-#: source/tmp/win-update/App.vue.ts:35
-msgid "Downloading your update"
-msgstr "正在下載更新"
+#: source/tmp/win-project-properties/App.vue.ts:62
+#: source/tmp/win-preferences/App.vue.ts:140
+msgid "General"
+msgstr "一般"
 
-#: source/tmp/win-update/App.vue.ts:36
-msgid "No update available. You have the most recent version."
-msgstr "不需要更新，已經是最新版本了。"
-
-#: source/tmp/win-update/App.vue.ts:42
-msgid "Click to start update"
-msgstr "點選此處開始更新"
-
-#: source/tmp/win-update/App.vue.ts:45
-msgid "never"
-msgstr "從未"
-
-#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
+#: source/tmp/win-preferences/App.vue.ts:56
 #, javascript-format
-msgid "Last checked: %s"
-msgstr "上次檢查：%s"
+msgid "No results for \"%s\""
+msgstr "「%s」沒有結果"
 
-#: source/tmp/win-update/App.vue.ts:124
-msgid "Starting update …"
-msgstr "正在開始更新…"
+#: source/tmp/win-preferences/App.vue.ts:57
+#: source/tmp/win-main/GlobalSearch.vue.ts:42
+msgid "Search"
+msgstr "搜尋"
 
-#: source/tmp/win-tag-manager/App.vue.ts:27
-msgid "Assign color"
-msgstr "指定顏色"
+#: source/tmp/win-preferences/App.vue.ts:150
+msgid "File Manager"
+msgstr "檔案管理器"
 
-#: source/tmp/win-tag-manager/App.vue.ts:28
-msgid "Remove color"
-msgstr "移除顏色"
+#: source/tmp/win-preferences/App.vue.ts:155
+msgid "Editor"
+msgstr "編輯器"
 
-#: source/tmp/win-tag-manager/App.vue.ts:29
-msgid "Tag name"
-msgstr "標籤名稱"
+#: source/tmp/win-preferences/App.vue.ts:175
+msgid "Zettelkasten"
+msgstr "Zettelkasten"
 
-#: source/tmp/win-tag-manager/App.vue.ts:30
-msgid "Color"
-msgstr "顏色"
+#: source/tmp/win-preferences/App.vue.ts:185
+msgid "Import and Export"
+msgstr "匯入與匯出"
 
-#: source/tmp/win-tag-manager/App.vue.ts:31
-#: source/tmp/win-main/PopoverTags.vue.ts:40
-msgid "Count"
-msgstr "數量"
+#: source/tmp/win-preferences/App.vue.ts:190
+msgid "Advanced"
+msgstr "進階"
 
-#: source/tmp/win-tag-manager/App.vue.ts:32
-msgid "A short description"
-msgstr "簡短描述"
+#: source/tmp/win-preferences/App.vue.ts:199
+#, javascript-format
+msgid "Searching: %s"
+msgstr "搜尋中：%s"
 
-#: source/tmp/win-tag-manager/App.vue.ts:33
-msgid ""
-"Here you can assign colors to different tags. If a tag is found in a file, "
-"its tile in the preview list will receive a colored indicator. The "
-"description will be shown on mouse hover."
+#: source/tmp/win-preferences/App.vue.ts:203
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
+#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
+#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
+#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
+#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
+msgid "Reset"
+msgstr "重設"
+
+#: source/tmp/common/vue/form/elements/ShortcutCaptureControl.vue.ts:22
+msgid "Click to set your shortcut"
 msgstr ""
-"在這裡您可以為不同的標籤指定顏色。如果在檔案中找到標籤，預覽列表中的標籤將顯"
-"示顏色指示。將滑鼠移到標籤上時會顯示描述。"
 
-#: source/tmp/win-tag-manager/App.vue.ts:35
-#: source/tmp/win-main/PopoverTags.vue.ts:47
-msgid "Filter tags…"
-msgstr "篩選標籤…"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select folder…"
+msgstr "選擇資料夾…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:36
-msgid "New tag"
-msgstr "新標籤"
+#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
+msgid "Select file…"
+msgstr "選擇檔案…"
 
-#: source/tmp/win-tag-manager/App.vue.ts:37
-msgid "Rename"
-msgstr "重新命名"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
+msgid "Add"
+msgstr "新增"
 
-#: source/tmp/win-tag-manager/App.vue.ts:38
-msgid "Rename tag…"
-msgstr "重新命名標籤…"
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
+msgid "Actions"
+msgstr "動作"
+
+#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
+msgid "Delete"
+msgstr "刪除"
 
 #: source/tmp/win-paste-image/App.vue.ts:57
 msgid "Insert Image from Clipboard"
 msgstr "從剪貼簿插入圖片"
-
-#: source/tmp/win-paste-image/App.vue.ts:58
-#: source/win-preferences/schema/editor.ts:214
-msgid "Image size"
-msgstr "圖片大小"
 
 #: source/tmp/win-paste-image/App.vue.ts:59
 msgid "Retain aspect ratio"
@@ -1830,10 +2832,6 @@ msgstr "檔案名稱"
 #: source/tmp/win-paste-image/App.vue.ts:63
 msgid "A unique filename"
 msgstr "唯一的檔案名稱"
-
-#: source/tmp/win-splash-screen/App.vue.ts:22
-msgid "Loading…"
-msgstr "載入中…"
 
 #: source/tmp/win-about/App.vue.ts:41
 msgid "Other projects"
@@ -1895,44 +2893,28 @@ msgstr ""
 msgid "Zettlr also makes use of these projects:"
 msgstr "Zettlr 也使用了這些專案："
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:23
-msgid ""
-"Here you can override the styles of Zettlr to customise it even further. "
-"<strong>Attention: This file overrides all CSS directives! Never alter the "
-"geometry of elements, otherwise the app may expose unwanted behaviour!</"
-"strong>"
-msgstr ""
-"在這裡您可以自訂 Zettlr 的樣式。<strong>注意：此檔案會覆蓋所有 CSS 指令！不要"
-"隨意改動元素的幾何參數，否則應用程式可能會出現無法預期的行為！</strong>"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:29
+msgid "Rename snippet"
+msgstr "重新命名小片段"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:56
-#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/SnippetsTab.vue.ts:30
+msgid "Snippets let you define reusable pieces of text with variables."
+msgstr "「小片段」讓您定義可以重複使用的文字片段，並可包含變數。"
+
+#: source/tmp/win-assets/SnippetsTab.vue.ts:31
+msgid "Open snippets folder"
+msgstr "開啟小片段資料夾"
+
 #: source/tmp/win-assets/SnippetsTab.vue.ts:106
+#: source/tmp/win-assets/DefaultsTab.vue.ts:180
+#: source/tmp/win-assets/CustomCSS.vue.ts:56
 msgid "Saving …"
 msgstr "儲存中…"
 
-#: source/tmp/win-assets/CustomCSS.vue.ts:66
-msgid "Saving failed"
-msgstr "儲存失敗"
-
-#: source/tmp/win-assets/App.vue.ts:21
-msgid "Exporting"
-msgstr "匯出中"
-
-#: source/tmp/win-assets/App.vue.ts:27
-msgid "Importing"
-msgstr "匯入中"
-
-#: source/tmp/win-assets/App.vue.ts:33
-#: source/win-preferences/schema/appearance.ts:218
-msgid "Custom CSS"
-msgstr "自訂 CSS"
-
-#: source/tmp/win-assets/App.vue.ts:39
-#: source/tmp/win-preferences/App.vue.ts:180
-#: source/win-preferences/schema/snippets.ts:24
-msgid "Snippets"
-msgstr "小片段"
+#: source/tmp/win-assets/SnippetsTab.vue.ts:116
+#: source/tmp/win-assets/DefaultsTab.vue.ts:190
+msgid "Saved!"
+msgstr "已儲存！"
 
 #: source/tmp/win-assets/DefaultsTab.vue.ts:56
 msgid ""
@@ -1954,39 +2936,78 @@ msgstr "開啟預設資料夾"
 msgid "Edit the default settings for imports or exports here."
 msgstr "在這裡編輯匯入或匯出的預設設定。"
 
-#: source/tmp/win-assets/DefaultsTab.vue.ts:190
-#: source/tmp/win-assets/SnippetsTab.vue.ts:116
-msgid "Saved!"
-msgstr "已儲存！"
+#: source/tmp/win-assets/App.vue.ts:21
+msgid "Exporting"
+msgstr "匯出中"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:29
-msgid "Rename snippet"
-msgstr "重新命名小片段"
+#: source/tmp/win-assets/App.vue.ts:27
+msgid "Importing"
+msgstr "匯入中"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:30
-msgid "Snippets let you define reusable pieces of text with variables."
-msgstr "「小片段」讓您定義可以重複使用的文字片段，並可包含變數。"
+#: source/tmp/win-assets/CustomCSS.vue.ts:23
+msgid ""
+"Here you can override the styles of Zettlr to customise it even further. "
+"<strong>Attention: This file overrides all CSS directives! Never alter the "
+"geometry of elements, otherwise the app may expose unwanted behaviour!</"
+"strong>"
+msgstr ""
+"在這裡您可以自訂 Zettlr 的樣式。<strong>注意：此檔案會覆蓋所有 CSS 指令！不要"
+"隨意改動元素的幾何參數，否則應用程式可能會出現無法預期的行為！</strong>"
 
-#: source/tmp/win-assets/SnippetsTab.vue.ts:31
-msgid "Open snippets folder"
-msgstr "開啟小片段資料夾"
+#: source/tmp/win-assets/CustomCSS.vue.ts:66
+msgid "Saving failed"
+msgstr "儲存失敗"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
-msgid "words"
-msgstr "字數"
+#: source/tmp/win-tag-manager/App.vue.ts:27
+msgid "Assign color"
+msgstr "指定顏色"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
-msgid "characters"
-msgstr "字元"
+#: source/tmp/win-tag-manager/App.vue.ts:28
+msgid "Remove color"
+msgstr "移除顏色"
 
-#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
-msgid "No open document"
-msgstr "沒有開啟的文件"
+#: source/tmp/win-tag-manager/App.vue.ts:29
+msgid "Tag name"
+msgstr "標籤名稱"
 
-#: source/tmp/win-main/PopoverPomodoro.vue.ts:24
-#: source/win-preferences/schema/appearance.ts:52
-msgid "Start"
-msgstr "開始"
+#: source/tmp/win-tag-manager/App.vue.ts:30
+msgid "Color"
+msgstr "顏色"
+
+#: source/tmp/win-tag-manager/App.vue.ts:31
+#: source/tmp/win-main/PopoverTags.vue.ts:40
+msgid "Count"
+msgstr "數量"
+
+#: source/tmp/win-tag-manager/App.vue.ts:32
+msgid "A short description"
+msgstr "簡短描述"
+
+#: source/tmp/win-tag-manager/App.vue.ts:33
+msgid ""
+"Here you can assign colors to different tags. If a tag is found in a file, "
+"its tile in the preview list will receive a colored indicator. The "
+"description will be shown on mouse hover."
+msgstr ""
+"在這裡您可以為不同的標籤指定顏色。如果在檔案中找到標籤，預覽列表中的標籤將顯"
+"示顏色指示。將滑鼠移到標籤上時會顯示描述。"
+
+#: source/tmp/win-tag-manager/App.vue.ts:35
+#: source/tmp/win-main/PopoverTags.vue.ts:47
+msgid "Filter tags…"
+msgstr "篩選標籤…"
+
+#: source/tmp/win-tag-manager/App.vue.ts:36
+msgid "New tag"
+msgstr "新標籤"
+
+#: source/tmp/win-tag-manager/App.vue.ts:37
+msgid "Rename"
+msgstr "重新命名"
+
+#: source/tmp/win-tag-manager/App.vue.ts:38
+msgid "Rename tag…"
+msgstr "重新命名標籤…"
 
 #: source/tmp/win-main/PopoverPomodoro.vue.ts:25
 msgid "Stop"
@@ -2012,76 +3033,114 @@ msgstr "音效"
 msgid "Volume"
 msgstr "音量"
 
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
-#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
-msgid "Table of contents"
-msgstr "目次"
+#: source/tmp/win-main/PopoverStats.vue.ts:29
+msgid "words last month"
+msgstr "上個月的字數"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
-msgid "Related files"
-msgstr "相關檔案"
+#: source/tmp/win-main/PopoverStats.vue.ts:30
+msgid "daily average"
+msgstr "日平均"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
-msgid "No related files"
-msgstr "沒有相關檔案"
+#: source/tmp/win-main/PopoverStats.vue.ts:31
+msgid "words today"
+msgstr "今天的字數"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
-msgid "This relation is based on a bidirectional link."
-msgstr "此關聯基於雙向連結。"
+#: source/tmp/win-main/PopoverStats.vue.ts:32
+msgid "🔥 You're on fire!"
+msgstr "🔥 你狀態超好！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
-msgid "This relation is based on an outbound link."
-msgstr "此關聯基於外部連結。"
+#: source/tmp/win-main/PopoverStats.vue.ts:33
+msgid "💪 You're close to hitting your daily average!"
+msgstr "💪 你快要達成每日平均了！"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
-msgid "This relation is based on a backlink."
-msgstr "此關聯基於反向連結。"
+#: source/tmp/win-main/PopoverStats.vue.ts:34
+msgid "✍🏼 Get writing to surpass your daily average."
+msgstr "✍🏼 開始寫作，來突破每日平均吧。"
 
-#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
+#: source/tmp/win-main/PopoverStats.vue.ts:35
+msgid "More statistics …"
+msgstr "更多統計資料…"
+
+#: source/tmp/win-main/App.vue.ts:221
 #, javascript-format
-msgid "This relation is based on %s shared tags: %s"
-msgstr "此關聯基於 %s 個共用標籤： %s"
+msgid "%s selected"
+msgstr "%s 已選擇"
 
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
-msgid "Other files"
-msgstr "其他檔案"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
-msgid "Open directory"
-msgstr "開啟目錄"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
-msgid "No other files"
-msgstr "沒有其他檔案"
-
-#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
-msgid "Current folder"
-msgstr "目前資料夾"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
-#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
-msgid "References"
-msgstr "參考"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
-msgid "There are no citations in this document."
-msgstr "這份文件沒有引文。"
-
-#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
+#. Multiple selections --> indicate
+#: source/tmp/win-main/App.vue.ts:230
 #, javascript-format
-msgid "circa %s words"
-msgstr "大約 %s 字"
+msgid "%s selections"
+msgstr "%s 選擇"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:39
-msgid "Name"
-msgstr "名稱"
+#: source/tmp/win-main/App.vue.ts:256
+#: source/tmp/win-main/GlobalSearch.vue.ts:35
+msgid "Search across all files"
+msgstr "在所有的檔案之中尋找"
 
-#: source/tmp/win-main/PopoverTags.vue.ts:48
-msgid "Tag Cloud"
-msgstr "標籤雲"
+#: source/tmp/win-main/App.vue.ts:270
+msgid "View writing statistics"
+msgstr "檢視寫作統計資訊"
+
+#: source/tmp/win-main/App.vue.ts:276
+msgid "View Tag Cloud"
+msgstr "檢視標籤雲"
+
+#: source/tmp/win-main/App.vue.ts:283
+msgid "Open settings"
+msgstr "開啟設定"
+
+#: source/tmp/win-main/App.vue.ts:318
+msgid "Export current file"
+msgstr "匯出目前檔案"
+
+#: source/tmp/win-main/App.vue.ts:324
+msgid "Toggle readability mode"
+msgstr "切換可讀性模式"
+
+#: source/tmp/win-main/App.vue.ts:336
+msgid "Insert comment"
+msgstr "插入註解"
+
+#: source/tmp/win-main/App.vue.ts:350
+msgid "Insert image"
+msgstr "插入圖片"
+
+#: source/tmp/win-main/App.vue.ts:371
+msgid "Insert footnote"
+msgstr "插入註腳"
+
+#: source/tmp/win-main/App.vue.ts:389
+msgid "Pomodoro timer"
+msgstr "番茄鐘計時器"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:29
+msgid "Temporary directory"
+msgstr "暫存目錄"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:30
+msgid "Current directory"
+msgstr "目前目錄"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:31
+msgid "Select directory"
+msgstr "選擇目錄"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Exporting…"
+msgstr "匯出中…"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:64
+msgid "Export"
+msgstr "匯出"
+
+#: source/tmp/win-main/PopoverExport.vue.ts:77
+msgid "command"
+msgstr "指令"
+
+#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
+#: source/tmp/win-main/GlobalSearch.vue.ts:38
+msgid "Filter…"
+msgstr "篩選…"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:99
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:101
@@ -2091,8 +3150,8 @@ msgstr "目錄"
 
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:106
 #: source/tmp/win-main/file-manager/FileItem.vue.ts:108
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 #: source/tmp/win-main/file-manager/FileTree.vue.ts:76
+#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:32
 msgid "Files"
 msgstr "檔案"
 
@@ -2106,10 +3165,26 @@ msgstr "字元"
 msgid "Words"
 msgstr "字數"
 
-#: source/tmp/win-main/file-manager/FileManager.vue.ts:46
-#: source/tmp/win-main/GlobalSearch.vue.ts:38
-msgid "Filter…"
-msgstr "篩選…"
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
+msgid "Workspaces"
+msgstr "工作區"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
+msgid "No open files or folders"
+msgstr "沒有開啟的檔案或資料夾"
+
+#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
+#: source/tmp/win-main/file-manager/FileList.vue.ts:59
+msgid "No results"
+msgstr "沒有結果"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:60
+msgid "No directory selected"
+msgstr "沒有選擇目錄"
+
+#: source/tmp/win-main/file-manager/FileList.vue.ts:61
+msgid "Empty directory"
+msgstr "空目錄"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:31
 #: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:35
@@ -2139,15 +3214,6 @@ msgstr "升序"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:38
 msgid "descending"
 msgstr "降序"
-
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:41
-#: source/tmp/win-main/file-manager/util/PopoverFileProps.vue.ts:37
-#: source/tmp/common/vue/form/elements/TextControl.vue.ts:47
-#: source/tmp/common/vue/form/elements/ColorControl.vue.ts:35
-#: source/tmp/common/vue/form/elements/ShortcutChooser.vue.ts:61
-#: source/tmp/common/vue/form/elements/NumberControl.vue.ts:40
-msgid "Reset"
-msgstr "重設"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:42
 msgid "Cog"
@@ -2208,13 +3274,6 @@ msgstr "眼"
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:58
 msgid "Eye (crossed)"
 msgstr ""
-
-#. STATIC VARIABLES
-#: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:59
-#: source/tmp/win-stats/CalendarView.vue.ts:26
-#: source/tmp/win-stats/App.vue.ts:27
-msgid "Calendar"
-msgstr "日曆"
 
 #: source/tmp/win-main/file-manager/util/PopoverDirProps.vue.ts:60
 msgid "Calculator"
@@ -2424,130 +3483,10 @@ msgstr "CD/DVD"
 msgid "Set writing target…"
 msgstr "設定寫作目標…"
 
-#: source/tmp/win-main/file-manager/FileList.vue.ts:59
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:79
-msgid "No results"
-msgstr "沒有結果"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:60
-msgid "No directory selected"
-msgstr "沒有選擇目錄"
-
-#: source/tmp/win-main/file-manager/FileList.vue.ts:61
-msgid "Empty directory"
-msgstr "空目錄"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:77
-msgid "Workspaces"
-msgstr "工作區"
-
-#: source/tmp/win-main/file-manager/FileTree.vue.ts:78
-msgid "No open files or folders"
-msgstr "沒有開啟的檔案或資料夾"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:29
-msgid "words last month"
-msgstr "上個月的字數"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:30
-msgid "daily average"
-msgstr "日平均"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:31
-msgid "words today"
-msgstr "今天的字數"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:32
-msgid "🔥 You're on fire!"
-msgstr "🔥 你狀態超好！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:33
-msgid "💪 You're close to hitting your daily average!"
-msgstr "💪 你快要達成每日平均了！"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:34
-msgid "✍🏼 Get writing to surpass your daily average."
-msgstr "✍🏼 開始寫作，來突破每日平均吧。"
-
-#: source/tmp/win-main/PopoverStats.vue.ts:35
-msgid "More statistics …"
-msgstr "更多統計資料…"
-
-#: source/tmp/win-main/App.vue.ts:221
+#: source/tmp/win-main/PopoverTable.vue.ts:30
 #, javascript-format
-msgid "%s selected"
-msgstr "%s 已選擇"
-
-#. Multiple selections --> indicate
-#: source/tmp/win-main/App.vue.ts:230
-#, javascript-format
-msgid "%s selections"
-msgstr "%s 選擇"
-
-#: source/tmp/win-main/App.vue.ts:256
-#: source/tmp/win-main/GlobalSearch.vue.ts:35
-msgid "Search across all files"
-msgstr "在所有的檔案之中尋找"
-
-#: source/tmp/win-main/App.vue.ts:270
-msgid "View writing statistics"
-msgstr "檢視寫作統計資訊"
-
-#: source/tmp/win-main/App.vue.ts:276
-msgid "View Tag Cloud"
-msgstr "檢視標籤雲"
-
-#: source/tmp/win-main/App.vue.ts:283
-msgid "Open settings"
-msgstr "開啟設定"
-
-#: source/tmp/win-main/App.vue.ts:318
-msgid "Export current file"
-msgstr "匯出目前檔案"
-
-#: source/tmp/win-main/App.vue.ts:324
-msgid "Toggle readability mode"
-msgstr "切換可讀性模式"
-
-#: source/tmp/win-main/App.vue.ts:336
-msgid "Insert comment"
-msgstr "插入註解"
-
-#: source/tmp/win-main/App.vue.ts:350
-msgid "Insert image"
-msgstr "插入圖片"
-
-#: source/tmp/win-main/App.vue.ts:371
-msgid "Insert footnote"
-msgstr "插入註腳"
-
-#: source/tmp/win-main/App.vue.ts:389
-msgid "Pomodoro timer"
-msgstr "番茄鐘計時器"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:29
-msgid "Temporary directory"
-msgstr "暫存目錄"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:30
-msgid "Current directory"
-msgstr "目前目錄"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:31
-msgid "Select directory"
-msgstr "選擇目錄"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Exporting…"
-msgstr "匯出中…"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:64
-msgid "Export"
-msgstr "匯出"
-
-#: source/tmp/win-main/PopoverExport.vue.ts:77
-msgid "command"
-msgstr "指令"
+msgid "Table size: %s &times; %s"
+msgstr "表格大小：%s &times; %s"
 
 #: source/tmp/win-main/GlobalSearch.vue.ts:36
 msgid "Enter your search terms below"
@@ -2569,11 +3508,6 @@ msgstr "限制在目錄中搜尋"
 msgid "Choose directory…"
 msgstr "選擇目錄…"
 
-#: source/tmp/win-main/GlobalSearch.vue.ts:42
-#: source/tmp/win-preferences/App.vue.ts:57
-msgid "Search"
-msgstr "搜尋"
-
 #: source/tmp/win-main/GlobalSearch.vue.ts:43
 msgid "Clear search"
 msgstr "清除搜尋"
@@ -2587,1063 +3521,135 @@ msgstr "切換結果"
 msgid "%s matches across %s files"
 msgstr "%s 個符合項目於 %s 個檔案中"
 
-#: source/tmp/win-main/PopoverTable.vue.ts:30
+#: source/tmp/win-main/PopoverTags.vue.ts:39
+msgid "Name"
+msgstr "名稱"
+
+#: source/tmp/win-main/PopoverTags.vue.ts:48
+msgid "Tag Cloud"
+msgstr "標籤雲"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:21
+msgid "words"
+msgstr "字數"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:22
+msgid "characters"
+msgstr "字元"
+
+#: source/tmp/win-main/PopoverDocInfo.vue.ts:23
+msgid "No open document"
+msgstr "沒有開啟的文件"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:33
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:51
+msgid "Related files"
+msgstr "相關檔案"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:34
+msgid "No related files"
+msgstr "沒有相關檔案"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:35
+msgid "This relation is based on a bidirectional link."
+msgstr "此關聯基於雙向連結。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:36
+msgid "This relation is based on an outbound link."
+msgstr "此關聯基於外部連結。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:37
+msgid "This relation is based on a backlink."
+msgstr "此關聯基於反向連結。"
+
+#: source/tmp/win-main/sidebar/RelatedFilesTab.vue.ts:221
 #, javascript-format
-msgid "Table size: %s &times; %s"
-msgstr "表格大小：%s &times; %s"
+msgid "This relation is based on %s shared tags: %s"
+msgstr "此關聯基於 %s 個共用標籤： %s"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:106
-msgid "Add"
-msgstr "新增"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:16
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:57
+msgid "Other files"
+msgstr "其他檔案"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:107
-msgid "Actions"
-msgstr "動作"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:17
+msgid "Open directory"
+msgstr "開啟目錄"
 
-#: source/tmp/common/vue/form/elements/ListControl.vue.ts:108
-msgid "Delete"
-msgstr "刪除"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:18
+msgid "No other files"
+msgstr "沒有其他檔案"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select folder…"
-msgstr "選擇資料夾…"
+#: source/tmp/win-main/sidebar/OtherFilesTab.vue.ts:37
+msgid "Current folder"
+msgstr "目前資料夾"
 
-#: source/tmp/common/vue/form/elements/FileControl.vue.ts:43
-msgid "Select file…"
-msgstr "選擇檔案…"
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:39
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:36
+#: source/tmp/win-main/sidebar/ToCTab.vue.ts:44
+msgid "Table of contents"
+msgstr "目次"
 
-#: source/tmp/win-project-properties/App.vue.ts:38
-msgid "Export project to:"
-msgstr "匯出專案到："
+#: source/tmp/win-main/sidebar/MainSidebar.vue.ts:45
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:35
+msgid "References"
+msgstr "參考"
 
-#: source/tmp/win-project-properties/App.vue.ts:39
-msgid "Use"
-msgstr "使用"
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:45
+msgid "There are no citations in this document."
+msgstr "這份文件沒有引文。"
 
-#: source/tmp/win-project-properties/App.vue.ts:40
-msgid "Format"
-msgstr "格式"
-
-#: source/tmp/win-project-properties/App.vue.ts:41
-msgid "Conversion"
-msgstr "轉換"
-
-#: source/tmp/win-project-properties/App.vue.ts:42
-msgid "Files to be included in the export"
-msgstr "要匯出的檔案"
-
-#: source/tmp/win-project-properties/App.vue.ts:43
-msgid "Please select at least one profile to build this project."
-msgstr "請至少選擇一個設定檔來建立此專案。"
-
-#: source/tmp/win-project-properties/App.vue.ts:44
-msgid "Project Title"
-msgstr "專案標題"
-
-#: source/tmp/win-project-properties/App.vue.ts:45
-msgid "CSL Stylesheet"
-msgstr "CSL 樣式表"
-
-#: source/tmp/win-project-properties/App.vue.ts:46
-msgid "LaTeX Template"
-msgstr "LaTeX 模板"
-
-#: source/tmp/win-project-properties/App.vue.ts:47
-msgid "HTML Template"
-msgstr "HTML 模板"
-
-#: source/tmp/win-project-properties/App.vue.ts:48
-msgid "Remove file from export"
-msgstr "從匯出中移除檔案"
-
-#: source/tmp/win-project-properties/App.vue.ts:49
-msgid "Add file to export"
-msgstr "新增檔案到匯出"
-
-#: source/tmp/win-project-properties/App.vue.ts:50
-msgid "Move file up"
-msgstr "上移檔案"
-
-#: source/tmp/win-project-properties/App.vue.ts:51
-msgid "Move file down"
-msgstr "下移檔案"
-
-#: source/tmp/win-project-properties/App.vue.ts:52
-msgid "You have not selected any files for export."
-msgstr "您尚未選擇任何要匯出的檔案。"
-
-#: source/tmp/win-project-properties/App.vue.ts:53
-msgid ""
-"Some files are selected for export but no longer exist in the directory."
-msgstr "有些檔案已選擇匯出，但在目錄中已不存在。"
-
-#: source/tmp/win-project-properties/App.vue.ts:62
-#: source/tmp/win-preferences/App.vue.ts:140
-msgid "General"
-msgstr "一般"
-
-#: source/tmp/win-preferences/App.vue.ts:56
+#: source/tmp/win-main/sidebar/ReferencesTab.vue.ts:66
 #, javascript-format
-msgid "No results for \"%s\""
-msgstr "「%s」沒有結果"
+msgid "circa %s words"
+msgstr "大約 %s 字"
 
-#: source/tmp/win-preferences/App.vue.ts:145
-#: source/win-preferences/schema/advanced.ts:51
-msgid "Appearance"
-msgstr "外觀"
+#: source/tmp/win-splash-screen/App.vue.ts:22
+msgid "Loading…"
+msgstr "載入中…"
 
-#: source/tmp/win-preferences/App.vue.ts:150
-msgid "File Manager"
-msgstr "檔案管理器"
+#: source/tmp/win-update/App.vue.ts:31
+msgid "Updater"
+msgstr "更新管理員"
 
-#: source/tmp/win-preferences/App.vue.ts:155
-msgid "Editor"
-msgstr "編輯器"
+#: source/tmp/win-update/App.vue.ts:32
+msgid "New update available"
+msgstr "有新的更新可用"
 
-#: source/tmp/win-preferences/App.vue.ts:160
-#: source/win-preferences/schema/spellchecking.ts:158
-msgid "Spellchecking"
-msgstr "拼字檢查"
+#: source/tmp/win-update/App.vue.ts:33
+msgid "Your version"
+msgstr "您的版本"
 
-#: source/tmp/win-preferences/App.vue.ts:165
-#: source/win-preferences/schema/autocorrect.ts:22
-msgid "Autocorrect"
-msgstr "自動更正"
+#: source/tmp/win-update/App.vue.ts:34
+msgid ""
+"There is a new version of Zettlr available to download. Please read the "
+"changelog below."
+msgstr "有新版本的 Zettlr 可供下載。請閱讀下方的更新日誌。"
 
-#: source/tmp/win-preferences/App.vue.ts:170
-#: source/win-preferences/schema/citations.ts:22
-msgid "Citations"
-msgstr "引文"
+#: source/tmp/win-update/App.vue.ts:35
+msgid "Downloading your update"
+msgstr "正在下載更新"
 
-#: source/tmp/win-preferences/App.vue.ts:175
-msgid "Zettelkasten"
-msgstr "Zettelkasten"
+#: source/tmp/win-update/App.vue.ts:36
+msgid "No update available. You have the most recent version."
+msgstr "不需要更新，已經是最新版本了。"
 
-#: source/tmp/win-preferences/App.vue.ts:185
-msgid "Import and Export"
-msgstr "匯入與匯出"
+#: source/tmp/win-update/App.vue.ts:42
+msgid "Click to start update"
+msgstr "點選此處開始更新"
 
-#: source/tmp/win-preferences/App.vue.ts:190
-msgid "Advanced"
-msgstr "進階"
+#: source/tmp/win-update/App.vue.ts:45
+msgid "never"
+msgstr "從未"
 
-#: source/tmp/win-preferences/App.vue.ts:199
+#: source/tmp/win-update/App.vue.ts:45 source/tmp/win-update/App.vue.ts:48
 #, javascript-format
-msgid "Searching: %s"
-msgstr "搜尋中：%s"
-
-#: source/tmp/win-preferences/App.vue.ts:203
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:28
-msgid "January"
-msgstr "一月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:29
-msgid "February"
-msgstr "二月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:30
-msgid "March"
-msgstr "三月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:31
-msgid "April"
-msgstr "四月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:32
-msgid "May"
-msgstr "五月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:33
-msgid "June"
-msgstr "六月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:34
-msgid "July"
-msgstr "七月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:35
-msgid "August"
-msgstr "八月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:36
-msgid "September"
-msgstr "九月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:37
-msgid "October"
-msgstr "十月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:38
-msgid "November"
-msgstr "十一月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:39
-msgid "December"
-msgstr "十二月"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:41
-msgid "Below the monthly average"
-msgstr "低於月平均"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:42
-msgid "Over the monthly average"
-msgstr "超過月平均"
-
-#: source/tmp/win-stats/CalendarView.vue.ts:43
-msgid "More than twice the monthly average"
-msgstr "月平均兩倍以上"
-
-#. Static properties
-#: source/tmp/win-stats/App.vue.ts:33 source/tmp/win-stats/ChartView.vue.ts:39
-msgid "Charts"
-msgstr "圖表"
-
-#: source/tmp/win-stats/App.vue.ts:39
-msgid "FSAL Stats"
-msgstr "FSAL 統計"
-
-#: source/tmp/win-stats/App.vue.ts:58
-msgid "Writing statistics"
-msgstr "寫作統計"
-
-#: source/win-preferences/schema/zettelkasten.ts:23
-msgid "Zettelkasten IDs"
-msgstr "Zettelkasten IDs"
-
-#: source/win-preferences/schema/zettelkasten.ts:29
-msgid "Pattern for Zettelkasten IDs"
-msgstr "Zettelkasten IDs 的模式"
-
-#: source/win-preferences/schema/zettelkasten.ts:30
-msgid "Uses ECMAScript regular expressions"
-msgstr "使用 ECMAScript 正規表達式"
-
-#: source/win-preferences/schema/zettelkasten.ts:36
-msgid "Pattern used to generate new IDs"
-msgstr "用於產生新 ID 的模式"
-
-#: source/win-preferences/schema/zettelkasten.ts:39
-#, javascript-format
-msgid "Available Variables: %s"
-msgstr "可用變數：%s"
-
-#: source/win-preferences/schema/zettelkasten.ts:44
-#: source/win-preferences/schema/import-export.ts:77
-msgid "Internal links"
-msgstr "內部連結"
-
-#: source/win-preferences/schema/zettelkasten.ts:50
-msgid "Link with filename only"
-msgstr "僅使用檔案名稱連結"
-
-#: source/win-preferences/schema/zettelkasten.ts:55
-msgid "When linking files, add the document name …"
-msgstr "連結檔案時，加入文件名稱…"
-
-#: source/win-preferences/schema/zettelkasten.ts:58
-msgid "Always"
-msgstr "總是"
-
-#: source/win-preferences/schema/zettelkasten.ts:59
-msgid "Only when linking using the ID"
-msgstr "僅在使用 ID 連結時"
-
-#: source/win-preferences/schema/zettelkasten.ts:60
-msgid "Never"
-msgstr "從不"
-
-#: source/win-preferences/schema/zettelkasten.ts:68
-msgid "Link format"
-msgstr "連結格式"
-
-#: source/win-preferences/schema/zettelkasten.ts:73
-msgid ""
-"Internal links allow you to add an optional title, separated by a vertical "
-"bar character from the actual link target. Here you can define the ordering "
-"of the two."
-msgstr ""
-"內部連結允許您新增一個非必要的標題，並用垂直條分隔符號與實際連結目標分開。在"
-"這裡您可以定義兩者的順序。"
-
-#: source/win-preferences/schema/zettelkasten.ts:79
-msgid "[[Link|Title]]: Link first (recommended)"
-msgstr "[[連結|標題]]：連結優先（推薦）"
-
-#: source/win-preferences/schema/zettelkasten.ts:80
-msgid "[[Title|Link]]: Title first"
-msgstr "[[標題|連結]]：標題優先"
-
-#: source/win-preferences/schema/zettelkasten.ts:88
-msgid "Start a full-text search when following internal links"
-msgstr "追蹤內部連結時啟動全文搜尋"
-
-#: source/win-preferences/schema/zettelkasten.ts:89
-msgid "The search string will match the content between the brackets: [[ ]]."
-msgstr "搜尋字串將對應括號中的內容：[[ ]]。"
-
-#: source/win-preferences/schema/zettelkasten.ts:96
-msgid ""
-"Automatically create non-existing files in this folder when following "
-"internal links"
-msgstr "追蹤內部連結時，自動在此資料夾中建立不存在的檔案"
-
-#: source/win-preferences/schema/zettelkasten.ts:101
-msgid "For this to work, the folder must be open as a Workspace in Zettlr."
-msgstr "要使其生效，資料夾必須以工作區的形式在 Zettlr 中開啟。"
-
-#: source/win-preferences/schema/zettelkasten.ts:106
-msgid "Path to folder"
-msgstr "資料夾路徑"
-
-#: source/win-preferences/schema/autocorrect.ts:32
-msgid "Smart quotes"
-msgstr "智慧引號"
-
-#: source/win-preferences/schema/autocorrect.ts:45
-msgid "Double Quotes"
-msgstr "雙引號"
-
-#: source/win-preferences/schema/autocorrect.ts:48
-#: source/win-preferences/schema/autocorrect.ts:70
-msgid "Disable Magic Quotes"
-msgstr "停用 Magic Quotes"
-
-#: source/win-preferences/schema/autocorrect.ts:67
-msgid "Single Quotes"
-msgstr "單引號"
-
-#: source/win-preferences/schema/autocorrect.ts:95
-msgid "Text-replacement patterns"
-msgstr "文字取代模式"
-
-#: source/win-preferences/schema/autocorrect.ts:99
-msgid "Match whole words"
-msgstr "符合整個單字"
-
-#: source/win-preferences/schema/autocorrect.ts:100
-msgid "When checked, AutoCorrect will never replace parts of words"
-msgstr "勾選時，自動更正將不會取代單字的一部分"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "Replace"
-msgstr "取代"
-
-#: source/win-preferences/schema/autocorrect.ts:107
-msgid "With"
-msgstr "取代為"
-
-#: source/win-preferences/schema/autocorrect.ts:112
-#: source/win-preferences/schema/spellchecking.ts:173
-#: source/win-preferences/schema/advanced.ts:115
-msgid "Filter"
-msgstr "篩選"
-
-#: source/win-preferences/schema/editor.ts:23
-msgid "Input mode"
-msgstr "輸入模式"
-
-#: source/win-preferences/schema/editor.ts:39
-msgid ""
-"The input mode determines how you interact with the editor. We recommend "
-"keeping this setting at \"Normal\". Only choose \"Vim\" or \"Emacs\" if you "
-"know what this implies."
-msgstr ""
-"輸入模式決定您如何與編輯器互動。我們建議將此設定保持在「普通」模式。只有在您"
-"了解其含義時才選擇「Vim」或「Emacs」。"
-
-#: source/win-preferences/schema/editor.ts:44
-msgid "Writing direction"
-msgstr "書寫方向"
-
-#: source/win-preferences/schema/editor.ts:57
-msgid "Markdown rendering"
-msgstr "Markdown 繪製"
-
-#: source/win-preferences/schema/editor.ts:64
-msgid ""
-"Check to enable live rendering of various Markdown elements to formatted "
-"appearance. This hides formatting characters (such as **text**) or renders "
-"images instead of their link."
-msgstr ""
-"勾選以啟用各種 Markdown 元素的即時繪製為格式化外觀。這會隱藏格式字元（例如 **"
-"文字**）或繪製圖片而非其連結。"
-
-#: source/win-preferences/schema/editor.ts:72
-msgid "Render citations"
-msgstr "繪製引文"
-
-#: source/win-preferences/schema/editor.ts:77
-msgid "Render iframes"
-msgstr "繪製 iframe"
-
-#: source/win-preferences/schema/editor.ts:82
-msgid "Render images"
-msgstr "繪製圖片"
-
-#: source/win-preferences/schema/editor.ts:87
-msgid "Render links"
-msgstr "繪製連結"
-
-#: source/win-preferences/schema/editor.ts:92
-msgid "Render formulae"
-msgstr "繪製方程式"
-
-#: source/win-preferences/schema/editor.ts:97
-msgid "Render tasks"
-msgstr "繪製任務"
-
-#: source/win-preferences/schema/editor.ts:102
-msgid "Hide heading characters"
-msgstr "隱藏標題字元"
-
-#: source/win-preferences/schema/editor.ts:107
-msgid "Render emphasis"
-msgstr "繪製強調部份"
-
-#: source/win-preferences/schema/editor.ts:116
-msgid "Formatting characters for bold and italics"
-msgstr "粗體和斜體的格式字元"
-
-#: source/win-preferences/schema/editor.ts:143
-msgid "Check Markdown for style issues"
-msgstr "檢查 Markdown 的樣式問題"
-
-#: source/win-preferences/schema/editor.ts:149
-msgid "Table Editor"
-msgstr "表格編輯器"
-
-#: source/win-preferences/schema/editor.ts:160
-msgid ""
-"The Table Editor is an interactive interface that simplifies creation and "
-"editing of tables. It provides buttons for common functionality, and takes "
-"care of Markdown formatting."
-msgstr ""
-"表格編輯器是一個互動介面，簡化了表格的建立和編輯。它提供了常用功能的按鈕，並"
-"處理 Markdown 格式。"
-
-#: source/win-preferences/schema/editor.ts:171
-msgid "Mute non-focused lines in distraction-free mode"
-msgstr "在專注模式時，讓周遭的文字顏色變淺"
-
-#: source/win-preferences/schema/editor.ts:176
-msgid "Hide toolbar in distraction-free mode"
-msgstr "在專注模式時隱藏工具列"
-
-#: source/win-preferences/schema/editor.ts:182
-msgid "Word counter"
-msgstr "字數統計"
-
-#: source/win-preferences/schema/editor.ts:189
-msgid "Count characters instead of words (e.g., for Chinese)"
-msgstr "統計字元數，而非字數（例如中文）"
-
-#: source/win-preferences/schema/editor.ts:195
-msgid "Readability mode"
-msgstr "可讀性模式"
-
-#: source/win-preferences/schema/editor.ts:202
-msgid "Algorithm"
-msgstr "演算法"
-
-#: source/win-preferences/schema/editor.ts:220
-msgid "Maximum width of images (%s %)"
-msgstr "最大圖片寬度（%s %）"
-
-#: source/win-preferences/schema/editor.ts:227
-msgid "Maximum height of images (%s %)"
-msgstr "最大圖片高度（%s %）"
-
-#: source/win-preferences/schema/editor.ts:235
-msgid "Other settings"
-msgstr "其他設定"
-
-#: source/win-preferences/schema/editor.ts:241
-msgid "Font size"
-msgstr "字型大小"
-
-#: source/win-preferences/schema/editor.ts:248
-msgid "Indentation size (number of spaces)"
-msgstr "縮排時使用幾個空格"
-
-#: source/win-preferences/schema/editor.ts:255
-msgid "Indent using tabs instead of spaces"
-msgstr "使用 Tab 縮排而非空格"
-
-#: source/win-preferences/schema/editor.ts:261
-msgid "Show formatting toolbar when text is selected"
-msgstr "當選取文字時顯示格式工作列"
-
-#: source/win-preferences/schema/editor.ts:266
-msgid "Highlight whitespace"
-msgstr "醒目顯示空白"
-
-#: source/win-preferences/schema/editor.ts:272
-msgid "Suggest emojis during autocompletion"
-msgstr "自動完成（AutoComplete）時建議表情符號"
-
-#: source/win-preferences/schema/editor.ts:277
-msgid "Show link previews"
-msgstr "顯示連結預覽"
-
-#: source/win-preferences/schema/editor.ts:283
-msgid "Automatically close matching character pairs"
-msgstr "括號自動配對"
-
-#: source/win-preferences/schema/appearance.ts:37
-msgid "Schedule"
-msgstr "排程"
-
-#: source/win-preferences/schema/appearance.ts:41
-#: source/win-preferences/schema/general.ts:47
-msgid "Off"
-msgstr "關閉"
-
-#: source/win-preferences/schema/appearance.ts:42
-msgid "Follow system"
-msgstr "依照系統設定"
-
-#: source/win-preferences/schema/appearance.ts:43
-msgid "On"
-msgstr "開啟"
-
-#: source/win-preferences/schema/appearance.ts:59
-msgid "End"
-msgstr "結束"
-
-#: source/win-preferences/schema/appearance.ts:69
-msgid "Theme"
-msgstr "主題"
-
-#: source/win-preferences/schema/appearance.ts:117
-msgid "Toolbar options"
-msgstr "工具列選項"
-
-#: source/win-preferences/schema/appearance.ts:124
-msgid "Left section"
-msgstr "左側區塊"
-
-#: source/win-preferences/schema/appearance.ts:128
-msgid "Display \"Open settings\" button"
-msgstr "顯示「開啟設定」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:133
-msgid "Display \"New file\" button"
-msgstr "顯示「新增檔案」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:138
-msgid "Display \"Previous file\" button"
-msgstr "顯示「上一個檔案」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:143
-msgid "Display \"Next file\" button"
-msgstr "顯示「下一個檔案」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:150
-msgid "Center section"
-msgstr "中間區塊"
-
-#: source/win-preferences/schema/appearance.ts:154
-msgid "Display \"Readability mode\" button"
-msgstr "顯示「可讀性」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:159
-msgid "Display \"Insert comment\" button"
-msgstr "顯示「插入註解」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:164
-msgid "Display \"Insert link\" button"
-msgstr "顯示「插入連結」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:169
-msgid "Display \"Insert image\" button"
-msgstr "顯示「插入圖片」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:174
-msgid "Display \"Insert task list\" button"
-msgstr "顯示「插入任務清單」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:179
-msgid "Display \"Insert table\" button"
-msgstr "顯示「插入表格」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:184
-msgid "Display \"Insert footnote\" button"
-msgstr "顯示「插入註腳」按鈕"
-
-#: source/win-preferences/schema/appearance.ts:191
-msgid "Right section"
-msgstr "右側區塊"
-
-#: source/win-preferences/schema/appearance.ts:195
-msgid "Display word/character counter"
-msgstr "顯示字數/字元統計"
-
-#: source/win-preferences/schema/appearance.ts:200
-msgid "Display Pomodoro timer"
-msgstr "顯示番茄鐘計時器"
-
-#: source/win-preferences/schema/appearance.ts:206
-msgid "Status bar"
-msgstr "狀態列"
-
-#: source/win-preferences/schema/appearance.ts:212
-msgid "Show status bar"
-msgstr "顯示狀態列"
-
-#: source/win-preferences/schema/appearance.ts:223
-msgid "Open CSS editor"
-msgstr "開啟 CSS 編輯器"
-
-#: source/win-preferences/schema/spellchecking.ts:24
-msgid "LanguageTool"
-msgstr "LanguageTool"
-
-#: source/win-preferences/schema/spellchecking.ts:34
-msgid "Strictness"
-msgstr "嚴格程度"
-
-#: source/win-preferences/schema/spellchecking.ts:37
-msgid "Standard"
-msgstr "標準"
-
-#: source/win-preferences/schema/spellchecking.ts:38
-msgid "Picky"
-msgstr "挑剔"
-
-#: source/win-preferences/schema/spellchecking.ts:47
-msgid "Mother language"
-msgstr "母語"
-
-#: source/win-preferences/schema/spellchecking.ts:53
-msgid "Not set"
-msgstr "未設定"
-
-#: source/win-preferences/schema/spellchecking.ts:61
-msgid "Preferred Variants"
-msgstr "偏好變體"
-
-#: source/win-preferences/schema/spellchecking.ts:66
-msgid ""
-"LanguageTool cannot distinguish certain language's variants. These settings "
-"will nudge LanguageTool to auto-detect your preferred variant of these "
-"languages."
-msgstr ""
-"LanguageTool 無法區分某些語言的變體。這些設定將促使 LanguageTool 自動偵測您偏"
-"好的語言變體。"
-
-#: source/win-preferences/schema/spellchecking.ts:71
-msgid "Interpret English as"
-msgstr "將英語解釋為"
-
-#: source/win-preferences/schema/spellchecking.ts:84
-msgid "Interpret German as"
-msgstr "將德語解釋為"
-
-#: source/win-preferences/schema/spellchecking.ts:94
-msgid "Interpret Portuguese as"
-msgstr "將葡萄牙語解釋為"
-
-#: source/win-preferences/schema/spellchecking.ts:105
-msgid "Interpret Catalan as"
-msgstr "將加泰羅尼亞語解釋為"
-
-#: source/win-preferences/schema/spellchecking.ts:114
-msgid "LanguageTool Provider"
-msgstr "LanguageTool 提供者"
-
-#: source/win-preferences/schema/spellchecking.ts:118
-msgid "Custom server"
-msgstr "自訂伺服器"
-
-#: source/win-preferences/schema/spellchecking.ts:125
-msgid "Custom server address"
-msgstr "自訂伺服器位址"
-
-#: source/win-preferences/schema/spellchecking.ts:134
-msgid "LanguageTool Premium"
-msgstr "LanguageTool 進階版"
-
-#: source/win-preferences/schema/spellchecking.ts:139
-msgid ""
-"Zettlr will ignore the \"LanguageTool provider\" settings if you enter any "
-"credentials here."
-msgstr "如果您在此輸入任何憑證，Zettlr 將忽略「LanguageTool 提供者」設定。"
-
-#: source/win-preferences/schema/spellchecking.ts:143
-msgid "LanguageTool Username"
-msgstr "LanguageTool 使用者名稱"
-
-#: source/win-preferences/schema/spellchecking.ts:150
-msgid "LanguageTool API key"
-msgstr "LanguageTool API 金鑰"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Active"
-msgstr "啟用"
-
-#: source/win-preferences/schema/spellchecking.ts:167
-msgid "Language"
-msgstr "語言"
-
-#: source/win-preferences/schema/spellchecking.ts:168
-msgid ""
-"Select the languages for which you want to enable automatic spell checking."
-msgstr "選擇您要啟用自動拼字檢查的語言。"
-
-#: source/win-preferences/schema/spellchecking.ts:180
-msgid "User dictionary. Remove words by clicking them."
-msgstr "使用者字典。點選單字以移除。"
-
-#: source/win-preferences/schema/spellchecking.ts:182
-msgid "Dictionary entry"
-msgstr "字典條目"
-
-#: source/win-preferences/schema/spellchecking.ts:185
-msgid "Search for entries …"
-msgstr "搜尋條目…"
-
-#: source/win-preferences/schema/file-manager.ts:23
-msgid "Display mode"
-msgstr "顯示模式"
-
-#: source/win-preferences/schema/file-manager.ts:32
-msgid "Thin"
-msgstr "精簡"
-
-#: source/win-preferences/schema/file-manager.ts:33
-msgid "Expanded"
-msgstr "展開"
-
-#: source/win-preferences/schema/file-manager.ts:34
-msgid "Combined"
-msgstr "合併"
-
-#: source/win-preferences/schema/file-manager.ts:40
-msgid ""
-"The Thin mode shows your directories and files separately. Select a "
-"directory to have its contents displayed in the file list. Switch between "
-"file list and directory tree by clicking on directories or the arrow button "
-"which appears at the top left corner of the file list."
-msgstr ""
-"精簡模式會將您的目錄和檔案分開顯示。選擇目錄即可在檔案清單中顯示其內容。您可"
-"以透過點選目錄或檔案清單左上角的箭頭按鈕，在檔案清單和目錄樹狀結構之間切換。"
-
-#: source/win-preferences/schema/file-manager.ts:45
-msgid "Show file information"
-msgstr "顯示檔案資訊"
-
-#: source/win-preferences/schema/file-manager.ts:50
-msgid "Show folders above files"
-msgstr "在檔案上方顯示資料夾"
-
-#: source/win-preferences/schema/file-manager.ts:56
-msgid "Markdown document name display"
-msgstr "Markdown 文件名稱顯示"
-
-#: source/win-preferences/schema/file-manager.ts:64
-msgid "Filename only"
-msgstr "僅檔案名稱"
-
-#: source/win-preferences/schema/file-manager.ts:65
-msgid "Title if applicable"
-msgstr "標題（如果適用）"
-
-#: source/win-preferences/schema/file-manager.ts:66
-msgid "First heading level 1 if applicable"
-msgstr "第一個一級標題（如果適用）"
-
-#: source/win-preferences/schema/file-manager.ts:67
-msgid "Title or first heading level 1 if applicable"
-msgstr "標題或第一個一級標題（如果適用）"
-
-#: source/win-preferences/schema/file-manager.ts:73
-msgid "Display Markdown file extensions"
-msgstr "顯示 Markdown 檔案的副檔名"
-
-#: source/win-preferences/schema/file-manager.ts:80
-msgid "Time display"
-msgstr "時間顯示"
-
-#: source/win-preferences/schema/file-manager.ts:88
-msgid "Last modification time"
-msgstr "最後修改時間"
-
-#: source/win-preferences/schema/file-manager.ts:89
-msgid "File creation time"
-msgstr "檔案建立時間"
-
-#: source/win-preferences/schema/file-manager.ts:95
-msgid "Sorting"
-msgstr "排序"
-
-#: source/win-preferences/schema/file-manager.ts:101
-msgid "When sorting documents…"
-msgstr "排序文件時…"
-
-#: source/win-preferences/schema/file-manager.ts:104
-msgid "Use natural order (2 comes before 10)"
-msgstr "使用自然順序（2 在 10 之前）"
-
-#: source/win-preferences/schema/file-manager.ts:105
-msgid "Use ASCII order (2 comes after 10)"
-msgstr "使用 ASCII 順序（2 在 10 之後）"
-
-#: source/win-preferences/schema/import-export.ts:24
-msgid "Import and export profiles"
-msgstr "匯入和匯出設定檔"
-
-#: source/win-preferences/schema/import-export.ts:30
-msgid "Open import profiles editor"
-msgstr "開啟匯入設定檔編輯器"
-
-#: source/win-preferences/schema/import-export.ts:44
-msgid "Open export profiles editor"
-msgstr "開啟匯出設定檔編輯器"
-
-#: source/win-preferences/schema/import-export.ts:59
-msgid "Export settings"
-msgstr "匯出設定"
-
-#. TODO: Must be radio; second option "Use system-wide Pandoc for exports"
-#: source/win-preferences/schema/import-export.ts:65
-msgid "Use Zettlr's internal Pandoc for exports"
-msgstr "使用 Zettlr 的內部 Pandoc 進行匯出"
-
-#: source/win-preferences/schema/import-export.ts:71
-msgid "Remove tags from files when exporting"
-msgstr "匯出時從檔案中移除標籤"
-
-#: source/win-preferences/schema/import-export.ts:80
-msgid "Remove internal links completely"
-msgstr "徹底移除內部連結"
-
-#: source/win-preferences/schema/import-export.ts:81
-msgid "Unlink internal links"
-msgstr "取消內部連結"
-
-#: source/win-preferences/schema/import-export.ts:82
-msgid "Don't touch internal links"
-msgstr "不要改變內部連結"
-
-#: source/win-preferences/schema/import-export.ts:88
-msgid "Destination folder for exported files"
-msgstr "匯出檔案的目的地資料夾"
-
-#. TODO: Add info-strings
-#: source/win-preferences/schema/import-export.ts:92
-msgid "Temporary folder"
-msgstr "暫存資料夾"
-
-#: source/win-preferences/schema/import-export.ts:93
-msgid "Same as file location"
-msgstr "與檔案位置相同"
-
-#: source/win-preferences/schema/import-export.ts:94
-msgid "Ask for folder when exporting"
-msgstr "匯出時詢問資料夾"
-
-#: source/win-preferences/schema/import-export.ts:100
-msgid ""
-"Warning! Files in the temporary folder are regularly deleted. Choosing the "
-"same location as the file overwrites files with identical filenames if they "
-"already exist."
-msgstr ""
-"警告！暫存資料夾中的檔案會定期刪除。選擇與檔案相同的位置會覆蓋已存在的同名檔"
-"案。"
-
-#: source/win-preferences/schema/import-export.ts:105
-msgid "Custom export commands"
-msgstr "自訂匯出命令"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Display name"
-msgstr "顯示名稱"
-
-#: source/win-preferences/schema/import-export.ts:113
-msgid "Command"
-msgstr "命令"
-
-#: source/win-preferences/schema/import-export.ts:114
-msgid ""
-"Enter custom commands to run the exporter with. Each command receives as its "
-"first argument the file or project folder to be exported."
-msgstr ""
-"輸入自訂命令以執行匯出器。每個命令的第一個參數是要匯出的檔案或專案資料夾。"
-
-#: source/win-preferences/schema/advanced.ts:30
-msgid "Pattern for new file names"
-msgstr "新檔案名稱的模式"
-
-#: source/win-preferences/schema/advanced.ts:36
-msgid "Define a pattern for new file names"
-msgstr "定義新檔案名稱的模式"
-
-#: source/win-preferences/schema/advanced.ts:38
-#, javascript-format
-msgid "Available variables: %s"
-msgstr "可用變數：%s"
-
-#: source/win-preferences/schema/advanced.ts:44
-msgid "Do not prompt for filename when creating new files"
-msgstr "建立新檔案時不提示檔名"
-
-#: source/win-preferences/schema/advanced.ts:57
-msgid "Use native window appearance"
-msgstr "使用原生視窗外觀"
-
-#: source/win-preferences/schema/advanced.ts:58
-msgid "Only available on Linux; this is the default for macOS and Windows."
-msgstr "僅適用於 Linux；這是 macOS 和 Windows 的預設值。"
-
-#: source/win-preferences/schema/advanced.ts:64
-msgid "Enable window vibrancy"
-msgstr "啟用視窗透明效果"
-
-#: source/win-preferences/schema/advanced.ts:65
-msgid "Only available on macOS; makes the window background opaque."
-msgstr "僅適用於 macOS；使視窗背景不透明。"
-
-#: source/win-preferences/schema/advanced.ts:72
-msgid "Show app in the notification area"
-msgstr "在通知區顯示 Zettlr"
-
-#: source/win-preferences/schema/advanced.ts:73
-msgid "Leave app running in the notification area"
-msgstr "讓 Zettlr 在通知區繼續執行"
-
-#: source/win-preferences/schema/advanced.ts:82
-msgid "Zoom behavior"
-msgstr "縮放行為"
-
-#: source/win-preferences/schema/advanced.ts:85
-msgid "Resizes the whole GUI"
-msgstr "調整整個使用者介面的大小"
-
-#: source/win-preferences/schema/advanced.ts:86
-msgid "Changes the editor font size"
-msgstr "更改編輯器字型大小"
-
-#: source/win-preferences/schema/advanced.ts:92
-msgid "Attachments sidebar"
-msgstr "附件側邊欄"
-
-#: source/win-preferences/schema/advanced.ts:98
-msgid "File extensions to be visible in the Attachments sidebar"
-msgstr "在附件側邊欄中可見的檔案副檔名"
-
-#: source/win-preferences/schema/advanced.ts:104
-msgid "Iframe rendering whitelist"
-msgstr "Iframe 顯示白名單"
-
-#: source/win-preferences/schema/advanced.ts:113
-msgid "Hostname"
-msgstr "主機名"
-
-#: source/win-preferences/schema/advanced.ts:120
-msgid "Watchdog polling"
-msgstr "看門狗輪詢"
-
-#: source/win-preferences/schema/advanced.ts:126
-msgid "Activate watchdog polling"
-msgstr "啟用看門狗輪詢"
-
-#: source/win-preferences/schema/advanced.ts:131
-msgid "Time to wait before writing a file is considered done (in ms)"
-msgstr "判斷一個檔案寫入完成前的等待時間（毫秒）"
-
-#: source/win-preferences/schema/advanced.ts:138
-msgid "Deleting items"
-msgstr "刪除項目"
-
-#: source/win-preferences/schema/advanced.ts:144
-msgid "Delete items irreversibly if moving them to trash fails"
-msgstr "如果移動到垃圾桶失敗，就直接刪除檔案"
-
-#: source/win-preferences/schema/advanced.ts:150
-msgid "Debug mode"
-msgstr "除錯模式"
-
-#: source/win-preferences/schema/advanced.ts:156
-msgid "Enable debug mode"
-msgstr "啟用除錯模式"
-
-#: source/win-preferences/schema/advanced.ts:163
-msgid "Beta releases"
-msgstr "Beta 版本"
-
-#: source/win-preferences/schema/advanced.ts:169
-msgid "Notify me about beta releases"
-msgstr "當有新 Beta 版本發布時通知我"
-
-#: source/win-preferences/schema/snippets.ts:30
-msgid "Open snippets editor"
-msgstr "開啟小片段編輯器"
-
-#: source/win-preferences/schema/general.ts:22
-msgid "Application language"
-msgstr "應用程式語言"
-
-#: source/win-preferences/schema/general.ts:33
-msgid "Autosave"
-msgstr "自動存檔"
-
-#: source/win-preferences/schema/general.ts:43
-msgid "Save modifications"
-msgstr "儲存修改"
-
-#: source/win-preferences/schema/general.ts:48
-msgid "Immediately"
-msgstr "立即"
-
-#: source/win-preferences/schema/general.ts:49
-msgid "After a short delay"
-msgstr "短暫延遲後"
-
-#: source/win-preferences/schema/general.ts:55
-msgid "Default image folder"
-msgstr "預設圖片資料夾"
-
-#: source/win-preferences/schema/general.ts:67
-msgid ""
-"Click \"Select folder…\" or type an absolute or relative path directly into "
-"the input field."
-msgstr "點選「選擇資料夾…」或直接在輸入欄中輸入絕對或相對路徑。"
-
-#: source/win-preferences/schema/general.ts:72
-msgid "Behavior"
-msgstr "行為"
-
-#: source/win-preferences/schema/general.ts:83
-msgid "Avoid opening files in new tabs if possible"
-msgstr "盡量避免在新分頁中開啟檔案"
-
-#: source/win-preferences/schema/general.ts:89
-msgid "Updates"
-msgstr "更新"
-
-#: source/win-preferences/schema/general.ts:95
-msgid "Automatically check for updates"
-msgstr "自動檢查更新"
-
-#: source/win-preferences/schema/citations.ts:28
-msgid "How would you like autocomplete to insert your citations?"
-msgstr "您希望「自動完成」功能如何插入引文？"
-
-#: source/win-preferences/schema/citations.ts:39
-msgid "Citation database (CSL JSON or BibTex)"
-msgstr "引用資料庫（CSL JSON 或 BibTex 格式）"
-
-#: source/win-preferences/schema/citations.ts:41
-#: source/win-preferences/schema/citations.ts:53
-msgid "Path to file"
-msgstr "檔案路徑"
-
-#: source/win-preferences/schema/citations.ts:51
-msgid "CSL style (optional)"
-msgstr "CSL 樣式（選擇性的）"
+msgid "Last checked: %s"
+msgstr "上次檢查：%s"
+
+#: source/tmp/win-update/App.vue.ts:124
+msgid "Starting update …"
+msgstr "正在開始更新…"
 
 #~ msgid "Open Link"
 #~ msgstr "開啟連結"


### PR DESCRIPTION
Implements: [#5584](https://github.com/Zettlr/Zettlr/issues/5584) — Restrict Graph View by Workspace

What’s New?
A dropdown UI is added to the Graph View toolbar to select a folder from the current workspace.

Selecting a folder will filter the graph to show only nodes and connections from that directory.

Selecting "All folders" resets the graph to its original state (showing all files).

The view updates reactively — any folder change triggers a rebuild of the graph via the buildGraph() function.

Why is this useful?
As described in the issue, users working on multiple writing projects or using Zettlr for Zettelkasten-style note-taking often organise notes into folders. This feature enables users to:

Focus the graph on just one writing project or context.
Reduce visual noise from unrelated notes.
Maintain better clarity across diverse folders within the workspace.

UI Design Reference:
The feature follows the UX pattern of the Global Search > Restrict to directory dropdown for consistency and ease of use.

Caveats:
This implementation focuses strictly on folder-based filtering. Future enhancements like filtering by search results or multi-select items in the file tree can be considered as separate features.