### PR TITLE
fix: Consistent layout of toolbar on Windows

### DIFF
--- a/source/common/vue/window/toolbar-controls/ThreeWayToggle.vue
+++ b/source/common/vue/window/toolbar-controls/ThreeWayToggle.vue
@@ -147,6 +147,7 @@ body.win32 {
   div#toolbar div.three-way-toggle {
     margin: 0 10px;
     border: 2px solid transparent;
+    display: flex;
 
     &:hover { border-color: rgb(180, 180, 180); }
     &.active { background-color: rgb(230, 230, 230); }


### PR DESCRIPTION
The buttons to search for files and toggle the file manager are stacking vertically when the window is shrunk horizontally. This doesn't match the behaviour of those buttons on other platforms where no such stacking occurs.

## Changes
This change updates the CSS so that the layout behaviour is consistent -- no stacking -- across platforms.

https://github.com/user-attachments/assets/9fa85a29-50a7-4348-96e8-b1933a03c364

https://github.com/user-attachments/assets/bfa996f8-96fa-4b2a-a7ac-a68678b9c195

## Additional information
Noticed while reviewing #5873

The glory for this change belongs to @benniekiss 🙇‍♂️ 

<!-- Please provide any testing system -->
Tested on: Windows 11
