### PR TITLE
[Feat] Clicking the diagnostic status toggles the lint panel.

### DIFF
--- a/source/common/modules/markdown-editor/statusbar/diagnostics.ts
+++ b/source/common/modules/markdown-editor/statusbar/diagnostics.ts
@@ -16,7 +16,9 @@ import { type EditorState } from '@codemirror/state'
 import { type EditorView } from '@codemirror/view'
 import { trans } from '@common/i18n-renderer'
 import { type StatusbarItem } from '.'
-import { openLintPanel, forEachDiagnostic } from '@codemirror/lint'
+import { openLintPanel, closeLintPanel, forEachDiagnostic } from '@codemirror/lint'
+
+let diagnosticsOpen = false
 
 /**
  * Displays a count of all diagnostics
@@ -45,7 +47,13 @@ export function diagnosticsStatus (state: EditorState, view: EditorView): Status
     allowHtml: true,
     title: trans('Open diagnostics panel'),
     onClick (event) {
-      openLintPanel(view)
+      if (diagnosticsOpen) {
+        closeLintPanel(view)
+        diagnosticsOpen = false
+      } else {
+        openLintPanel(view)
+        diagnosticsOpen = true
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR allows clicking the diagnostics section of the statusbar to toggle the lint panel.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Currently, clicking the diagnostics section only opens the lint panel.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
While I was exploring the app, the current functionality was confusing to me. I did not notice the (x) close button at first, so my first instinct was to click the diagnostics again to close the panel. Since it did not work, I thought I would implement it since this seemed like a natural function.
<!-- Please provide any testing system -->
Tested on: <!-- OS including version ->
macOS 15.6 