### PR TITLE
[Enhancement] Improve spellchecker linting

### DIFF
--- a/source/app/service-providers/dictionary/index.ts
+++ b/source/app/service-providers/dictionary/index.ts
@@ -96,6 +96,8 @@ export default class DictionaryProvider extends ProviderContract {
         return Promise.all(terms.map(t => this.suggest(t, limit)))
       } else if (command === 'add') {
         return Promise.all(terms.map(t => this.add(t)))
+      } else if (command === 'remove') {
+        return Promise.all(terms.map(t => this.remove(t)))
       }
     })
 

--- a/source/app/service-providers/dictionary/index.ts
+++ b/source/app/service-providers/dictionary/index.ts
@@ -400,14 +400,14 @@ export default class DictionaryProvider extends ProviderContract {
       return suggestions
     }
 
-    if (this._userHunspell !== undefined) {
-      const userSuggestions = await this._userHunspell?.suggest(term) ?? []
-      suggestions.push(...userSuggestions.slice(0, limit))
-    }
-
     for (const dictionary of this.hunspell) {
       const values = await dictionary.suggest(term) ?? []
       suggestions.push(...values.slice(0, limit))
+    }
+
+    if (this._userHunspell !== undefined) {
+      const userSuggestions = await this._userHunspell?.suggest(term) ?? []
+      suggestions.push(...userSuggestions.slice(0, limit))
     }
 
     return suggestions

--- a/source/common/modules/markdown-editor/linters/spellcheck.ts
+++ b/source/common/modules/markdown-editor/linters/spellcheck.ts
@@ -20,15 +20,6 @@ import { trans } from '@common/i18n-renderer'
 
 const ipcRenderer = window.ipc
 
