### PR TITLE
[CSS] Add margin to file manager `TreeItem`

### DIFF
--- a/source/win-main/file-manager/TreeItem.vue
+++ b/source/win-main/file-manager/TreeItem.vue
@@ -610,7 +610,7 @@ body {
     .tree-item {
       white-space: nowrap;
       display: flex;
-      margin: 8px;
+      margin: 8px 0px;
 
       .item-icon, .toggle-icon {
         display: flex;
@@ -621,8 +621,11 @@ body {
       }
 
       .display-text {
+        font-size: 13px;
+        padding: 3px 5px;
         overflow: hidden;
         text-overflow: ellipsis;
+        margin-right: 8px;
 
         // These inputs should be more or less "invisible"
         input {
@@ -673,10 +676,7 @@ body.darwin {
     clr-icon.special { color: var(--system-accent-color, --c-primary); }
 
     .display-text {
-      font-size: 13px;
-      padding: 3px 5px;
       border-radius: 4px;
-      overflow: hidden;
 
       &.highlight {
         outline-width: 2px;
@@ -701,10 +701,6 @@ body.win32 {
   .tree-item {
 
     .display-text {
-      font-size: 13px;
-      padding: 3px 5px;
-      overflow: hidden;
-
       &.highlight {
         // This class is applied on drag & drop
         background-color: var(--system-accent-color, --c-primary);
@@ -718,10 +714,6 @@ body.linux {
   .tree-item {
 
     .display-text {
-      font-size: 13px;
-      padding: 3px 5px;
-      overflow: hidden;
-
       &.highlight {
         // This class is applied on drag & drop
         background-color: var(--system-accent-color, --c-primary);

--- a/source/win-main/file-manager/TreeItem.vue
+++ b/source/win-main/file-manager/TreeItem.vue
@@ -610,6 +610,7 @@ body {
     .tree-item {
       white-space: nowrap;
       display: flex;
+      margin: 8px;
 
       .item-icon, .toggle-icon {
         display: flex;
@@ -666,7 +667,6 @@ body {
 
 body.darwin {
   .tree-item {
-    margin: 6px 0px;
     color: rgb(53, 53, 53);
 
     // On macOS, non-standard icons are normally displayed in color
@@ -699,7 +699,6 @@ body.darwin {
 
 body.win32 {
   .tree-item {
-    margin: 8px 0px;
 
     .display-text {
       font-size: 13px;
@@ -717,7 +716,6 @@ body.win32 {
 
 body.linux {
   .tree-item {
-    margin: 8px 0px;
 
     .display-text {
       font-size: 13px;


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR adds a margin to the right side of the file manager `TreeItem` items.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The platform-specific margins were unified into a single margin size. Only macOS margins were changed, essentially, increasing from `6px` to `8px`.

`font-size`, `overflow`, and `padding` of `.display-text` styles were unified.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Current:

<img width="161" height="387" alt="Screenshot 2025-09-09 at 16 25 02" src="https://github.com/user-attachments/assets/bd25fe24-cb0e-4798-baef-76ef8cd7fbd5" />

PR:

<img width="148" height="347" alt="Screenshot 2025-09-09 at 16 24 46" src="https://github.com/user-attachments/assets/8e674dfc-cf03-4b5c-b59f-e0706b90785e" />

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6 and Fedora 42
