### PR TITLE
fix: toSentenceCase no longer skips the first word

### DIFF
--- a/source/common/modules/markdown-editor/commands/transforms/to-sentence-case.ts
+++ b/source/common/modules/markdown-editor/commands/transforms/to-sentence-case.ts
@@ -51,7 +51,7 @@ export const toSentenceCase =
             if (character.index === 0) {
               theWord += character.segment.toLocaleUpperCase(locale)
             } else {
-              theWord += character.segment
+              theWord += character.segment.toLocaleLowerCase(locale)
             }
           }
 

--- a/test/transform-selected-text/to-sentence-case.spec.ts
+++ b/test/transform-selected-text/to-sentence-case.spec.ts
@@ -29,6 +29,11 @@ describe('MarkdownEditor#toSentenceCase()', function () {
       expectedOutput: 'A',
       expectedLengthAfterStripping: 1
     },
+    {
+      input: 'WRITE ONE SAMPLE SENTENCE TO EXEMPLIFY THIS.',
+      expectedOutput: 'Write one sample sentence to exemplify this.',
+      expectedLengthAfterStripping: 44
+    },
   ]
 
   sunnyDayTestCases.forEach((testCase) => {


### PR DESCRIPTION
## Description
Given a sentence where the first word was ALL_CAPS, the `toSentenceCase` function would transform the other, subsequent, words in the sentence to sentence case... but it'd essentially skip casing the first word.

Bug was spotted by @nathanlesage and [described here](https://github.com/Zettlr/Zettlr/issues/5659#issuecomment-3131843870).

## Changes
This fix adds a test case to flush out the bug and then fixes the bug in the implementation code.

## Demonstration

https://github.com/user-attachments/assets/16222c49-6273-4e24-88db-bca15583e2ec




## Additional information
Tested on: Windows 11 Home.
