### PR TITLE
[CSS] Cleanup print preview CSS

### DIFF
--- a/source/win-print/App.vue
+++ b/source/win-print/App.vue
@@ -106,7 +106,7 @@ function handleClick (buttonID?: string): void {
 #print-container {
   width: 100%;
   border: none;
-  
+
   // Styles primarily copied from the Pandoc default HTML template to emulate
   // the old print preview:
   // https://github.com/jgm/pandoc/blob/main/data/templates/styles.html
@@ -124,7 +124,9 @@ function handleClick (buttonID?: string): void {
   font-family: Georgia, 'Times New Roman', serif;
   font-size: 12pt;
   overflow-y: auto;
-  line-height: 120%;
+  // minimum recommended height for accessibility
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#accessibility
+  line-height: 1.5;
 
   p {
     margin: 1em 0;
@@ -139,7 +141,7 @@ function handleClick (buttonID?: string): void {
     height: auto;
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
     margin-top: 1.4em;
   }
 

--- a/source/win-print/App.vue
+++ b/source/win-print/App.vue
@@ -124,9 +124,7 @@ function handleClick (buttonID?: string): void {
   font-family: Georgia, 'Times New Roman', serif;
   font-size: 12pt;
   overflow-y: auto;
-  // minimum recommended height for accessibility
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#accessibility
-  line-height: 1.5;
+  line-height: 1.2;
 
   p {
     margin: 1em 0;


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes some CSS related to print previews.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The `line-height` parameter was changed from a percentage to a number. Setting it this way is the [recommended approach](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#number), likewise, it means other elements with different font sizes inherit the property correctly. It was set to `1.5` to meet [minimum accessibility recommendations](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#accessibility).

The `margin-top` parameter for headings is only applied to all but the first element. This removes additional margin at the top of the document.
 
## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Current:

<img width="613" height="723" alt="Screenshot 2025-09-24 at 11 54 50" src="https://github.com/user-attachments/assets/459ae25f-f527-4258-bda9-b92393d9b46a" />

PR:

<img width="606" height="722" alt="Screenshot 2025-09-24 at 11 54 37" src="https://github.com/user-attachments/assets/2a10a0c5-7460-420b-9928-432343bc9a16" />

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
