### PR TITLE
[Fix] Style drop cursor with editor theme

### DIFF
--- a/source/common/modules/markdown-editor/theme/berlin.ts
+++ b/source/common/modules/markdown-editor/theme/berlin.ts
@@ -60,6 +60,7 @@ export const themeBerlinLight = EditorView.theme({
   },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionLight
@@ -80,6 +81,7 @@ export const themeBerlinDark = EditorView.theme({
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-bracket': { color: 'var(--grey-1)' },
   '.cm-string': { color: 'var(--green-0)' },

--- a/source/common/modules/markdown-editor/theme/bielefeld.ts
+++ b/source/common/modules/markdown-editor/theme/bielefeld.ts
@@ -47,6 +47,7 @@ export const themeBielefeldLight = EditorView.theme({
   },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionLight
@@ -67,6 +68,7 @@ export const themeBielefeldDark = EditorView.theme({
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-bracket': { color: 'var(--grey-1)' },
   '.cm-string': { color: 'var(--green-0)' },

--- a/source/common/modules/markdown-editor/theme/bordeaux.ts
+++ b/source/common/modules/markdown-editor/theme/bordeaux.ts
@@ -52,6 +52,7 @@ export const themeBordeauxLight = EditorView.theme({
   },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionLight
@@ -75,6 +76,7 @@ export const themeBordeauxDark = EditorView.theme({
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-bracket': { color: 'var(--grey-1)' },
   '.cm-string': { color: 'var(--green-0)' },

--- a/source/common/modules/markdown-editor/theme/frankfurt.ts
+++ b/source/common/modules/markdown-editor/theme/frankfurt.ts
@@ -60,6 +60,7 @@ export const themeFrankfurtLight = EditorView.theme({
   },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: blueSelectionLight
@@ -80,6 +81,7 @@ export const themeFrankfurtDark = EditorView.theme({
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-bracket': { color: 'var(--grey-1)' },
   '.cm-string': { color: 'var(--green-0)' },

--- a/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
+++ b/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
@@ -60,6 +60,7 @@ export const themeKarlMarxStadtLight = EditorView.theme({
   },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionLight
@@ -80,6 +81,7 @@ export const themeKarlMarxStadtDark = EditorView.theme({
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-cursor-primary': { background: primaryColor },
   '.cm-cursor-secondary': { background: 'var(--red-2)' },
+  '.cm-dropCursor': { borderLeftColor: primaryColor },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-bracket': { color: 'var(--grey-1)' },
   '.cm-string': { color: 'var(--green-0)' },

--- a/source/common/modules/markdown-editor/theme/main-override.ts
+++ b/source/common/modules/markdown-editor/theme/main-override.ts
@@ -23,6 +23,9 @@ export const mainOverride = EditorView.baseTheme({
     backgroundColor: 'transparent',
     cursor: 'auto'
   },
+  '&dark .cm-dropCursor': {
+    borderLeftColor: '#ddd'
+  },
   '.cm-scroller': {
     flexGrow: '1', // Ensure the content pushes possible panels towards the edge
     outline: '0' // Remove the outline


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR adds CSS styling for the drop-cursor (shown when dragging selected text, etc.)

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The editor themes were updated to set the drop cursor color, and the main theme was updated to set the color in dark mode.

The CSS attributes were chosen based on the code here: https://github.com/codemirror/view/blob/b7c8f63f079c331fd48e59db84268feb626ae250/src/theme.ts#L125-L138

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Currently, the drop cursor is unstyled, and it does not show up against the page in dark mode.

Current:

<img width="106" height="69" alt="DropCursorLM" src="https://github.com/user-attachments/assets/816e3640-6054-432d-9838-2fb1227b0922" />

<img width="87" height="70" alt="DropCursorDM" src="https://github.com/user-attachments/assets/cda5874e-49b8-4e2a-a57a-e88685759aa9" />


PR:

<img width="102" height="72" alt="PR-DropCursorLM" src="https://github.com/user-attachments/assets/1e448c8a-9c0b-42b8-86dc-5884ae0b3339" />

<img width="100" height="66" alt="PR-DropCursorDM" src="https://github.com/user-attachments/assets/4605b666-bead-456d-915d-3154a5d5fd11" />

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6
