### PR TITLE
[Fix] Add special handling for InlineCode (`` and $$) in LanguageTool pre-parsing

### DIFF
--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -282,7 +282,7 @@ const ltLinter = linter(async view => {
     // https://github.com/codemirror/lint/commit/50bd1188fe15d92b03cc5c1ea4ffbee44f28a090
     // lands in a release
     actions.push({
-      name: trans('Disable: %s', match.rule.id),
+      name: trans('Disable Rule'),
       apply (view) {
         // In order to ignore a rule, we do two things. First, we keep the
         // local ignoring-mechanism from @benniekiss, because that will allow us

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -148,7 +148,6 @@ const ltLinter = linter(async view => {
   // to address spacing errors that occur when these nodes are included
   // as markup.
   const codeNodes = extractASTNodes(ast, 'InlineCode')
-  const filterRegions: { from: number, to: number }[] = codeNodes.map(node => { return { from: node.from, to: node.to } })
 
   const combinedNodes = codeNodes.concat(textNodes).sort((a, b) => a.from - b.from)
 
@@ -225,8 +224,8 @@ const ltLinter = linter(async view => {
     const matchFrom: number = match.offset
     const matchTo: number = match.offset + match.length
 
-    // Exclude diagnostics overlapping with our filtered regions
-    if (filterRegions.some(range => !(matchTo <= range.from || matchFrom >= range.to))) { continue }
+    // Exclude diagnostics overlapping with InlineCode nodes.
+    if (codeNodes.some(node => !(matchTo <= node.from || matchFrom >= node.to))) { continue }
 
     const word = view.state.sliceDoc(matchFrom, matchTo)
     const issueType = match.rule.issueType


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR implements a simpler way to handle inline markup when sanitizing the payload for LanguageTool.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
When we sanitize the payload for LanguageTool, inline code and math pose unique issues due to how LT parses the spacing. Initially, I tried manually adjust the whitespace, however, there are too many edgecases.

This approach tries to simplify sanitization. By including the inline markup with the regular text and later filtering out diagnostics generated for those inline regions, LT processes the text correctly, and we can exclude any unwanted errors.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
