### PR TITLE
Use LanguageTool API `data` parameter to reduce load; and filter words from local dictionary

### DIFF
--- a/source/app/service-providers/commands/language-tool.ts
+++ b/source/app/service-providers/commands/language-tool.ts
@@ -119,7 +119,7 @@ export default class LanguageTool extends ZettlrCommand {
    *
    * @return  {Promise<LanguageToolAPIResponse|string|undefined>}       The result
    */
-  async run (evt: string, arg: { text: string, language: string }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
+  async run (evt: string, arg: { text: string, data: string, language: string }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
     const {
       active,
       level,
@@ -130,13 +130,13 @@ export default class LanguageTool extends ZettlrCommand {
       customServer,
       provider
     } = this._app.config.getConfig().editor.lint.languageTool
-    const { text, language } = arg
+    const { text, data, language } = arg
 
     if (!active) {
       return undefined // LanguageTool is not active
     }
 
-    const searchParams = new URLSearchParams({ language, text, level })
+    const searchParams = new URLSearchParams({ language, data, level })
 
     // If the user has set the mother tongue, add it to the params
     if (motherTongue.trim() !== '') {

--- a/source/app/service-providers/commands/language-tool.ts
+++ b/source/app/service-providers/commands/language-tool.ts
@@ -21,7 +21,8 @@ import type { AppServiceContainer } from 'source/app/app-service-container'
 
 export interface Annotation {
   text?: string,
-  markup?: string
+  markup?: string,
+  interpretAs?: string
 }
 
 export interface AnnotationData {

--- a/source/app/service-providers/commands/language-tool.ts
+++ b/source/app/service-providers/commands/language-tool.ts
@@ -129,7 +129,7 @@ export default class LanguageTool extends ZettlrCommand {
    *
    * @return  {Promise<LanguageToolAPIResponse|string|undefined>}       The result
    */
-  async run (evt: string, arg: { data: AnnotationData, language: string }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
+  async run (evt: string, arg: { data: AnnotationData, language: string, disabledRules: string[] }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
     const {
       active,
       level,
@@ -140,13 +140,13 @@ export default class LanguageTool extends ZettlrCommand {
       customServer,
       provider
     } = this._app.config.getConfig().editor.lint.languageTool
-    const { data, language } = arg
+    const { data, language, disabledRules } = arg
 
     if (!active) {
       return undefined // LanguageTool is not active
     }
 
-    const searchParams = new URLSearchParams({ language, data: JSON.stringify(data), level })
+    const searchParams = new URLSearchParams({ language, data: JSON.stringify(data), level, disabledRules: disabledRules.join(',') })
 
     // If the user has set the mother tongue, add it to the params
     if (motherTongue.trim() !== '') {

--- a/source/app/service-providers/commands/language-tool.ts
+++ b/source/app/service-providers/commands/language-tool.ts
@@ -19,6 +19,15 @@ import { app } from 'electron'
 import { trans } from '@common/i18n-main'
 import type { AppServiceContainer } from 'source/app/app-service-container'
 
+export interface Annotation {
+  text?: string,
+  markup?: string
+}
+
+export interface AnnotationData {
+  annotation: Annotation[]
+}
+
 export interface LanguageToolAPIMatch {
   message: string // Long message (English)
   shortMessage: string
@@ -119,7 +128,7 @@ export default class LanguageTool extends ZettlrCommand {
    *
    * @return  {Promise<LanguageToolAPIResponse|string|undefined>}       The result
    */
-  async run (evt: string, arg: { text: string, data: string, language: string }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
+  async run (evt: string, arg: { data: AnnotationData, language: string }): Promise<[LanguageToolAPIResponse, string[]]|string|undefined> {
     const {
       active,
       level,
@@ -130,13 +139,13 @@ export default class LanguageTool extends ZettlrCommand {
       customServer,
       provider
     } = this._app.config.getConfig().editor.lint.languageTool
-    const { text, data, language } = arg
+    const { data, language } = arg
 
     if (!active) {
       return undefined // LanguageTool is not active
     }
 
-    const searchParams = new URLSearchParams({ language, data, level })
+    const searchParams = new URLSearchParams({ language, data: JSON.stringify(data), level })
 
     // If the user has set the mother tongue, add it to the params
     if (motherTongue.trim() !== '') {
@@ -171,6 +180,8 @@ export default class LanguageTool extends ZettlrCommand {
       server = server.substring(0, server.length - 1)
     }
 
+    const numCharacters = data.annotation.reduce((a, b) => a + (b.text?.length ?? b.markup?.length ?? 0), 0)
+
     const headers = {
       // NOTE: For debugging purposes, we send a custom User-Agent string. This
       // should help figure out potential problems in case Zettlr causes large
@@ -179,7 +190,7 @@ export default class LanguageTool extends ZettlrCommand {
     }
 
     try {
-      this._app.log.verbose(`[Application] Contacting LanguageTool at ${server} (using credentials: ${String(useCredentials)}); payload: ${text.length} characters`)
+      this._app.log.verbose(`[Application] Contacting LanguageTool at ${server} (using credentials: ${String(useCredentials)}); payload: ${numCharacters} characters`)
       const languages = await fetchSupportedLanguages(server)
       // NOTE: Documentation at https://languagetool.org/http-api/#!/default/post_check
       const result = await got(`${server}/v2/check`, { method: 'post', body: searchParams.toString(), headers })

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -97,12 +97,12 @@ const ltLinter = linter(async view => {
     const from = node.from - node.whitespaceBefore.length
 
     if (from - idx > 0) {
-      const markup: Annotation = { markup: view.state.sliceDoc(idx, from - 1) }
+      const markup: Annotation = { markup: view.state.sliceDoc(idx, from) }
       annotations.annotation.push(markup)
     }
     const text: Annotation = { text: view.state.sliceDoc(from, node.to) }
     annotations.annotation.push(text)
-    idx = node.to + 1
+    idx = node.to
   }
   // If the last TextNode does not extend to the end of the document,
   // add the remainder as `markup`.
@@ -153,8 +153,8 @@ const ltLinter = linter(async view => {
       : (match.rule.issueType === 'misspelling') ? 'error' : 'warning'
 
     const dia: Diagnostic = {
-      from: match.offset + 1,
-      to: match.offset + 1 + match.length,
+      from: match.offset,
+      to: match.offset + match.length,
       message: match.message,
       severity,
       source

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -30,23 +30,19 @@ export interface LanguageToolStateField {
   lastError: string|undefined
 }
 
-interface UserDictionaryStore {
-  value: Set<string>
-}
-
 // store the local dictionary for later filtering
-const userDictionary: UserDictionaryStore = {
-  value: new Set()
-}
+const userDictionary: Set<string> = new Set()
 
 function refreshUserDictionary (): void {
-  userDictionary.value.clear()
+  userDictionary.clear()
 
   ipcRenderer.invoke(
     'dictionary-provider',
     { command: 'get-user-dictionary' }
   ).then((dictionary: string[]) => {
-    userDictionary.value = new Set(dictionary)
+    for (const word of dictionary) {
+      userDictionary.add(word)
+    }
   }).catch(console.error)
 }
 
@@ -256,7 +252,7 @@ const ltLinter = linter(async view => {
     const word = view.state.sliceDoc(match.offset, match.offset + match.length)
     const issueType = match.rule.issueType
     // skip matches for words in the local dictionary
-    if (issueType === 'misspelling' && userDictionary.value.has(word)) { continue }
+    if (issueType === 'misspelling' && userDictionary.has(word)) { continue }
 
     const source = `language-tool(${match.rule.issueType})`
     const severity = (issueType === 'style')

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -214,12 +214,10 @@ const ltLinter = linter(async view => {
     prevNode = text
     idx = to
   }
-
-  // If the last TextNode does not extend to the end of the document,
-  // add the remainder as `markup`.
-  if (idx < view.state.doc.length) {
-    annotations.annotation.push({ markup: view.state.sliceDoc(idx) })
-  }
+  // Note: Since the iteration ends on a text node, any markup
+  // at the end of the document will be excluded from what is
+  // sent to the LT API server. This can potentially reduce the
+  // amount of data sent.
 
   const response: [LanguageToolAPIResponse, string[]]|undefined|string = await ipcRenderer.invoke('application', {
     command: 'run-language-tool',

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -320,6 +320,9 @@ const ltLinter = linter(async view => {
       }
     }
 
+    // TODO: Add a class and styling once
+    // https://github.com/codemirror/lint/commit/50bd1188fe15d92b03cc5c1ea4ffbee44f28a090
+    // lands in a release
     actions.push({
       name: trans('Ignore: %s', match.rule.id),
       apply (view) {

--- a/source/common/modules/markdown-editor/theme/main-override.ts
+++ b/source/common/modules/markdown-editor/theme/main-override.ts
@@ -76,9 +76,6 @@ export const mainOverride = EditorView.baseTheme({
     color: 'var(--grey-2)',
     backgroundColor: 'var(--grey-0)'
   },
-  '.cm-diagnostic button[aria-label*="Ignore Rule"]': {
-    backgroundColor: 'orangered',
-  },
   '&dark .cm-yaml-frontmatter-start::after': {
     color: 'var(--grey-0)',
     backgroundColor: 'var(--grey-4)'

--- a/source/common/modules/markdown-editor/theme/main-override.ts
+++ b/source/common/modules/markdown-editor/theme/main-override.ts
@@ -76,6 +76,9 @@ export const mainOverride = EditorView.baseTheme({
     color: 'var(--grey-2)',
     backgroundColor: 'var(--grey-0)'
   },
+  '.cm-diagnostic button[aria-label*="Ignore Rule"]': {
+    backgroundColor: 'orangered',
+  },
   '&dark .cm-yaml-frontmatter-start::after': {
     color: 'var(--grey-0)',
     backgroundColor: 'var(--grey-4)'

--- a/source/common/modules/markdown-utils/markdown-ast/parse-children.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/parse-children.ts
@@ -34,6 +34,7 @@ const EMPTY_NODES = [
   'SubscriptMark',
   'HighlightMark',
   'HeaderMark',
+  'Blockquote',
   'QuoteMark',
   'ListMark',
   'TaskMarker',

--- a/source/common/modules/markdown-utils/markdown-ast/parse-children.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/parse-children.ts
@@ -42,6 +42,7 @@ const EMPTY_NODES = [
   'Document',
   'List',
   'ListItem',
+  'TaskMarker',
   'PandocAttribute'
 ]
 

--- a/source/common/modules/markdown-utils/markdown-to-html.ts
+++ b/source/common/modules/markdown-utils/markdown-to-html.ts
@@ -80,6 +80,8 @@ function getTagInfo (node: GenericNode): HTMLTag {
     ret.selfClosing = true
   } else if (node.name === 'Paragraph') {
     ret.tagName = 'p'
+  } else if (node.name === 'Blockquote') {
+    ret.tagName = 'blockquote'
   } else if (node.name === 'FencedCode' || node.name === 'InlineCode') {
     ret.tagName = 'code'
   } else if (node.children.length === 1) {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR changes the languagetool API call to pass the document as the `data` parameter, and it filters out languagetool responses which match words in the local user dictionary.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
By sanitizing the document into a list of `{ text: string}` and `{ markup: string }` objects, we can pass the JSON to the LanguageTool API, and it will only use the `text` objects to generate errors.

This reduces the load on the API service and increases the number of meaningful lints returned by the API.

The linter now filters out any matches for words that are in the local user dictionary.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
~~Currently, it seems that `Task` nodes are not parsed correctly -- in my testing, `[ ]` is marked as a text node. I believe this is because we do not activate [all of the GFM extensions](https://github.com/lezer-parser/markdown?tab=readme-ov-file#user-content-gfm), we only activate the base GFM extension via `markdownLanguage`. There could be other causes, but I have not pinned down the problem.~~ So it actually seems to be an issue with the `parseChildren` method when generating the AST for list items. <-- This should be fixed now.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
