### PR TITLE
[FEAT] Enable a scrolling toolbar on overflow

### DIFF
--- a/source/common/vue/window/WindowToolbar.vue
+++ b/source/common/vue/window/WindowToolbar.vue
@@ -209,10 +209,12 @@ body div#toolbar {
 
     &.left {
       left: 0;
+      height: auto;
       background-color: inherit;
     }
     &.right {
       right: 0;
+      height: auto;
       background-color: inherit;
     }
   }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR implements a scrollable area for the toolbar when its content overflows, such as with narrow window widths.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The toolbar was refactored so that the buttons appear in a scrollable area. The toolbar only becomes scrollable when content overflows. When content overflows, buttons appear on either side of the toolbar indicating the overflow, and they can be clicked to scroll either left or right. When there is no remaining content to one side, the button will be disabled.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Closes #5022

Behavior:

https://github.com/user-attachments/assets/a1b76f30-f8b0-4c36-a452-c7bfdbd7855e

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6 and Fedora 42 (aarch64)
