### PR TITLE
[CSS] Match formatting toolbar and menu toolbar `comment` icon

### DIFF
--- a/source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts
+++ b/source/common/modules/markdown-editor/tooltips/formatting-toolbar.ts
@@ -62,12 +62,12 @@ function getToolbar (state: EditorState): Tooltip[] {
       const comment = document.createElement('button')
       comment.classList.add('formatting-toolbar-button')
       comment.setAttribute('title', trans('Comment'))
-      comment.innerHTML = '<cds-icon shape="code-alt"></cds-icon>'
+      comment.innerHTML = '<cds-icon shape="code"></cds-icon>'
 
       const code = document.createElement('button')
       code.classList.add('formatting-toolbar-button')
       code.setAttribute('title', trans('Code'))
-      code.innerHTML = '<cds-icon shape="code"></cds-icon>'
+      code.innerHTML = '<cds-icon shape="code-alt"></cds-icon>'
 
       buttonWrapper.append(bold, italic, link, image, comment, code)
       dom.append(buttonWrapper)


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR matches the icon used for inserting comments between the formatting toolbar and the menu toolbar

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The formatting toolbar icon for inserting comments was updated to `code` to match the menu toolbar icon.

The icon for inserting code was changed to `code-alt`. 

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I chose to switch the formatting toolbar icons rather than changing the menu toolbar icon because the `code` icon, `</>`, makes more sense to me as a comment. Likewise, the `code-alt` icon, `< >`, matches what is used in the Github text editor.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 15.6
