### PR TITLE
feat: Enable fuzzy autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ the leading period of the extension, so do not write `$FILENAME.$EXTENSION`.)
   is already running.
 - **Feature**: Individual global search results can now be copied to the
   clipboard (#2070).
+- **Feature**: Autocomplete suggestions (links, tags, etc.) now use _fuzzy
+  matching_. You no longer need to type the exact text, but rather a few
+  letters from it will be enough to bring the best results to the top of the
+  list. (#5878)
 - **Change**: Snippets: The `$FILENAME` variable now does not contain the file
   extension anymore. Users who also want the extension should update their
   snippets to `$FILENAME$EXTENSION` (#4191).

--- a/source/common/modules/markdown-editor/autocomplete/index.ts
+++ b/source/common/modules/markdown-editor/autocomplete/index.ts
@@ -87,14 +87,13 @@ const autocompleteSource: CompletionSource = function (ctx): CompletionResult|nu
   }
 
   if (plugin !== undefined) {
-    const initialOptions = plugin.entries(ctx, ctx.state.doc.sliceString(startpos, ctx.pos).toLowerCase())
+    const initialOptions = plugin.entries(ctx, '')
     return {
       from: startpos,
       options: initialOptions,
-      filter: false,
+      filter: true,
       update: (current, from, to, ctx) => {
-        const query = ctx.state.doc.sliceString(from, to).toLowerCase()
-        current.options = plugin!.entries(ctx, query)
+        current.options = plugin!.entries(ctx, '')
         return current
       }
     }


### PR DESCRIPTION
## Description
This PR enables _fuzzy matching_ for autocomplete suggestions.

## Changes
In function `autocompleteSource()`:
- Always get _all_ possible entries
- Enable the `filter` flag

See changes in action below:

https://github.com/user-attachments/assets/f70aff09-c59c-4175-a5d3-72be58301b33


https://github.com/user-attachments/assets/47e49325-763c-47a6-9212-b4b3f1cdae06










<!-- Please provide any testing system -->
Tested on: Ubuntu WSL
