### PR TITLE
[Fix] Reduce Resize observer infinite loops in dev environment

### DIFF
--- a/source/common/vue/window/SplitView.vue
+++ b/source/common/vue/window/SplitView.vue
@@ -69,7 +69,11 @@ const view2WidthMin = ref<number>(availableSize.value * (props.minimumSizePercen
 // Properties necessary for hiding views programmatically
 const originalViewWidth = ref<[number, number]>([ 0, 0 ])
 const hasHiddenView = ref<0|1|2>(0) // Is 1 or 2 if one view is hidden
-const observer = new ResizeObserver(recalculateSizes)
+const observer = new ResizeObserver(() => {
+  requestAnimationFrame(() => {
+    recalculateSizes()
+  })
+})
 
 const element = ref<HTMLDivElement|null>(null)
 

--- a/source/common/vue/window/SplitView.vue
+++ b/source/common/vue/window/SplitView.vue
@@ -108,7 +108,6 @@ function recalculateSizes (): void {
 }
 
 onMounted(() => {
-  window.addEventListener('resize', recalculateSizes)
   recalculateSizes()
   if (element.value !== null) {
     observer.observe(element.value, { box: 'border-box' })
@@ -116,7 +115,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', recalculateSizes)
   if (element.value !== null) {
     observer.unobserve(element.value)
   }

--- a/source/win-main/DocumentTabs.vue
+++ b/source/win-main/DocumentTabs.vue
@@ -105,7 +105,9 @@ const props = defineProps<{
 
 const showScrollers = ref<boolean>(false)
 const resizeObserver = new ResizeObserver(() => {
-  maybeActivateScrollers()
+  requestAnimationFrame(() => {
+    maybeActivateScrollers()
+  })
 })
 
 // Is there a document being dragged over this tabbar?

--- a/source/win-stats/GraphView.vue
+++ b/source/win-stats/GraphView.vue
@@ -84,7 +84,11 @@ const zoomFactor = ref(1)
 const graphElement = ref<d3.Selection<SVGSVGElement, undefined, null, undefined>|null>(null)
 const simulation = ref<d3.Simulation<d3.SimulationNodeDatum, undefined>|null>(null)
 // Add an observer to resize the SVG element as necessary
-const controlsObserver = new ResizeObserver(updateGraphSize)
+const controlsObserver = new ResizeObserver(() => {
+  requestAnimationFrame(() => {
+    updateGraphSize()
+  })
+})
 
 const selectableComponents = computed(() => {
   const ret: Record<string, string> = {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR attempts to reduce infinite loops in the various resize observers

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The resize observers were refactored to delay calculation using `requestAnimationFrame` as suggested by https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors

What appeared to be duplicate `resize` event listeners were removed.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
In a dev environment, I'm constantly plagued by `Resize Observer infinite loop` erros and `undelivered window notification` errors. On linux, the issue is especially bad. This approach seemed like the simplest without refactoring the resize calculations. In my testing, this drastically reduced any warnings or errors.

This problem does not occur in a production environment.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26, Fedora 42
