### PR TITLE
Fix for unit test errors caused by file path platform variances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ the leading period of the extension, so do not write `$FILENAME.$EXTENSION`.)
 ## Under the Hood
 
 - Update Electron to version `37.2.5`.
+- Changed unit test path handling to be normalized across platforms, mainly to handle differences with win32 platforms
 
 # 3.6.0
 

--- a/test/extract-bibtex-attachments.spec.ts
+++ b/test/extract-bibtex-attachments.spec.ts
@@ -83,9 +83,10 @@ describe('Utility#extractBibTexAttachments()', function () {
     // Normalizing the paths in the validResults object for proper comparison to the files object
     for (const key in validResults) {
       const validResultsValue = validResults[key]
+      //conditional to filter all 'false' validResults values
       if(validResultsValue){
         validResultsValue.forEach((element, index) => {
-          const normalized_path = path.normalize(element)
+          const normalized_path = path.normalize(element) //normalizing to avoid different results based on platform
           validResultsValue[index] = normalized_path
         })
       }

--- a/test/extract-bibtex-attachments.spec.ts
+++ b/test/extract-bibtex-attachments.spec.ts
@@ -16,6 +16,7 @@
 import extractBibTexAttachments from '../source/app/service-providers/citeproc/extract-bibtex-attachments'
 import assert from 'assert'
 import 'mocha'
+import path from 'path'
 
 interface BibTexAttachments {
   [citekey: string]: string[]|false
@@ -79,6 +80,16 @@ const invalidBibTexFile = `
 describe('Utility#extractBibTexAttachments()', function () {
   it('should successfully parse a valid BibTex file', function () {
     const files = extractBibTexAttachments(validBibTexFile, '')
+    // Normalizing the paths in the validResults object for proper comparison to the files object
+    for (const key in validResults) {
+      const validResultsValue = validResults[key]
+      if(validResultsValue){
+        validResultsValue.forEach((element, index) => {
+          const normalized_path = path.normalize(element)
+          validResultsValue[index] = normalized_path
+        })
+      }
+    }
     assert.deepStrictEqual(Object.keys(files), Object.keys(validResults), 'The parsed results do not contain the same keys!')
     for (const key in files) {
       assert.deepStrictEqual(files[key], validResults[key], `Key ${key} differs from the expected result!`)

--- a/test/make-valid-uri.spec.ts
+++ b/test/make-valid-uri.spec.ts
@@ -48,8 +48,13 @@ const makeUriTesters = [
 
 describe('Utility#makeValidUri()', function () {
   for (const test of makeUriTesters) {
+    // Adds a conditional to remove the extra '/' inserted for Windows, should be removed if that is ever changed.
+    let uriToTest = makeValidUri(test.input, base)
+      if(process.platform === 'win32' && test.expected.startsWith('safe-file') && !test.input.startsWith('//')) {
+        uriToTest = uriToTest.replace('/','')
+      }
     it(`Input "${test.input}" should return "${test.expected}"`, function () {
-      assert.strictEqual(makeValidUri(test.input, base), test.expected)
+      assert.strictEqual(uriToTest, test.expected)
     })
   }
 })

--- a/test/merge-events-into-tree.spec.ts
+++ b/test/merge-events-into-tree.spec.ts
@@ -19,17 +19,24 @@ import type { DirDescriptor, MDFileDescriptor } from '@dts/common/fsal'
 import type { ChangeDescriptor } from '@providers/workspaces/root'
 import _ from 'lodash'
 import { getSorter } from '@providers/fsal/util/directory-sorter'
+import path from 'path'
+
+//Define the path variables up top to avoid having to repeat fixes for platforms
+const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
+const testPathString = '/path/file.md'.replaceAll('/',PATH_SEP)
+const testPathObject = path.parse(testPathString)
+const { root, dir, base, ext } = testPathObject
 
 const infile: MDFileDescriptor = {
-  path: '/path/file.md',
-  dir: '/path',
-  name: 'file.md',
+  path: testPathString,
+  dir: dir,
+  name: base,
   root: true,
   type: 'file',
   size: 0,
   modtime: 10,
   creationtime: 10,
-  ext: '.md',
+  ext: ext,
   id: '',
   tags: [],
   links: [],
@@ -44,9 +51,9 @@ const infile: MDFileDescriptor = {
 }
 
 const outfile: MDFileDescriptor = {
-  path: '/path/file.md',
-  dir: '/path',
-  name: 'file.md',
+  path: testPathString,
+  dir: dir,
+  name: base,
   root: true,
   type: 'file',
   size: 0,
@@ -67,8 +74,8 @@ const outfile: MDFileDescriptor = {
 }
 
 const indir: DirDescriptor = {
-  path: '/path',
-  dir: '/',
+  path: dir,
+  dir: root,
   name: 'path',
   root: true,
   type: 'directory',
@@ -85,8 +92,8 @@ const indir: DirDescriptor = {
 }
 
 const outdirDescriptor: DirDescriptor = {
-  path: '/path',
-  dir: '/',
+  path: dir,
+  dir: root,
   name: 'path',
   root: true,
   type: 'directory',
@@ -103,8 +110,8 @@ const outdirDescriptor: DirDescriptor = {
 }
 
 const outdir: DirDescriptor = {
-  path: '/path',
-  dir: '/',
+  path: dir,
+  dir: root,
   name: 'path',
   root: true,
   type: 'directory',

--- a/test/merge-events-into-tree.spec.ts
+++ b/test/merge-events-into-tree.spec.ts
@@ -22,10 +22,10 @@ import { getSorter } from '@providers/fsal/util/directory-sorter'
 import path from 'path'
 
 //Define the path variables up top to avoid having to repeat fixes for platforms
-const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
-const testPathString = '/path/file.md'.replaceAll('/',PATH_SEP)
-const testPathObject = path.parse(testPathString)
-const { root, dir, base, ext } = testPathObject
+const PATH_SEP = process.platform === 'win32' ? '\\' : '/' // defines the path separator for the platform
+const testPathString = '/path/file.md'.replaceAll('/',PATH_SEP) // applies the path separator
+const testPathObject = path.parse(testPathString) //creates a path object to then destructure, using node:path
+const { root, dir, base, ext } = testPathObject // creates variables for each property, used in the Descriptor objects that follow
 
 const infile: MDFileDescriptor = {
   path: testPathString,


### PR DESCRIPTION
## Description
This PR should solve unit test errors caused by expected file path values not accounting for win32 platforms.

## Changes
Changed extractBibTexAttachments, makeValidUri, and mergeEventsIntoTree unit tests so that when they are run on win32 platforms, the expected values are adjusted to match what can be expected on win32 platforms.

## Additional information
The makeValidUri unit test is impacted by the extra '/' inserted into Windows URI paths for local files by the makeValidUri function. The fix implemented in this change addresses that by removing the extra '/'. When that extra '/' is no longer being used to make Windows URI paths for local files work, this will be unnecessary and should be removed.

Tested on: Windows 10 Home, Version 10.0.19045 Build 19045

