### PR TITLE
[CSS] Style assets window

### DIFF
--- a/source/common/vue/form/elements/SelectableList.vue
+++ b/source/common/vue/form/elements/SelectableList.vue
@@ -132,9 +132,13 @@ function handleContextMenu (event: MouseEvent, idx: number): void {
 <style lang="less">
 body .selectable-list-wrapper {
   --selectable-list-border-color: rgb(230, 230, 230);
-  padding: 10px;
+  height: 100%;
+  min-height: 0;
+  padding: 10px 10px 0px 10px;
+  display: flex;
+  flex-direction: column;
 
-  &.has-footer { padding-bottom: 40px; }
+  &.has-footer { margin-bottom: 20px; }
 
   .selectable-list-footer {
     height: 22px;
@@ -155,7 +159,8 @@ body .selectable-list-wrapper {
 
   .selectable-list-container {
     border: 1px solid var(--selectable-list-border-color);
-    height: 100%;
+    flex: 1;
+    min-height: 50px;
     overflow: auto;
 
     div.item {

--- a/source/win-assets/App.vue
+++ b/source/win-assets/App.vue
@@ -73,16 +73,16 @@ const tabs: WindowTab[] = [
     icon: 'import'
   },
   {
-    label: trans('Custom CSS'),
-    controls: 'tab-custom-css',
-    id: 'tab-custom-css-control',
-    icon: 'code'
-  },
-  {
     label: trans('Snippets'),
     controls: 'tab-snippets',
     id: 'tab-snippets-control',
     icon: 'pinboard'
+  },
+  {
+    label: trans('Custom CSS'),
+    controls: 'tab-custom-css',
+    id: 'tab-custom-css-control',
+    icon: 'code'
   }
 ]
 </script>

--- a/source/win-assets/DefaultsTab.vue
+++ b/source/win-assets/DefaultsTab.vue
@@ -7,22 +7,29 @@
     v-bind:initial-total-width="100"
   >
     <template #view1>
-      <SelectableList
-        v-bind:items="listItems"
-        v-bind:editable="true"
-        v-bind:selected-item="currentItem"
-        v-on:select="currentItem = $event"
-        v-on:add="newDefaultsFile()"
-        v-on:remove="removeFile($event)"
-      ></SelectableList>
+      <div id="defaults-container-list">
+        <SelectableList
+          v-bind:items="listItems"
+          v-bind:editable="true"
+          v-bind:selected-item="currentItem"
+          v-on:select="currentItem = $event"
+          v-on:add="newDefaultsFile()"
+          v-on:remove="removeFile($event)"
+        ></SelectableList>
+        <ButtonControl
+          v-bind:label="openDefaultsFolderLabel"
+          v-bind:inline="false"
+          v-on:click="openDefaultsDirectory"
+        ></ButtonControl>
+      </div>
     </template>
     <template #view2>
       <div id="defaults-container">
         <p>{{ defaultsExplanation }}</p>
-
         <p>
           <TextControl
             v-model="currentFilename"
+            class="default-name-input"
             v-bind:inline="false"
             v-bind:disabled="currentItem < 0"
             v-on:confirm="renameFile()"
@@ -34,13 +41,6 @@
             v-on:click="renameFile()"
           ></ButtonControl>
         </p>
-
-        <ButtonControl
-          v-bind:label="openDefaultsFolderLabel"
-          v-bind:inline="false"
-          v-on:click="openDefaultsDirectory"
-        ></ButtonControl>
-
         <ZtrAdmonition v-if="visibleItems.length > 0 && visibleItems[currentItem].isProtected === true" type="info">
           {{ protectedProfileWarning }}
         </ZtrAdmonition>
@@ -56,8 +56,9 @@
         ></CodeEditor>
 
         <!-- This div is used to keep the buttons in a line despite the flex -->
-        <div>
+        <div class="save-default-file">
           <ButtonControl
+            class="save-button"
             v-bind:primary="true"
             v-bind:label="saveButtonLabel"
             v-bind:inline="true"
@@ -228,7 +229,6 @@ async function loadDefaultsForState (): Promise<void> {
   lastLoadedEditorContents.value = data
   editorContents.value = data
   currentFilename.value = visibleItems.value[currentItem.value].name
-  savingStatus.value = ''
 }
 
 async function retrieveDefaultsFiles (): Promise<void> {
@@ -259,9 +259,9 @@ function saveDefaultsFile (): void {
   } as AssetsProviderIPCAPI)
     .then(async () => {
       lastLoadedEditorContents.value = editorContents.value
-      savingStatus.value = trans('Saved!')
+      setTimeout(() => { savingStatus.value = trans('Saved!') }, 1000)
       await retrieveDefaultsFiles() // Always make sure to pull in any changes
-      setTimeout(() => { savingStatus.value = '' }, 1000)
+      setTimeout(() => { savingStatus.value = '' }, 2000)
     })
     .catch(err => console.error(err))
 }
@@ -330,11 +330,56 @@ function openDefaultsDirectory (): void {
 </script>
 
 <style lang="less">
+#defaults-container-list {
+  display: flex;
+  flex-direction: column;
+  height: stretch;
+
+  .form-control {
+    display: flex;
+    padding: 10px;
+
+    button {
+      flex: 1;
+    }
+  }
+}
+
 #defaults-container {
-  padding: 10px;
+  padding: 0px 10px;
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  .admonition {
+    margin-top: 15px;
+  }
+
+  .default-name-input {
+    flex: 1;
+  }
+
+  .save-default-file {
+    padding: 10px 0px;
+    display: flex;
+    gap: 15px;
+
+    button {
+      width: 50px;
+    }
+  }
+
+  .form-control {
+    button:not(.input-reset-button) {
+      height: stretch;
+    }
+  }
+
+  p {
+    display: flex;
+    gap: 15px;
+    margin-top: 5px;
+  }
 
   .CodeMirror {
     flex-grow: 1;

--- a/source/win-assets/SnippetsTab.vue
+++ b/source/win-assets/SnippetsTab.vue
@@ -7,14 +7,21 @@
     v-bind:initial-total-width="100"
   >
     <template #view1>
-      <SelectableList
-        v-bind:items="availableSnippets"
-        v-bind:selected-item="currentItem"
-        v-bind:editable="true"
-        v-on:select="currentItem = $event"
-        v-on:add="addSnippet()"
-        v-on:remove="removeSnippet($event)"
-      ></SelectableList>
+      <div id="snippets-container-list">
+        <SelectableList
+          v-bind:items="availableSnippets"
+          v-bind:selected-item="currentItem"
+          v-bind:editable="true"
+          v-on:select="currentItem = $event"
+          v-on:add="addSnippet()"
+          v-on:remove="removeSnippet($event)"
+        ></SelectableList>
+        <ButtonControl
+          v-bind:label="openSnippetsFolderLabel"
+          v-bind:inline="false"
+          v-on:click="openSnippetsDirectory"
+        ></ButtonControl>
+      </div>
     </template>
     <template #view2>
       <div id="snippets-container">
@@ -23,7 +30,8 @@
         <p>
           <TextControl
             v-model="currentSnippetText"
-            v-bind:inline="true"
+            class="snippet-name-input"
+            v-bind:inline="false"
             v-bind:disabled="currentItem < 0"
             v-on:confirm="renameSnippet()"
           ></TextControl>
@@ -35,27 +43,22 @@
           ></ButtonControl>
         </p>
 
-        <ButtonControl
-          v-bind:label="openSnippetsFolderLabel"
-          v-bind:inline="false"
-          v-on:click="openSnippetsDirectory"
-        ></ButtonControl>
-
         <CodeEditor
           ref="code-editor"
           v-model="editorContents"
           v-bind:mode="'markdown-snippets'"
           v-bind:readonly="currentItem < 0"
         ></CodeEditor>
-
-        <ButtonControl
-          v-bind:primary="true"
-          v-bind:label="saveButtonLabel"
-          v-bind:inline="true"
-          v-bind:disabled="currentItem < 0 || ($refs['code-editor'] as any).isClean()"
-          v-on:click="saveSnippet()"
-        ></ButtonControl>
-        <span v-if="savingStatus !== ''" class="saving-status">{{ savingStatus }}</span>
+        <div class="save-snippet-file">
+          <ButtonControl
+            v-bind:primary="true"
+            v-bind:label="saveButtonLabel"
+            v-bind:inline="true"
+            v-bind:disabled="currentItem < 0 || ($refs['code-editor'] as any).isClean()"
+            v-on:click="saveSnippet()"
+          ></ButtonControl>
+          <span v-if="savingStatus !== ''" class="saving-status">{{ savingStatus }}</span>
+        </div>
       </div>
     </template>
   </SplitView>
@@ -176,10 +179,8 @@ function saveSnippet (): void {
     }
   } as AssetsProviderIPCAPI)
     .then(() => {
-      savingStatus.value = trans('Saved!')
-      setTimeout(() => {
-        savingStatus.value = ''
-      }, 1000)
+      setTimeout(() => { savingStatus.value = trans('Saved!') }, 1000)
+      setTimeout(() => { savingStatus.value = '' }, 2000)
     })
     .catch(err => console.error(err))
 }
@@ -268,11 +269,52 @@ function openSnippetsDirectory (): void {
 </script>
 
 <style lang="less">
+#snippets-container-list {
+  display: flex;
+  flex-direction: column;
+  height: stretch;
+
+  .form-control {
+    display: flex;
+    padding: 10px;
+
+    button {
+      flex: 1;
+    }
+  }
+}
+
 #snippets-container {
-  padding: 10px;
+  padding: 0px 10px;
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  .snippet-name-input {
+    flex: 1;
+  }
+
+  .save-snippet-file {
+    padding: 10px 0px;
+    display: flex;
+    gap: 15px;
+
+    button {
+      width: 50px;
+    }
+  }
+
+  .form-control {
+    button:not(.input-reset-button) {
+      height: stretch;
+    }
+  }
+
+  p {
+    display: flex;
+    gap: 15px;
+    margin-top: 5px;
+  }
 
   .CodeMirror {
     flex-grow: 1;

--- a/source/win-preferences/App.vue
+++ b/source/win-preferences/App.vue
@@ -18,20 +18,22 @@
       v-bind:initial-total-width="100"
     >
       <template #view1>
-        <TextControl
-          v-model="query"
-          v-bind:placeholder="searchPlaceholder"
-          v-bind:search-icon="true"
-          v-bind:autofocus="true"
-          v-bind:reset="true"
-          style="padding: 10px 10px 0px 10px;"
-        ></TextControl>
-        <SelectableList
-          v-bind:items="groups"
-          v-bind:editable="false"
-          v-bind:selected-item="selectedItem"
-          v-on:select="selectGroup($event)"
-        ></SelectableList>
+        <div id="preferences-container-list">
+          <TextControl
+            v-model="query"
+            v-bind:placeholder="searchPlaceholder"
+            v-bind:search-icon="true"
+            v-bind:autofocus="true"
+            v-bind:reset="true"
+            style="padding: 10px 10px 0px 10px;"
+          ></TextControl>
+          <SelectableList
+            v-bind:items="groups"
+            v-bind:editable="false"
+            v-bind:selected-item="selectedItem"
+            v-on:select="selectGroup($event)"
+          ></SelectableList>
+        </div>
       </template>
       <template #view2>
         <FormBuilder
@@ -406,6 +408,13 @@ div[role="tabpanel"] {
   overflow: auto; // Enable scrolling, if necessary
   padding: 10px;
   width: 100%;
+}
+
+#preferences-container-list {
+  display: flex;
+  flex-direction: column;
+  max-height: stretch;
+  margin-bottom: 20px;
 }
 
 #no-results-message {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors the styling of the assets window.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Elements had margin spacing increased so they are no longer cramped together.

The `Open Directory` button of the defaults and snippets tab was moved to below the file picker.

The file picker element, `SelectableList` was made so that it expands to the size of the container, and when the window shrinks or there are too many files, the list scrolls rather than the whole container. See the attached video. Because of this change, the Preferences window had to be adjusted so that it scrolls correctly.

The `CSS` tab was moved to the end of the list because it offers a different window setup than snippets and defaults, which share a structure.

The `Save` button labeling was refactored to add some delay when clicking save so that the label doesn't quickly flash between `Saving...` and `Saved!`.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

**Current:**

<img width="869" height="516" alt="Screenshot 2025-10-08 at 11 49 30" src="https://github.com/user-attachments/assets/4090f2a8-2e2a-43b7-ad27-43bbc597df8b" />

https://github.com/user-attachments/assets/8217c79c-559d-4db7-9b64-2816519e870b

**PR:**

<img width="882" height="498" alt="Screenshot 2025-10-08 at 11 46 47" src="https://github.com/user-attachments/assets/0741277d-ec11-4e01-8eee-4468b514336f" />
<img width="874" height="503" alt="Screenshot 2025-10-08 at 11 47 02" src="https://github.com/user-attachments/assets/a3311f24-5c86-43d2-a59f-ce0dc160407f" />
<img width="700" height="374" alt="Screenshot 2025-10-08 at 11 47 13" src="https://github.com/user-attachments/assets/c56e7156-3a41-41d0-87af-fb2e636868c6" />

https://github.com/user-attachments/assets/50fb9bcb-0d0c-48b4-a35b-953909343823

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26 and Fedora 42
