### PR TITLE
[CSS] Fix macOS UX on scrollable toolbar

### DIFF
--- a/source/common/vue/window/WindowToolbar.vue
+++ b/source/common/vue/window/WindowToolbar.vue
@@ -248,6 +248,7 @@ body.darwin {
   div#toolbar {
     // On macOS, there is no titlebar, and as such we need to make the toolbar draggable
     -webkit-app-region: drag;
+    button, .toolbar-text { -webkit-app-region: no-drag; }
 
     height: @toolbar-height;
     font-size: @font-size;
@@ -274,7 +275,6 @@ body.darwin {
       background-color: transparent;
       border: none;
       padding: 4px 8px;
-      -webkit-app-region: no-drag;
 
       &:hover {
         background-color: rgb(230, 230, 230);


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
~~This PR re-enables trackpad scrolling in the toolbar when it is overflowing, but maintains draggability when there is no overflow. It also increases the traffic light padding to provide a draggable space no matter the overflow state.~~
This PR fixes button clicking and window dragging in the toolbar on macOS.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
~~A class, `.is-overflowing` is dynamically added to the `toolbar` element depending on the overflow state.~~

~~The CSS was updated to configure dragging behavior based on the `.is-overflowing` class. The traffic-light padding was also increased to provide a larger draggable area.~~

Added `-webkit-app-region: no-drag;` to macOS toolbar buttons and `.toolbar-text` classes so that they can be clicked.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
So it seems the electron drag handling is a bit more complicated. I tried to create a safe, draggable margin between the traffic lights and the scroll area, but the issue is when the scrollable area moves under this region, electron seems to detect it for no dragging, defeating the purpose. By ignoring dragging on buttons, we keep window dragging behavior, and the scroll area still responds to the trackpad when the scroll originates on a button.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6
