### PR TITLE
[CSS] Style the global search pane

### DIFF
--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -555,6 +555,25 @@ body div#global-search-pane {
     border-bottom: 1px solid #ccc;
   }
 
+  p {
+    margin-top: 5px;
+    display: flex;
+    gap: 5px;
+  }
+
+  .form-control {
+    input {
+      margin-top: 5px;
+    }
+  }
+
+  // hide chromium 'search-clear' element since it cannot be styled
+  input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+    display: none;
+  }
+
   div.search-result-container {
     border-bottom: 1px solid rgb(180, 180, 180);
     padding: 10px;

--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -558,6 +558,7 @@ body div#global-search-pane {
   p {
     margin-top: 5px;
     display: flex;
+    flex-wrap: wrap;
     gap: 5px;
   }
 

--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -568,13 +568,6 @@ body div#global-search-pane {
     }
   }
 
-  // hide chromium 'search-clear' element since it cannot be styled
-  input[type="search"]::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    appearance: none;
-    display: none;
-  }
-
   div.search-result-container {
     border-bottom: 1px solid rgb(180, 180, 180);
     padding: 10px;


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR restyles the global search pane to increase spacing between elements.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Added margin between the `form-control` label and input box.

Wrapped the `search` and `cancel` buttons in a flex container and created a gap between the buttons

Hid the `search-clear` element since it cannot be styled. 

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Current:
<img width="298" height="216" alt="Screenshot 2025-09-09 at 17 16 27" src="https://github.com/user-attachments/assets/24bdc43c-f976-4a24-b503-62057f4df8ed" />

PR:

<img width="293" height="272" alt="Screenshot 2025-09-09 at 17 16 06" src="https://github.com/user-attachments/assets/2a97ef67-d60e-4b4f-9b89-c8f42d991ac1" />

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6, Fedora 42
