### PR TITLE
fix: Make sure cursor is moved behind insertion text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ so long to fix all of these issues at once!
   dedicated button. You can now also trigger a new search while another search
   is already running.
 - Fixed WebP images not rendering from relative paths (#5181).
+- Fixed incorrect cursor position after inserting IDs (#5846)
 
 ## Under the Hood
 

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -618,12 +618,8 @@ export default class MarkdownEditor extends EventEmitter {
    * @param   {string}  text  The text to replace the selection with
    */
   replaceSelection (text: string): void {
-    const mainSel = this._instance.state.selection.main
-    const newCursorPos = mainSel.from + text.length
-    this._instance.dispatch({
-      changes: { from: mainSel.from, to: mainSel.to, insert: text },
-      selection: { anchor: newCursorPos, head: newCursorPos }
-    })
+    const transaction = this._instance.state.replaceSelection(text)
+    this._instance.dispatch(transaction)
   }
 
   /**

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -619,8 +619,10 @@ export default class MarkdownEditor extends EventEmitter {
    */
   replaceSelection (text: string): void {
     const mainSel = this._instance.state.selection.main
+    const newCursorPos = mainSel.from + text.length
     this._instance.dispatch({
-      changes: { from: mainSel.from, to: mainSel.to, insert: text }
+      changes: { from: mainSel.from, to: mainSel.to, insert: text },
+      selection: { anchor: newCursorPos, head: newCursorPos }
     })
   }
 


### PR DESCRIPTION
## Description
Problem: When inserting a ZKN ID, the cursor stays _in front_ of the inserted ID string. This disrupts the editing flow, as the user has to manually correct the cursor position before continuing to type.

This PR solves this by ensuring the cursor is always right behind the inserted ID.

## Changes
Modified the Markdown editor's custom `replaceSelection` method to also include a `selection` update (containing the new cursor location) in the transaction.

## Additional information
As far as I can tell, the `replaceSelection` method is currently only accessed when inserting IDs, or new tables. I have tested the new changes with both, and it seems to work as expected (also tested with and without having texts selected).

<!-- Please provide any testing system -->
Tested on: WSL Ubuntu