-// Below's monstrosity is taken from https://stackoverflow.com/a/43243160
-// const emojiRegex = /(?:[\u00A9\u00AE\u203C\u2049\u2122\u2139\u2194-\u2199\u21A9-\u21AA\u231A-\u231B\u2328\u23CF\u23E9-\u23F3\u23F8-\u23FA\u24C2\u25AA-\u25AB\u25B6\u25C0\u25FB-\u25FE\u2600-\u2604\u260E\u2611\u2614-\u2615\u2618\u261D\u2620\u2622-\u2623\u2626\u262A\u262E-\u262F\u2638-\u263A\u2640\u2642\u2648-\u2653\u2660\u2663\u2665-\u2666\u2668\u267B\u267F\u2692-\u2697\u2699\u269B-\u269C\u26A0-\u26A1\u26AA-\u26AB\u26B0-\u26B1\u26BD-\u26BE\u26C4-\u26C5\u26C8\u26CE-\u26CF\u26D1\u26D3-\u26D4\u26E9-\u26EA\u26F0-\u26F5\u26F7-\u26FA\u26FD\u2702\u2705\u2708-\u270D\u270F\u2712\u2714\u2716\u271D\u2721\u2728\u2733-\u2734\u2744\u2747\u274C\u274E\u2753-\u2755\u2757\u2763-\u2764\u2795-\u2797\u27A1\u27B0\u27BF\u2934-\u2935\u2B05-\u2B07\u2B1B-\u2B1C\u2B50\u2B55\u3030\u303D\u3297\u3299]|(?:\uD83C[\uDC04\uDCCF\uDD70-\uDD71\uDD7E-\uDD7F\uDD8E\uDD91-\uDD9A\uDDE6-\uDDFF\uDE01-\uDE02\uDE1A\uDE2F\uDE32-\uDE3A\uDE50-\uDE51\uDF00-\uDF21\uDF24-\uDF93\uDF96-\uDF97\uDF99-\uDF9B\uDF9E-\uDFF0\uDFF3-\uDFF5\uDFF7-\uDFFF]|\uD83D[\uDC00-\uDCFD\uDCFF-\uDD3D\uDD49-\uDD4E\uDD50-\uDD67\uDD6F-\uDD70\uDD73-\uDD7A\uDD87\uDD8A-\uDD8D\uDD90\uDD95-\uDD96\uDDA4-\uDDA5\uDDA8\uDDB1-\uDDB2\uDDBC\uDDC2-\uDDC4\uDDD1-\uDDD3\uDDDC-\uDDDE\uDDE1\uDDE3\uDDE8\uDDEF\uDDF3\uDDFA-\uDE4F\uDE80-\uDEC5\uDECB-\uDED2\uDEE0-\uDEE5\uDEE9\uDEEB-\uDEEC\uDEF0\uDEF3-\uDEF6]|\uD83E[\uDD10-\uDD1E\uDD20-\uDD27\uDD30\uDD33-\uDD3A\uDD3C-\uDD3E\uDD40-\uDD45\uDD47-\uDD4B\uDD50-\uDD5E\uDD80-\uDD91\uDDC0]))/
-// The L matches any letter from any alphabet, including chinese, Japanese,
-// Russian, etc. Additionally, we have quote characters so that "don't" (with
-// typographically correct quotes) is also recognized.
-const anyLetterRE = /[\p{L}'’‘]+/gu
-const noneLetterRE = /^['’‘]+$/
-const nonLetters = '\'’‘'
-
 // The cache is a simple hashmap. NOTE: This is shared across all spellcheckers,
 // which reduces the memory footprint but prevents differences in spellchecker
 // configuration across the window. So if we want to allow that at some point,
@@ -179,26 +170,21 @@ export const spellcheck = linter(async view => {
   const ast = markdownToAST(view.state.doc.toString())
   const textNodes = extractTextnodes(ast)
 
-  const wordsToCheck: Array<{ word: string, index: number, nodeStart: number }> = textNodes
+  const locale: string = window.config.get('appLang')
+  const segmenter = new Intl.Segmenter(locale, { granularity: 'word' })
+
+  const wordsToCheck: { word: string, index: number, nodeStart: number }[] = textNodes
     // First, extract all words from the node's value
     .flatMap(node => {
-      const words: Array<{ index: number, word: string }> = []
-      for (const match of node.value.matchAll(anyLetterRE)) {
-        // Remove words that only consists, e.g., of quotes
-        if (!noneLetterRE.test(match[0])) {
-          // Remove none-letters from the beginnings and ends of words
-          let word = match[0]
-          while (nonLetters.includes(word[0])) {
-            word = word.slice(1)
-          }
-          while (nonLetters.includes(word[word.length - 1])) {
-            word = word.slice(0, word.length - 1)
-          }
-          words.push({ word, index: match.index })
+      const words: { index: number, word: string, nodeStart: number }[] = []
+
+      for (const { segment, index, isWordLike } of segmenter.segment(node.value)) {
+        if (isWordLike === true) {
+          words.push({ word: segment, index: index, nodeStart: node.from })
         }
       }
 
-      return words.map(x => ({ ...x, nodeStart: node.from }))
+      return words
     })
 
   // Now make sure everything is cached beforehand with two IPC calls


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR implements hunspell functionality for the local dictionary and enables spelling suggestions for mispelled words.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The dictionary provider was refactored to load and save the local dictionary as a hunspell dictionary. If an affix file does not exist, a barebones version is written at `user.aff` with the contents `SET UTF-8` whenever `persistUserDictionary()` is called. The file is only written if it does not exist.

`persistUserDictionary()` was refactored so that the first line of the written dictionary includes the number of terms in the list. I tried to implement this without that line, which I don't believe is technically necessary, but the local dictionary would not load without it.

Multiple methods were refactored to use the `async` hunspell functions, since Nodehun recommends against using the `Sync` versions.

The `add` function was refactored so that it now adds words to the runtime dictionary.

A `remove` function was added to remove words from the runtime user directory and remove them from the words list. Likewise, the `setUserDictionary()` function was refactored to use the remove method.

The `spellcheck` linter now returns spelling suggestions, currently limited at 3 per loaded dictionary. The linter now uses the `Intl.Segmenter` class to split text nodes into words rather than using regex.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
This should allow users to write dictionaries with the full power of hunspell.

Regarding the refactored `setUserDictionary()` method, I'm not sure if there are cases where this kind of `add/remove` would get out of sync, so I'm happy to revert it to the old way of a complete reset. I went this approach to avoid having to reload the hunspell object.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
