### PR TITLE
[Fix] Ensure table delimiters include at least one hyphen

### DIFF
--- a/source/common/modules/markdown-editor/table-editor/commands/tables.ts
+++ b/source/common/modules/markdown-editor/table-editor/commands/tables.ts
@@ -55,7 +55,7 @@ export function setAlignment (alignTo: 'left'|'right'|'center'): (target: Editor
       const delimOffsets = getDelimiterLineCellOffsets(delimLine, delimChar)
       const [ from, to ] = delimOffsets[idx]
       if (alignTo === 'left') {
-        return { from: node.from + from, to: node.from + to, insert: fillChar.repeat(Math.max(to - from, 2)) }
+        return { from: node.from + from, to: node.from + to, insert: fillChar.repeat(Math.max(to - from, 3)) }
       } else if (alignTo === 'right') {
         return { from: node.from + from, to: node.from + to, insert: fillChar.repeat(Math.max(to - from - 1, 2)) + ':' }
       } else {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR addresses a rendering/parsing issue when an empty cell is aligned. It ensures the delimiter contains at least one hyphen.

Closes #5830

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
When an empty cell is center aligned, it results in a delimiter like so: `|::|`, however, it seems that the markdown parser expects there to be at least one hyphen, according to https://github.github.com/gfm/#tables-extension- 

> The [delimiter row](https://github.github.com/gfm/#delimiter-row) consists of cells whose only content are hyphens (-), and optionally, a leading or trailing colon (:), or both, to indicate left, right, or center alignment respectively.

Likewise, if a person handwrites a table with a single hyphen in the delimiter, further attempts to align an empty cell would result in a delimiter like `|:|`, which is ambiguous.

This PR ensures that there is at least one hyphen in the delimiter. I chose to sanitize to 3 characters so that center, right, and left alignment resulted in the same minimum number of characters.

The formatter also picked up trailing whitespace that was removed.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Current behavior:

https://github.com/user-attachments/assets/94ba1a30-c6f9-4aae-a2b3-35ed5ad69027

PR behavior:

https://github.com/user-attachments/assets/a09144c0-ccd3-411f-a8c5-0e643ba6fd1f

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6

**EDIT: expanded the sanitation to account for handwritten tables with one-hyphen delimiters.**