### PR TITLE
feat: Text transform to remove ligatures

### DIFF
--- a/source/common/modules/markdown-editor/commands/transforms/substitute-ligatures.ts
+++ b/source/common/modules/markdown-editor/commands/transforms/substitute-ligatures.ts
@@ -1,0 +1,96 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        TextTransform
+ * CVM-Role:        CodeMirror command
+ * Maintainer:      Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     This plugin contains a single text transformer.
+ *
+ * END HEADER
+ */
+import { transformSelectedText } from './transform-selected-text'
+
+type Substitution = {
+  target: string
+  replacement: string
+}
+
+const SUBSTITUTIONS_LIGATURE: ReadonlyArray<Substitution> = [
+  {
+    target: '\u00C6',
+    replacement: 'AE',
+  },
+  {
+    target: '\u00E6',
+    replacement: 'ae',
+  },
+  {
+    target: '\u0132',
+    replacement: 'IJ',
+  },
+  {
+    target: '\u0133',
+    replacement: 'ij',
+  },
+  {
+    target: '\u0152',
+    replacement: 'OE',
+  },
+  {
+    target: '\u0153',
+    replacement: 'oe',
+  },
+  {
+    target: '\uFB00',
+    replacement: 'ff',
+  },
+  {
+    target: '\uFB01',
+    replacement: 'fi',
+  },
+  {
+    target: '\uFB02',
+    replacement: 'fl',
+  },
+  {
+    target: '\uFB03',
+    replacement: 'ffi',
+  },
+  {
+    target: '\uFB04',
+    replacement: 'ffl',
+  },
+  {
+    target: '\uFB05',
+    replacement: 'st',
+  },
+  {
+    target: '\uFB06',
+    replacement: 'st',
+  },
+]
+
+/**
+ * Return a function that'll return a `StateCommand` to substitute ligatures,
+ * expanding them as necessary.
+ *
+ * This is a higher-order function that itself returns a higher-order function
+ * because we need to know the substitutions.
+ *
+ * @param   {string}        substitutions  The substitutions.
+ *
+ * @return  {StateCommand}  A `StateCommand` to substitute ligatures.
+ */
+export const substituteLigatures = transformSelectedText((text) => {
+  return SUBSTITUTIONS_LIGATURE.reduce(
+    (memo, substitution) =>
+      memo.replaceAll(
+        new RegExp(substitution.target, 'g'),
+        substitution.replacement
+      ),
+    text
+  )
+})

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -34,6 +34,7 @@ import { toDoubleQuotes } from 'source/common/modules/markdown-editor/commands/t
 import { toSentenceCase } from 'source/common/modules/markdown-editor/commands/transforms/to-sentence-case'
 import { toTitleCase } from 'source/common/modules/markdown-editor/commands/transforms/to-title-case'
 import { zapGremlins } from 'source/common/modules/markdown-editor/commands/transforms/zap-gremlins'
+import { substituteLigatures } from 'source/common/modules/markdown-editor/commands/transforms/substitute-ligatures'
 import { configField } from '../util/configuration'
 
 const ipcRenderer = window.ipc
