### PR TITLE
[Feat] Set the editor dark mode separately

### DIFF
--- a/source/app/service-providers/config/config-validation.ts
+++ b/source/app/service-providers/config/config-validation.ts
@@ -16,6 +16,7 @@ import { trans } from '@common/i18n-main'
 
 const RULES = {
   darkMode: 'required|boolean|default:false',
+  darkModeEditor: 'required|string|in:match,light,dark|default:match',
   autoDarkMode: 'required|string|in:off,system,schedule,auto|default:off',
   fileMeta: 'required|boolean|default:true',
   sorting: 'required|string|in:natural,ascii|default:natural',

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -60,6 +60,7 @@ export interface ConfigOptions {
   appLang: string
 
   darkMode: boolean
+  darkModeEditor: 'match'|'light'|'dark'
   autoDarkMode: 'off'|'system'|'schedule'
   autoDarkModeStart: string
   autoDarkModeEnd: string
@@ -301,6 +302,7 @@ export function getConfigTemplate (): ConfigOptions {
     attachmentExtensions: [],
     // UI related options
     darkMode: nativeTheme.shouldUseDarkColors,
+    darkModeEditor: 'match', // Possible values: 'match', 'light', 'dark'
     alwaysReloadFiles: true, // Should Zettlr automatically load remote changes?
     autoDarkMode: 'system', // Possible values: 'off', 'system', 'schedule', 'auto'
     autoDarkModeStart: '21:00', // Switch into dark mode at this time

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -60,6 +60,7 @@ export interface ConfigOptions {
   appLang: string
 
   darkMode: boolean
+  darkModeEditor: 'match'|'light'|'dark'
   autoDarkMode: 'off'|'system'|'schedule'
   autoDarkModeStart: string
   autoDarkModeEnd: string
@@ -302,6 +303,7 @@ export function getConfigTemplate (): ConfigOptions {
     attachmentExtensions: [],
     // UI related options
     darkMode: nativeTheme.shouldUseDarkColors,
+    darkModeEditor: 'match', // Possible values: 'match', 'light', 'dark'
     alwaysReloadFiles: true, // Should Zettlr automatically load remote changes?
     autoDarkMode: 'system', // Possible values: 'off', 'system', 'schedule', 'auto'
     autoDarkModeStart: '21:00', // Switch into dark mode at this time

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -60,7 +60,7 @@ import { mdPasteDropHandlers } from './plugins/md-paste-drop-handlers'
 import { footnoteGutter } from './plugins/footnote-gutter'
 import { yamlFrontmatterLint } from './linters/yaml-frontmatter-lint'
 import {
-  mainThemes, darkMode,
+  mainThemes, darkMode, useDarkModeEditor,
   themeBerlinLight, themeBerlinDark,
   themeBielefeldLight, themeBielefeldDark,
   themeBordeauxLight, themeBordeauxDark,
@@ -171,7 +171,7 @@ function getCoreExtensions (options: CoreExtensionOptions): Extension[] {
     inputModeCompartment.of(inputMode),
     // Then, include the default keymap
     defaultKeymap(),
-    darkMode({ darkMode: options.initialConfig.darkMode, ...themes[options.initialConfig.theme] }),
+    darkMode({ darkMode: useDarkModeEditor(options.initialConfig.darkMode, options.initialConfig.darkModeEditor), ...themes[options.initialConfig.theme] }),
     // CODE FOLDING
     codeFolding(),
     Prec.low(foldGutter()), // The fold gutter should appear next to the text content

--- a/source/common/modules/markdown-editor/editor.css
+++ b/source/common/modules/markdown-editor/editor.css
@@ -142,6 +142,7 @@
     border-radius: 3px;
     padding: 0 4px;
 
+
     span {
       font-size: 20px;
       font-weight: normal;
@@ -178,6 +179,36 @@
     cursor: help;
     margin: 0 auto; /* (Re-)center */
   }
+
+  /* Style the following elements so they adopt
+   * the main ui theme, not the editor theme */
+  .cm-panels, .cm-tooltip, .cm-statusbar {
+    color: black;
+    background-color: #f5f5f5;
+  }
+
+  .cm-panel.cm-panel-lint button[aria-label="close"] {
+    color: #000000;
+  }
+
+  .cm-panel .cm-button {
+    background-image: none;
+    background-color: inherit;
+    border-color: #aaa;
+    border-radius: 6px;
+    font-size: 13px;
+  }
+
+  .cm-formatting-bar {
+    background-color: #f5f5f5;
+    border-color: #f5f5f5;
+
+    .cm-tooltip-arrow::before, .cm-tooltip-arrow::after {
+      border-top-color: #f5f5f5;
+      border-bottom-color: #f5f5f5;
+    }
+  }
+  /* END */
 
   /* The underlying gfm mode is funny. For top level task items, it applies the
   class cm-variable-2 for the full text. For second-level task items, it

--- a/source/common/modules/markdown-editor/editor.css
+++ b/source/common/modules/markdown-editor/editor.css
@@ -178,6 +178,7 @@
     border-radius: 3px;
     padding: 0 4px;
 
+
     span {
       font-size: 20px;
       font-weight: normal;
@@ -214,6 +215,36 @@
     cursor: help;
     margin: 0 auto; /* (Re-)center */
   }
+
+  /* Style the following elements so they adopt
+   * the main ui theme, not the editor theme */
+  .cm-panels, .cm-tooltip, .cm-statusbar {
+    color: black;
+    background-color: #f5f5f5;
+  }
+
+  .cm-panel.cm-panel-lint button[aria-label="close"] {
+    color: #000000;
+  }
+
+  .cm-panel .cm-button {
+    background-image: none;
+    background-color: inherit;
+    border-color: #aaa;
+    border-radius: 6px;
+    font-size: 13px;
+  }
+
+  .cm-formatting-bar {
+    background-color: #f5f5f5;
+    border-color: #f5f5f5;
+
+    .cm-tooltip-arrow::before, .cm-tooltip-arrow::after {
+      border-top-color: #f5f5f5;
+      border-bottom-color: #f5f5f5;
+    }
+  }
+  /* END */
 
   /* The underlying gfm mode is funny. For top level task items, it applies the
   class cm-variable-2 for the full text. For second-level task items, it

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -96,7 +96,7 @@ import {
 import { markdownToAST } from '../markdown-utils'
 import { countField, updateWordCountEffect } from './plugins/statistics-fields'
 import type { SyntaxNode } from '@lezer/common'
-import { darkModeEffect } from './theme/dark-mode'
+import { useDarkModeEditor, darkModeEffect } from './theme/dark-mode'
 import { editorMetadataFacet } from './plugins/editor-metadata'
 import { projectInfoUpdateEffect, type ProjectInfo } from './plugins/project-info-field'
 import { moveSection } from './commands/move-section'
@@ -607,6 +607,7 @@ export default class MarkdownEditor extends EventEmitter {
   private onConfigUpdate (newOptions: Partial<EditorConfiguration>): void {
     const inputModeChanged = newOptions.inputMode !== undefined && newOptions.inputMode !== this.config.inputMode
     const darkModeChanged = newOptions.darkMode !== undefined && newOptions.darkMode !== this.config.darkMode
+    const editorModeChanged = newOptions.darkModeEditor !== undefined && newOptions.darkModeEditor !== this.config.darkModeEditor
     const themeChanged = newOptions.theme !== undefined && newOptions.theme !== this.config.theme
 
     // Third: The input mode, if applicable
@@ -621,12 +622,15 @@ export default class MarkdownEditor extends EventEmitter {
     }
 
     // Fourth: Switch theme, if applicable
-    if (darkModeChanged || themeChanged) {
+    if (darkModeChanged || editorModeChanged || themeChanged) {
       const themes = getMainEditorThemes()
+
+      const darkMode = newOptions.darkMode ?? this.config.darkMode
+      const darkModeEditor = newOptions.darkModeEditor ?? this.config.darkModeEditor
 
       this._instance.dispatch({
         effects: darkModeEffect.of({
-          darkMode: newOptions.darkMode,
+          darkMode: useDarkModeEditor(darkMode, darkModeEditor),
           ...themes[newOptions.theme ?? this.config.theme]
         })
       })

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -94,7 +94,7 @@ import {
 } from './plugins/remote-doc'
 import { markdownToAST } from '../markdown-utils'
 import { countField, updateWordCountEffect } from './plugins/statistics-fields'
-import { darkModeEffect } from './theme/dark-mode'
+import { useDarkModeEditor, darkModeEffect } from './theme/dark-mode'
 import { editorMetadataFacet } from './plugins/editor-metadata'
 import { projectInfoUpdateEffect, type ProjectInfo } from './plugins/project-info-field'
 import { moveSection } from './commands/move-section'
@@ -543,6 +543,7 @@ export default class MarkdownEditor extends EventEmitter {
   private onConfigUpdate (newOptions: Partial<EditorConfiguration>): void {
     const inputModeChanged = newOptions.inputMode !== undefined && newOptions.inputMode !== this.config.inputMode
     const darkModeChanged = newOptions.darkMode !== undefined && newOptions.darkMode !== this.config.darkMode
+    const editorModeChanged = newOptions.darkModeEditor !== undefined && newOptions.darkModeEditor !== this.config.darkModeEditor
     const themeChanged = newOptions.theme !== undefined && newOptions.theme !== this.config.theme
 
     // Third: The input mode, if applicable
@@ -557,12 +558,15 @@ export default class MarkdownEditor extends EventEmitter {
     }
 
     // Fourth: Switch theme, if applicable
-    if (darkModeChanged || themeChanged) {
+    if (darkModeChanged || editorModeChanged || themeChanged) {
       const themes = getMainEditorThemes()
+
+      const darkMode = newOptions.darkMode ?? this.config.darkMode
+      const darkModeEditor = newOptions.darkModeEditor ?? this.config.darkModeEditor
 
       this._instance.dispatch({
         effects: darkModeEffect.of({
-          darkMode: newOptions.darkMode,
+          darkMode: useDarkModeEditor(darkMode, darkModeEditor),
           ...themes[newOptions.theme ?? this.config.theme]
         })
       })

--- a/source/common/modules/markdown-editor/table-editor/subview.ts
+++ b/source/common/modules/markdown-editor/table-editor/subview.ts
@@ -24,7 +24,7 @@ import { tableEditorKeymap } from '../keymaps/table-editor'
 import { dispatchFromSubview, maybeDispatchToSubview, syncAnnotation } from './util/data-exchange'
 import { configField, type EditorConfiguration } from '../util/configuration'
 import { getMainEditorThemes } from '../editor-extension-sets'
-import { darkMode } from '../theme/dark-mode'
+import { darkMode, useDarkModeEditor } from '../theme/dark-mode'
 import { markdownSyntaxHighlighter } from '../theme/syntax'
 import { defaultKeymap } from '../keymaps/default'
 
@@ -219,7 +219,7 @@ export function createSubviewForCell (
       // The config field will automagically update since we forward any effects
       // to the subview.
       configField.init(_state => cfg),
-      darkMode({ darkMode: cfg.darkMode, ...themes[cfg.theme] }),
+      darkMode({ darkMode: useDarkModeEditor(cfg.darkMode, cfg.darkModeEditor), ...themes[cfg.theme] }),
       syntaxHighlighting(defaultHighlightStyle),
       markdownSyntaxHighlighter(),
       EditorView.lineWrapping,

--- a/source/common/modules/markdown-editor/table-editor/subview.ts
+++ b/source/common/modules/markdown-editor/table-editor/subview.ts
@@ -24,7 +24,7 @@ import { tableEditorKeymap } from '../keymaps/table-editor'
 import { dispatchFromSubview, maybeDispatchToSubview, syncAnnotation } from './util/data-exchange'
 import { configField, type EditorConfiguration } from '../util/configuration'
 import { getMainEditorThemes } from '../editor-extension-sets'
-import { darkMode } from '../theme/dark-mode'
+import { darkMode, useDarkModeEditor } from '../theme/dark-mode'
 import { markdownSyntaxHighlighter } from '../theme/syntax'
 import { defaultKeymap } from '../keymaps/default'
 import { clickListeners } from '../plugins/click-listeners'
@@ -236,7 +236,7 @@ export function createSubviewForCell (
       // The config field will automagically update since we forward any effects
       // to the subview.
       configField.init(_state => cfg),
-      darkMode({ darkMode: cfg.darkMode, ...themes[cfg.theme] }),
+      darkMode({ darkMode: useDarkModeEditor(cfg.darkMode, cfg.darkModeEditor), ...themes[cfg.theme] }),
       syntaxHighlighting(defaultHighlightStyle),
       markdownSyntaxHighlighter(),
       EditorView.lineWrapping,

--- a/source/common/modules/markdown-editor/theme/dark-mode.ts
+++ b/source/common/modules/markdown-editor/theme/dark-mode.ts
@@ -121,6 +121,25 @@ const darkModeSwitcher = EditorState.transactionExtender.of(transaction => {
 })
 
 /**
+ * This public helper function returns a boolean depending
+ * on whether the editor should use a light theme, dark theme,
+ * or match the main UI.
+ *
+ * @param   {boolean}   darkMode      The main UI dark mode setting
+ * @param   {string}    editorTheme   The theme of the editor. 'match' will
+ *                                    match the value of darkMode
+ *
+ * @return  {boolean}                  Whether to use a dark theme
+ */
+export function useDarkModeEditor (darkMode: boolean, editorTheme: 'match'|'dark'|'light' = 'match'): boolean {
+  return {
+    match: darkMode,
+    light: false,
+    dark: true,
+  }[editorTheme]
+}
+
+/**
  * An extension that enables a CodeMirror editor to quickly switch between light
  * and dark themes. Pass an initial configuration to the function, and continue
  * to configure the extension with the darkModeEffect.

--- a/source/common/modules/markdown-editor/theme/dark-mode.ts
+++ b/source/common/modules/markdown-editor/theme/dark-mode.ts
@@ -131,12 +131,15 @@ const darkModeSwitcher = EditorState.transactionExtender.of(transaction => {
  *
  * @return  {boolean}                  Whether to use a dark theme
  */
-export function useDarkModeEditor (darkMode: boolean, editorTheme: 'match'|'dark'|'light' = 'match'): boolean {
-  return {
-    match: darkMode,
-    light: false,
-    dark: true,
-  }[editorTheme]
+export function useDarkModeEditor (appDarkMode: boolean, editorTheme: 'match'|'dark'|'light' = 'match'): boolean {
+  switch(editorTheme) {
+    case 'match':
+      return appDarkMode
+    case 'light':
+      return false
+    case 'dark':
+      return true
+  }
 }
 
 /**

--- a/source/common/modules/markdown-editor/theme/index.ts
+++ b/source/common/modules/markdown-editor/theme/index.ts
@@ -15,7 +15,7 @@
 import { editorTheme } from './editor'
 import { codeTheme } from './code'
 
-export { darkMode } from './dark-mode'
+export { darkMode, useDarkModeEditor } from './dark-mode'
 
 export { themeBerlinLight, themeBerlinDark } from './themes/berlin'
 export { themeBielefeldLight, themeBielefeldDark } from './themes/bielefeld'

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -76,6 +76,7 @@ export interface EditorConfiguration {
   showStatusbar: boolean
   showFormattingToolbar: boolean
   darkMode: boolean
+  darkModeEditor: 'match'|'light'|'dark'
   theme: MarkdownTheme
   margins: 'S'|'M'|'L'
   highlightWhitespace: boolean
@@ -140,6 +141,7 @@ export function getDefaultConfig (): EditorConfiguration {
     showStatusbar: false,
     showFormattingToolbar: true,
     darkMode: false,
+    darkModeEditor: 'match',
     theme: 'berlin',
     margins: 'M',
     highlightWhitespace: false,

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -77,6 +77,7 @@ export interface EditorConfiguration {
   showStatusbar: boolean
   showFormattingToolbar: boolean
   darkMode: boolean
+  darkModeEditor: 'match'|'light'|'dark'
   theme: MarkdownTheme
   margins: 'S'|'M'|'L'
   highlightWhitespace: boolean
@@ -142,6 +143,7 @@ export function getDefaultConfig (): EditorConfiguration {
     showStatusbar: false,
     showFormattingToolbar: true,
     darkMode: false,
+    darkModeEditor: 'match',
     theme: 'berlin',
     margins: 'M',
     highlightWhitespace: false,

--- a/source/win-main/EditorBranch.vue
+++ b/source/win-main/EditorBranch.vue
@@ -211,8 +211,10 @@ body .split-pane-container {
   }
 }
 
-body.dark .split-pane-container .editor-pane {
-  &.border-right { border-color: #505050; }
+body.dark .split-pane-container {
+  .editor-pane, & {
+    &.border-right { border-color: #505050; }
     &.border-bottom { border-color: #505050; }
+  }
 }
 </style>

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -228,7 +228,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
   // right after setting the new configurations. Plus, the user won't update
   // everything all the time, but rather do one initial configuration, so
   // even if we incur a performance penalty, it won't be noticed that much.
-  const { editor, display, zkn, darkMode } = configStore.config
+  const { editor, display, zkn, darkMode, darkModeEditor } = configStore.config
   return {
     indentUnit: editor.indentUnit,
     indentWithTabs: editor.indentWithTabs,
@@ -278,6 +278,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     showStatusbar: editor.showStatusbar,
     showFormattingToolbar: editor.showFormattingToolbar,
     darkMode,
+    darkModeEditor,
     theme: display.theme,
     highlightWhitespace: editor.showWhitespace,
     showMarkdownLineNumbers: editor.showMarkdownLineNumbers,

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -231,7 +231,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
   // right after setting the new configurations. Plus, the user won't update
   // everything all the time, but rather do one initial configuration, so
   // even if we incur a performance penalty, it won't be noticed that much.
-  const { editor, display, zkn, darkMode } = configStore.config
+  const { editor, display, zkn, darkMode, darkModeEditor } = configStore.config
   return {
     indentUnit: editor.indentUnit,
     indentWithTabs: editor.indentWithTabs,
@@ -282,6 +282,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     showStatusbar: editor.showStatusbar,
     showFormattingToolbar: editor.showFormattingToolbar,
     darkMode,
+    darkModeEditor,
     theme: display.theme,
     highlightWhitespace: editor.showWhitespace,
     showMarkdownLineNumbers: editor.showMarkdownLineNumbers,

--- a/source/win-preferences/schema/appearance.ts
+++ b/source/win-preferences/schema/appearance.ts
@@ -69,6 +69,16 @@ export function getAppearanceFields (config: ConfigOptions): PreferencesFieldset
       title: trans('Editor Theme'),
       infoString: trans('Select a color and font theme for the editor.'),
       group: PreferencesGroups.Appearance,
+      titleField: {
+        type: 'select',
+        model: 'darkModeEditor',
+        inline: true,
+        options: {
+          match: trans('Automatic'),
+          light: trans('Light Theme'),
+          dark: trans('Dark Theme')
+        }
+      },
       help: undefined, // TODO
       fields: [
         { type: 'separator' },

--- a/source/win-preferences/schema/appearance.ts
+++ b/source/win-preferences/schema/appearance.ts
@@ -74,7 +74,7 @@ export function getAppearanceFields (config: ConfigOptions): PreferencesFieldset
         model: 'darkModeEditor',
         inline: true,
         options: {
-          match: trans('Automatic'),
+          match: trans('Follow App'),
           light: trans('Light Theme'),
           dark: trans('Dark Theme')
         }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR allows a user to set the editor dark mode separately from the main UI.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
A radio button setting is added to the appearance settings pane which allows a user to set the editor theme mode to either `light`, `dark`, or `match`. If the mode is `match`, it will follow the main UI dark mode. 

A helper function was added to `dark-mode.ts` to get the right dark mode setting for the editor, and several calls to `darkMode()` and `darkModeEffect` were updated to use this helper.

In terms of CSS, I added a `background-color` setting to several of the preset themes, otherwise, the incorrect background was shown since they were inheriting a transparent background. Likewise, I moved the styling of the `cm-statusbar` and `cm-formatting-bar` so that they took on the styling of the main UI, not the editor. I think this gives a more consistent feel.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
MS Word and LibreOffice both offer the option to have a dark or light page when setting dark mode, and Pages defaults to a white page, otherwise a user can chose the `Blank Black` template for a black page. Additionally, this functionality is important in terms of accessibility.

When I'm writing, I prefer a dark UI but a light page. I was looking into achieving this with only CSS, but there were several components that needed reconfigured, and I would have had to do it for every theme I wanted to use. I decided to implement it in the app.

Images:

Light Mode / Dark Editor:

<img width="1163" height="1079" alt="Light Mode / Dark Editor" src="https://github.com/user-attachments/assets/da509ce7-4860-4051-91a6-63d43cd6a36c" />

Dark Mode / Light Editor:

<img width="1163" height="1080" alt="Dark Mode / Light Editor" src="https://github.com/user-attachments/assets/27434070-a237-4ddf-9288-60562998c80f" />


<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6