### PR TITLE
[Fix] Handle snippet tabstop removal

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -25,7 +25,8 @@ import {
   EditorSelection,
   Facet,
   type SelectionRange,
-  type EditorState
+  type EditorState,
+  MapMode,
 } from '@codemirror/state'
 import { Decoration, EditorView, WidgetType } from '@codemirror/view'
 import { type AutocompletePlugin } from '.'
@@ -161,9 +162,16 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
     }
 
     // This monstrosity ensures that our ranges stay in sync while the user types
-    val.activeSelections = val.activeSelections.map(selection => {
-      return selection.map(transaction.changes)
-    })
+    val.activeSelections = val.activeSelections
+      .filter(selection => selection.ranges.some(r => {
+        if (transaction.changes.mapPos(r.from, -1, MapMode.TrackBefore) === null) {
+          return false
+        }
+        return true
+      }))
+      .map(selection => {
+        return selection.map(transaction.changes)
+      })
 
     return { ...val }
   },

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -118,7 +118,7 @@ export function defaultKeymap (): Extension {
     { key: 'Backspace', run: deleteBracketPair },
     { key: 'Backspace', run: handleBackspace },
 
-    { key: 'Esc', run: abortSnippet },
+    { key: 'Escape', run: abortSnippet },
     { key: 'Space', run: handleReplacement },
 
     { key: 'Alt-ArrowUp', run: customMoveLineUp, shift: copyLineUp },


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes two bugs related to tabstop removal from snippets 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The `Escape` shortcut was fixed so that it now correctly removes all remaining tabstops. There was ony a small typo.

Tabstops are now removed if the context before them was deleted by mapping positions using `MapMode.TrackBefore`. This enables a user to manually select and remove tabstops.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
