### PR TITLE
[Fix] Style unfocused selected lint panel items in darkmode

### DIFF
--- a/source/common/modules/markdown-editor/theme/main-override.ts
+++ b/source/common/modules/markdown-editor/theme/main-override.ts
@@ -46,6 +46,10 @@ export const mainOverride = EditorView.baseTheme({
   '.cm-panel.cm-search': {
     userSelect: 'none' // prevent search panel text elements from being selected
   },
+  '&dark .cm-panel.cm-panel-lint ul [aria-selected]': {
+    // Fixes highlighting of unfocused selected lint panel items in dark mode.
+    backgroundColor: '#787878'
+  },
   // TOOLTIPS
   '.cm-tooltip': {
     padding: '4px',


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR styles unfocused selected lint panel items in dark mode to improve accessibility.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Added a CSS attribute to change the background color of lint panel items when they are selected but unfocused.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Previous:

<img width="1209" height="135" alt="Screenshot 2025-09-03 at 10 29 33" src="https://github.com/user-attachments/assets/9be4f8e8-5604-4296-9142-cf4c63a5f124" />

PR:

<img width="1197" height="154" alt="Screenshot 2025-09-03 at 10 29 17" src="https://github.com/user-attachments/assets/0d044457-58bb-4c89-9719-f40adba23365" />


<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6
