### PR TITLE
feat: Allow global search to be cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ so long to fix all of these issues at once!
   against data loss, and more ergonomic usage.
 - Fixed inline math not rendering when transforming Markdown to HTML (e.g., in
   footnotes).
+- **Feature**: Full-text (aka. global) search runs can now be cancelled via a
+  dedicated button. You can now also trigger a new search while another search
+  is already running.
 
 ## Under the Hood
 

--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -29,7 +29,7 @@
         v-on:click="startSearch()"
       ></ButtonControl>
       <ButtonControl
-        label="Cancel"
+        v-bind:label="cancelButtonLabel"
         v-bind:inline="true"
         v-bind:disabled="!searchIsRunning"
         v-on:click="cancelSearch()"
@@ -167,6 +167,7 @@ const filterLabel = trans('Filter search results')
 const restrictDirLabel = trans('Restrict search to directory')
 const restrictDirPlaceholder = trans('Choose directory…')
 const searchButtonLabel = trans('Search')
+const cancelButtonLabel = trans('Cancel')
 const clearButtonLabel = trans('Clear search')
 const toggleButtonLabel = trans('Toggle results')
 

--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -25,8 +25,14 @@
       <ButtonControl
         v-bind:label="searchButtonLabel"
         v-bind:inline="true"
-        v-bind:disabled="filesToSearch.length > 0"
+        v-bind:disabled="false"
         v-on:click="startSearch()"
+      ></ButtonControl>
+      <ButtonControl
+        label="Cancel"
+        v-bind:inline="true"
+        v-bind:disabled="!searchIsRunning"
+        v-on:click="cancelSearch()"
       ></ButtonControl>
     </p>
     <!-- ... as well as two buttons to clear the results or toggle them. -->
@@ -61,7 +67,7 @@
           v-bind:max="sumFilesToSearch"
           v-bind:value="sumFilesToSearch - filesToSearch.length"
           v-bind:interruptible="true"
-          v-on:interrupt="filesToSearch = []"
+          v-on:interrupt="cancelSearch()"
         ></ProgressControl>
       </div>
       <hr>
@@ -268,6 +274,9 @@ const filteredSearchResults = computed<SearchResultWrapper[]>(() => {
   })
 })
 
+const searchIsRunning = computed(() => { return filesToSearch.value.length > 0 })
+const shouldStartNewSearch = ref<boolean>(false)
+
 watch(fileTree, () => {
   recomputeDirectorySuggestions()
 })
@@ -297,14 +306,14 @@ function recomputeDirectorySuggestions (): void {
 }
 
 function startSearch (overrideQuery?: string): void {
-  if (filesToSearch.value.length > 0) {
-    console.warn('Global search in progress: Not starting a new one.')
-    return
-  }
-
   // This allows other components to inject a new query when starting a search
   if (overrideQuery !== undefined) {
     query.value = overrideQuery
+  }
+
+  if (searchIsRunning.value) {
+    cancelSearch(true)
+    return
   }
 
   // We should start a search. We need two types of information for that:
@@ -429,8 +438,17 @@ async function singleSearchRun (): Promise<void> {
   finaliseSearch()
 }
 
+function cancelSearch (startNewSearch: boolean = false): void {
+  filesToSearch.value = []
+  shouldStartNewSearch.value = startNewSearch
+}
+
 function finaliseSearch (): void {
   filesToSearch.value = [] // Reset, in case the search was aborted.
+  if (shouldStartNewSearch.value) {
+    shouldStartNewSearch.value = false
+    startSearch()
+  }
 }
 
 function emptySearchResults (): void {


### PR DESCRIPTION
## Description
This PR adds the ability to cancel/re-trigger an already in-flight global search run.

This feature was present in the past, but got removed at some point. While I'm not sure why the removal happened, I thought of reintroducing the feature, as it might be useful in certain cases where a user wants to cancel a long running search.

## Changes
- Added a new "Cancel" button next to the "Search" button
  - It is only enabled if a search is running
  - If clicked, it will result in the current search run being cancelled
- The search button is now also enabled during an already running search
  - If clicked, it will trigger a new search run based on the current value of the search field

<!-- Please provide any testing system -->
Tested on: Ubuntu WSL, Windows 11