@@ -305,6 +306,12 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
           enabled: true
         },
         {
+          label: trans('Substitute ligatures'),
+          id: 'substituteLigatures',
+          type: 'normal',
+          enabled: true
+        },
+        {
           type: 'separator'
         },
         {
@@ -425,6 +432,8 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       toTitleCase(window.config.get('appLang'))(view)
     } else if (clickedID === 'zapGremlins') {
       zapGremlins(view)
+    } else if (clickedID === 'substituteLigatures') {
+      substituteLigatures(view)
     } else if (clickedID === 'no-suggestion') {
       // Do nothing
     } else if (clickedID === 'add-to-dictionary' && word !== undefined) {

--- a/test/transform-selected-text/substitute-ligatures.spec.ts
+++ b/test/transform-selected-text/substitute-ligatures.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Tests for the substituteLigatures function
+ * CVM-Role:        TESTING
+ * Maintainers:     Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     This file tests the substituteLigatures function.
+ *
+ * END HEADER
+ */
+
+import { EditorSelection, EditorState, Transaction } from '@codemirror/state'
+import { deepEqual, fail, strictEqual } from "assert"
+import { substituteLigatures } from "../../source/common/modules/markdown-editor/commands/transforms/substitute-ligatures"
+import { selectAll } from "../codemirror-test-utils/select-all"
+
+describe("MarkdownEditor#substituteLigatures()", function () {
+  const testCases = [
+    {
+      ligature: "\u00C6",
+      substitution: "AE",
+      expectedLength: 2,
+    },
+    {
+      ligature: "Æ",
+      substitution: "AE",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\u00E6",
+      substitution: "ae",
+      expectedLength: 2,
+    },
+    {
+      ligature: "æ",
+      substitution: "ae",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\u0132",
+      substitution: "IJ",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\u0133",
+      substitution: "ij",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\u0152",
+      substitution: "OE",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\u0153",
+      substitution: "oe",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\uFB00",
+      substitution: "ff",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\uFB01",
+      substitution: "fi",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\uFB02",
+      substitution: "fl",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\uFB03",
+      substitution: "ffi",
+      expectedLength: 3,
+    },
+    {
+      ligature: "\uFB04",
+      substitution: "ffl",
+      expectedLength: 3,
+    },
+    {
+      ligature: "\uFB05",
+      substitution: "st",
+      expectedLength: 2,
+    },
+    {
+      ligature: "\uFB06",
+      substitution: "st",
+      expectedLength: 2,
+    },
+  ]
+
+  testCases.forEach(({ ligature, substitution, expectedLength }) => {
+    it(`substitutes ligature '${ligature}' with '${substitution}'`, function () {
+      const state = EditorState.create({
+        doc: ligature,
+        selection: selectAll(ligature),
+      })
+
+      let wasDispatched = false
+
+      const dispatch = (tx: Transaction) => {
+        wasDispatched = true
+
+        deepEqual(tx.changes, {
+          inserted: [
+            {
+              length: expectedLength,
+              text: [substitution],
+            },
+          ],
+          sections: [1, expectedLength],
+        })
+      }
+
+      substituteLigatures({ state, dispatch })
+
+      strictEqual(
+        wasDispatched,
+        true,
+        "A transaction must have been dispatched"
+      )
+    })
+  })
+
+  it("substitutes multiple occurrences of the same ligature", function () {
+    const text = "Falstaﬀ, grab thy staﬀ and let's laﬀ."
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    let wasDispatched = false
+
+    const dispatch = (tx: Transaction) => {
+      wasDispatched = true
+
+      deepEqual(tx.changes, {
+        inserted: [
+          {
+            length: 40,
+            text: ["Falstaff, grab thy staff and let's laff."],
+          },
+        ],
+        sections: [37, 40],
+      })
+    }
+
+    substituteLigatures({ state, dispatch })
+
+    strictEqual(wasDispatched, true, "A transaction must have been dispatched")
+  })
+
+  it("substitutes interleaved occurrences of different ligatures", function () {
+    const text = "Falstaﬀ, grab thy waﬄes and let's laﬀ at the kerfuﬄe."
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    let wasDispatched = false
+
+    const dispatch = (tx: Transaction) => {
+      wasDispatched = true
+
+      deepEqual(tx.changes, {
+        inserted: [
+          {
+            length: 59,
+            text: ["Falstaff, grab thy waffles and let's laff at the kerfuffle."],
+          },
+        ],
+        sections: [53, 59],
+      })
+    }
+
+    substituteLigatures({ state, dispatch })
+
+    strictEqual(wasDispatched, true, "A transaction must have been dispatched")
+  })
+
+  it('given text with substitutable ligatures but those ligatures are not in the selected text then no transaction is dispatched', function () {
+    const text = 'Oh `laﬀ` now'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: EditorSelection.create([
+        // select just the first word which *doesn't* include the ligature
+        EditorSelection.range(0, 2),
+      ]),
+    })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    substituteLigatures({ state, dispatch })
+  })
+
+  it('given text with no ligatures then no transaction is dispatched', function () {
+    const text = 'There are no ligatures in this text'
+
+    const state = EditorState.create({
+      doc: text,
+      selection: selectAll(text),
+    })
+
+    const dispatch = () => fail('No transaction must be dispatched')
+
+    substituteLigatures({ state, dispatch })
+  })
+})


### PR DESCRIPTION
Closes #5820

## Description
Adds a text transform to substitute/replace/expand ligatures.

https://github.com/user-attachments/assets/0fe7ab88-85d6-4d24-a33c-f79c6e0dfaf4

## Changes
I added another of the text transforms that we've had a spate of recently.

## Additional information

This is marked as a draft PR only because I think @wideaperture may want to nail down:

* the exact label for the UI menu item; currently it is _Substitute ligatures_
* firmly decide on the exact set of ligatures to be substituted/replaced/expanded
* decide where/how the transform is to be accessed
  * via the existing popup menu
  * a new _Transforms_ submenu of the existing _Edit_ menu
  * both?
  * something else entirely

Purely to facilitate manual testing the transform is actioned by an item in the context menu.

Tested on: Windows 11.