### PR TITLE
[Fix] Refactor table alignment handling

### DIFF
--- a/source/common/modules/markdown-editor/table-editor/widget.ts
+++ b/source/common/modules/markdown-editor/table-editor/widget.ts
@@ -267,7 +267,7 @@ function updateRow (
   tr: HTMLTableRowElement,
   astRow: TableRow,
   idx: number,
-  align: Array<'left'|'center'|'right'>,
+  align: Array<'left'|'center'|'right'|null>,
   view: EditorView,
   rowsChanged: boolean,
   selectionCoords?: { col: number, row: number },
@@ -387,7 +387,7 @@ function updateRow (
         tds[i].appendChild(elem)
       }
     }
-    
+
     if (i === 0 && row === idx) {
       // Selection is in this row
       for (const elem of generateRowControls(view)) {
@@ -399,7 +399,7 @@ function updateRow (
     // include whitespace here (minus one space padding if applicable).
     tds[i].dataset.cellFrom = String(cell.from)
     tds[i].dataset.cellTo = String(cell.to)
-    tds[i].style.textAlign = align[i] ?? 'left'
+    tds[i].style.textAlign = align[i] ?? ''
 
     const contentWrapper: HTMLDivElement = tds[i].querySelector('div.content')!
     const subview = EditorView.findFromDOM(contentWrapper)

--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -367,7 +367,7 @@ export interface Table extends MDNode {
   /**
    * A list of column alignments in the table.
    */
-  alignment: Array<'left'|'center'|'right'>
+  alignment: Array<'left'|'center'|'right'|null>
   /**
    * This property contains the table type in the source.
    */

--- a/source/common/modules/markdown-utils/markdown-ast/parse-table-node.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/parse-table-node.ts
@@ -109,12 +109,12 @@ export function parseTableNode (node: SyntaxNode, markdown: string): Table|TextN
     .filter(c => c.length > 0)
     .map(c => {
       // Now extract the alignment characters
-      if (c.startsWith(':')) {
+      if (c.startsWith(':') && c.endsWith(':')) {
+        return 'center'
+      } else if (c.startsWith(':')) {
         return 'left'
       } else if (c.endsWith(':')) {
         return 'right'
-      } else if (c.startsWith(':') && c.endsWith(':')) {
-        return 'center'
       } else {
         return null
       }

--- a/source/common/modules/markdown-utils/markdown-ast/parse-table-node.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/parse-table-node.ts
@@ -109,15 +109,17 @@ export function parseTableNode (node: SyntaxNode, markdown: string): Table|TextN
     .filter(c => c.length > 0)
     .map(c => {
       // Now extract the alignment characters
-      if (c.startsWith(':') && c.endsWith(':')) {
-        return 'center'
+      if (c.startsWith(':')) {
+        return 'left'
       } else if (c.endsWith(':')) {
         return 'right'
+      } else if (c.startsWith(':') && c.endsWith(':')) {
+        return 'center'
       } else {
-        return 'left'
+        return null
       }
     })
-  
+
   // Delimiter row determines alignment + correct number of columns
   const nCols = astNode.alignment.length
 

--- a/source/common/util/build-pipe-markdown-table.ts
+++ b/source/common/util/build-pipe-markdown-table.ts
@@ -81,7 +81,7 @@ export function buildPipeMarkdownTable (ast: string[][], colAlignment: Array<'ce
       case 'center':
         return ':' + '-'.repeat(Math.max(size, 1)) + ':'
       default:
-        return '-'.repeat(Math.max(size, 3))
+        return '-'.repeat(Math.max(size + 2, 3))
     }
   }).join('|')
 

--- a/source/common/util/build-pipe-markdown-table.ts
+++ b/source/common/util/build-pipe-markdown-table.ts
@@ -53,19 +53,19 @@ export function buildPipeMarkdownTable (ast: string[][], colAlignment: Array<'ce
 
   // Then, build the table in a quick MapReduce fashion
   const rows = ast.map(row => {
-    const rowContents = row.map((col, idx) => {
+    const rowContents = row.map((cell, idx) => {
       let pad = Math.max(colSizes[idx], 1)
 
       switch (colAlignment[idx]) {
         case 'left':
-          return col.padEnd(pad, ' ')
+          return cell.padEnd(pad, ' ')
         case 'right':
-          return col.padStart(pad, ' ')
+          return cell.padStart(pad, ' ')
         case 'center':
-          pad = pad - col.length
-          return ' '.repeat(Math.floor(pad/2)) + col + ' '.repeat(Math.ceil(pad/2))
+          pad = pad - cell.length
+          return ' '.repeat(Math.floor(pad/2)) + cell + ' '.repeat(Math.ceil(pad/2))
         default:
-          return col.padEnd(pad, ' ')
+          return cell.padEnd(pad, ' ')
       }
     }).join(' | ')
     return `| ${rowContents} |`

--- a/source/common/util/build-pipe-markdown-table.ts
+++ b/source/common/util/build-pipe-markdown-table.ts
@@ -24,9 +24,9 @@ export default function calculateColSizes (ast: string[][]): number[] {
   const numCols = ast[0].length
   const sizes: number[] = Array(numCols).fill(0)
 
-  ast.forEach((row) => {
-    row.forEach((cell, idx) => {
-      let colSize = sizes[idx]
+  for (const row of ast) {
+    for (let idx = 0; idx < numCols; idx++) {
+      const cell = row[idx]
 
       let cellLength = cell.length
       if (cell.includes('\n')) {
@@ -34,11 +34,11 @@ export default function calculateColSizes (ast: string[][]): number[] {
         cellLength = Math.max(...cell.split('\n').map(x => x.length))
       }
 
-      if (cellLength > colSize) {
+      if (cellLength > sizes[idx]) {
         sizes[idx] = cellLength
       }
-    })
-  })
+    }
+  }
 
   return sizes
 }

--- a/source/common/util/build-pipe-markdown-table.ts
+++ b/source/common/util/build-pipe-markdown-table.ts
@@ -41,7 +41,7 @@ export default function calculateColSizes (ast: string[][]): number[] {
   return sizes
 }
 
-export function buildPipeMarkdownTable (ast: string[][], colAlignment: Array<'center'|'left'|'right'>): string {
+export function buildPipeMarkdownTable (ast: string[][], colAlignment: Array<'center'|'left'|'right'|null>): string {
   if (ast.length < 2) {
     throw new Error('Cannot build pipe table: Must have at least two rows.')
   }
@@ -63,12 +63,15 @@ export function buildPipeMarkdownTable (ast: string[][], colAlignment: Array<'ce
 
   // Finally, insert the required header row at index 2
   const headerRowContents = colSizes.map((size, idx) => {
-    if (colAlignment[idx] === 'left') {
-      return '-'.repeat(size + 2)
-    } else if (colAlignment[idx] === 'center') {
-      return ':' + '-'.repeat(size) + ':'
-    } else {
-      return '-'.repeat(size + 1) + ':'
+    switch (colAlignment[idx]) {
+      case 'left':
+        return ':' + '-'.repeat(Math.max(size - 1, 2))
+      case 'right':
+        return '-'.repeat(Math.max(size - 1, 2)) + ':'
+      case 'center':
+        return ':' + '-'.repeat(Math.max(size - 2, 1)) + ':'
+      default:
+        return '-'.repeat(Math.max(size, 3))
     }
   }).join('|')
 

--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -692,16 +692,9 @@ function editorSidebarSplitComponentResized (sizes: [number, number]): void {
 
 function insertTable (spec: { rows: number, cols: number }): void {
   // Generate a simple table based on the info, and insert it.
-  const ast: string[][] = []
-  const align: Array<'center'|'left'|'right'> = []
-  for (let i = 0; i < spec.rows; i++) {
-    const row: string[] = []
-    align.push('left')
-    for (let k = 0; k < spec.cols; k++) {
-      row.push('')
-    }
-    ast.push(row)
-  }
+  const align: Array<'center'|'left'|'right'|null> = Array(spec.cols).fill(null)
+  const row = (): string[] => Array(spec.cols).fill('')
+  const ast: string[][] = Array.from({ length: spec.rows }, row)
 
   editorCommands.value.data = buildPipeMarkdownTable(ast, align)
   editorCommands.value.replaceSelection = !editorCommands.value.replaceSelection

--- a/test/build-pipe-table.spec.ts
+++ b/test/build-pipe-table.spec.ts
@@ -19,7 +19,7 @@
 import { deepStrictEqual } from 'assert'
 import { buildPipeMarkdownTable } from 'source/common/util/build-pipe-markdown-table'
 
-const table: Array<{ ast: string[][], colAlignments: Array<'left'|'right'|'center'> }> = []
+const table: Array<{ ast: string[][], colAlignments: Array<'left'|'right'|'center'|null> }> = []
 const tableResults: string[] = []
 
 /** * * * * * * * * * * * * * * * * * *
@@ -70,6 +70,22 @@ table.push({
     [ 'Col. 1', 'Col. 2', 'Col. 3' ]
   ],
   colAlignments: [ 'left', 'center', 'right' ]
+})
+
+/** * * * * * * * * * * * * * * * * * *
+* TABLE FOUR
+*/
+tableResults.push(`\
+| One | Two | Three | Four | Five |
+|:----|-----|:-----:|------|-----:|
+| 1   | 2   |   3   | 4    |    5 |`)
+
+table.push({
+  ast: [
+    [ 'One', 'Two', 'Three', 'Four', 'Five' ],
+    [ '1', '2', '3', '4', '5' ]
+  ],
+  colAlignments: [ 'left', null, 'center', null, 'right' ]
 })
 
 describe('TableEditor#buildGrid()', function () {

--- a/test/build-pipe-table.spec.ts
+++ b/test/build-pipe-table.spec.ts
@@ -25,9 +25,10 @@ const tableResults: string[] = []
 /** * * * * * * * * * * * * * * * * * *
 * TABLE ONE
 */
-tableResults.push(`|  |  |
-|--|--|
-|  |  |`)
+tableResults.push(`\
+|   |   |
+|:--|:--|
+|   |   |`)
 
 table.push({
   ast: [
@@ -40,10 +41,11 @@ table.push({
 /** * * * * * * * * * * * * * * * * * *
 * TABLE TWO
 */
-tableResults.push(`|  |  |  |  |
-|--|--|--|--|
-|  |  |  |  |
-|  |  |  |  |`)
+tableResults.push(`\
+|   |   |   |   |
+|:--|:--|:--|:--|
+|   |   |   |   |
+|   |   |   |   |`)
 
 table.push({
   ast: [
@@ -57,16 +59,17 @@ table.push({
 /** * * * * * * * * * * * * * * * * * *
 * TABLE THREE
 */
-tableResults.push(`| Right | Left  | Centered |
-|------:|-------|:--------:|
-| Col 1 | Col 2 | Col 3    |`)
+tableResults.push(`\
+| Left   | Centered |  Right |
+|:-------|:--------:|-------:|
+| Col. 1 |  Col. 2  | Col. 3 |`)
 
 table.push({
   ast: [
-    [ 'Right', 'Left', 'Centered' ],
-    [ 'Col 1', 'Col 2', 'Col 3' ]
+    [ 'Left', 'Centered', 'Right' ],
+    [ 'Col. 1', 'Col. 2', 'Col. 3' ]
   ],
-  colAlignments: [ 'right', 'left', 'center' ]
+  colAlignments: [ 'left', 'center', 'right' ]
 })
 
 describe('TableEditor#buildGrid()', function () {

--- a/test/markdown-to-ast.spec.ts
+++ b/test/markdown-to-ast.spec.ts
@@ -27,7 +27,7 @@ const TESTERS: Array<{ description: string, input: string, output: ASTNode }> = 
       children: [
         {
           type: 'Table', name: 'Table', from: 0, to: 54, whitespaceBefore: '',
-          tableType: 'pipe', alignment: [ 'left', 'left' ],
+          tableType: 'pipe', alignment: [ null, null ],
           rows: [
             {
               type: 'TableRow', name: 'TableHeader', from: 0, to: 16, whitespaceBefore: '', isHeaderOrFooter: true,
@@ -74,7 +74,7 @@ C|D`,
       children: [
         {
           type: 'Table', name: 'Table', tableType: 'pipe', from: 0, to: 11, whitespaceBefore: '',
-          alignment: ['left', 'left'],
+          alignment: [null, null],
           rows: [
             {
               type: 'TableRow', name: 'TableHeader', isHeaderOrFooter: true, from: 0, to: 3, whitespaceBefore: '',


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors table alignment handling to improve functionality and readability. It enables setting no alignment (`---`), tries to enforce a minimum of 3 characters per cell, fixes an error related to center alignment parsing and rendering, and fixes an error with table insertion related to alignment.  

Supersedes  #5875
Closes #5830 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
This PR addresses inconsistencies in how `left` alignment was handled. In several places, it was used when the actual alignment was unaligned, `---`. This PR corrects it so that all references to `left` alignment result in a delimiter with a colon, `:--`. To compensate, several functions and types were updated to accept an alignment of `null`, which corresponds to `---`, including the `Table` AST node

Cell padding was refactored to ensure that cells contain a minimum of 3 characters, including delimiter cells. See the previous PR for the rationale.

Column alignment on table insertion was refactored. Previously, the alignment was calculated based on the row index, not the column index. This resulted in errors when inserting a table that had more columns than rows, in which case the difference in columns would all be `right` aligned.

The code was generally refactored for readability. Long `if...else` statements were refactored into `switch` statements, and some nested loops were refactored to simpler list constructions.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6
