### PR TITLE
[Enhancement] Refactor Footnote handling

### DIFF
--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -133,6 +133,7 @@ export interface ConfigOptions {
     boldFormatting: '**'|'__'
     italicFormatting: '_'|'*'
     readabilityAlgorithm: 'dale-chall'|'gunning-fog'|'coleman-liau'|'automated-readability'
+    cleanupFootnotes: boolean
     lint: {
       markdown: boolean
       languageTool: {
@@ -334,6 +335,7 @@ export function getConfigTemplate (): ConfigOptions {
       readabilityAlgorithm: 'dale-chall', // The algorithm to use with readability mode.
       showStatusbar: true,
       showFormattingToolbar: true,
+      cleanupFootnotes: false,
       lint: {
         markdown: true, // Should Markdown be linted?
         languageTool: {

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -76,6 +76,7 @@ import { defaultKeymap } from './keymaps/default'
 import { vimPlugin } from './plugins/vim-mode'
 import { projectInfoField } from './plugins/project-info-field'
 import { headingGutter } from './renderers/render-headings'
+import { cleanupFootnotesExtension } from './plugins/footnotes'
 
 /**
  * This interface describes the required properties which the extension sets
@@ -331,6 +332,7 @@ export function getMarkdownExtensions (options: CoreExtensionOptions): Extension
     formattingToolbar,
     footnoteHover,
     footnoteGutter, // Should be after markdownFolding
+    cleanupFootnotesExtension(options.initialConfig.cleanupFootnotes),
     urlHover,
     filePreview,
     backgroundLayers, // Add a background behind inline code and code blocks

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -98,6 +98,8 @@ export function defaultKeymap (): Extension {
     { key: 'Mod-Alt-i', mac: 'Mod-Shift-i', run: insertImage },
     { key: 'Mod-C', run: applyComment },
     { key: 'Mod-Alt-f', mac: 'Mod-Alt-r', run: addNewFootnote },
+    // TODO: Find a good key combo
+    // { key: 'Mod-Alt-Shift-f', mac: 'Mod-Alt-Shift-r', run: cleanupFootnotes },
 
     // Overload Tab, depending on context (priority high->low)
     { key: 'Tab', run: acceptCompletion },

--- a/source/common/modules/markdown-editor/parser/citation-parser.ts
+++ b/source/common/modules/markdown-editor/parser/citation-parser.ts
@@ -345,7 +345,7 @@ export const citationParser: InlineParser = {
       return -1
     }
 
-    
+
     // Ensure the character before `pos` is valid. NOTE: The InlineContext may
     // include newlines, since single newlines are considered part of the same
     // line due to the hard wrapping rule.
@@ -462,24 +462,24 @@ export const citationParser: InlineParser = {
           parts.push(ctx.elt(NODES.MARK, i, i + 1))
           continue
         }
-        
+
         if (ch === CHAR.BRACKET_CLOSE) {
           // End-condition -- marks the finish of the entire parsing.
           parts.push(ctx.elt(NODES.MARK, i, ++i))
           break // Stop iterating; citation is between pos and i.
         }
-        
+
         if (ch === CHAR.HYPHEN && citekeyStart < 0 && nextCh === CHAR.AT) {
           // Suppress-author-flag: Before citekey starts, must be followed by @
           if (i > citationPartStart) {
             // Add prefix node. Note that we have to add nodes in proper sorted
             // order.
             parts.push(ctx.elt(NODES.PREFIX, citationPartStart, i))
-          } 
+          }
           parts.push(ctx.elt(NODES.AUTHORFLAG, i, i + 1))
           continue
         }
-        
+
         if (ch === CHAR.AT && citekeyStart < 0 && [ CHAR.SPACE, CHAR.HYPHEN, CHAR.BRACKET_OPEN ].includes(prevCh)) {
           // Start citekey (must be preceded by [, a space, or -)
           if (i > citationPartStart && prevCh !== CHAR.HYPHEN) {
@@ -492,7 +492,7 @@ export const citationParser: InlineParser = {
           citekeyStart = i + 1 // Key excludes the '@'
           continue
         }
-        
+
         if (citekeyStart > -1 && citekeyEnd < 0) {
           // We are inside the citekey
           if (i === citekeyStart && ch === CHAR.CURLY_OPEN) {
@@ -537,7 +537,7 @@ export const citationParser: InlineParser = {
           parts.push(ctx.elt(NODES.MARK, i, i + 1))
           continue
         }
-        
+
         // Code points 48-57 are digits. Implicit and explicit locators must be
         // preceded by a space, bracketed locators do not.
         if (citekeyEnd > -1 && locatorStart < 0 && prevCh === CHAR.SPACE && ((ch >= 48 && ch <= 57) || ROMAN_NUMERAL_CODES.includes(ch))) {
@@ -570,7 +570,7 @@ export const citationParser: InlineParser = {
           }
           continue
         }
-        
+
         if (locatorStart > -1 && locatorEnd < 0) {
           // We are inside the locator
           if (locatorInBrackets && ch === CHAR.CURLY_CLOSE) {

--- a/source/common/modules/markdown-editor/plugins/footnotes.ts
+++ b/source/common/modules/markdown-editor/plugins/footnotes.ts
@@ -1,0 +1,101 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Footnote Cleanup Extension
+ * CVM-Role:        Extension
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     An extension thats removes dangling footnotes,
+ *                  sorts them, and moves them to the end of the document
+ *
+ * END HEADER
+ */
+
+import { EditorState, Compartment, type Extension } from '@codemirror/state'
+import { ViewPlugin, type ViewUpdate, type EditorView } from '@codemirror/view'
+import { configUpdateEffect } from '../util/configuration'
+import { cleanupFootnotes } from '../commands/footnotes'
+
+/**
+ * This ViewPlugin debounces the footnote cleanup dispatch
+*/
+const cleanupFootnotesAndNumbering = ViewPlugin.fromClass(class {
+  private timeout: number | null = null
+  private delay = 2000
+
+  update (update: ViewUpdate) {
+    if (!update.docChanged) { return }
+
+    // Avoid cyclic updates
+    for (const tr of update.transactions) {
+      if (tr.isUserEvent('footnote-cleanup')) {
+        return
+      }
+    }
+
+    this.cleanupFootnotes(update.view)
+  }
+
+  cleanupFootnotes (view: EditorView) {
+    if (this.timeout != null) {
+      window.clearTimeout(this.timeout)
+    }
+
+    this.timeout = window.setTimeout(() => {
+      this.timeout = null
+      cleanupFootnotes(view)
+
+    }, this.delay)
+  }
+
+  destroy () {
+    if (this.timeout != null) {
+      window.clearTimeout(this.timeout)
+      this.timeout = null
+    }
+  }
+})
+
+const extensionCompartment = new Compartment()
+
+/**
+ * A TransactionExtender that reconfigures the extension compartment in response
+ * to a configUpdateEffect if applicable.
+ */
+const modeSwitcher = EditorState.transactionExtender.of(transaction => {
+  let cleanupRefs: boolean|undefined
+
+  for (const effect of transaction.effects) {
+    if (effect.is(configUpdateEffect)) {
+      if (effect.value.cleanupFootnotes !== undefined) {
+        cleanupRefs = effect.value.cleanupFootnotes
+      }
+    }
+  }
+
+  if (cleanupRefs === true) {
+    return { effects: extensionCompartment.reconfigure([cleanupFootnotesAndNumbering]) }
+  }
+
+  if (cleanupRefs === false) {
+    return { effects: extensionCompartment.reconfigure([]) }
+  }
+
+  return null
+})
+
+/**
+ * A configurable extension to cleanup footnotes
+ *
+ * @param   {boolean}      cleanup    Initial setting for the cleanup behavior
+ *                                    (default: true)
+ *
+ * @return  {Extension[]}             The extension.
+ */
+export function cleanupFootnotesExtension (cleanup?: boolean): Extension[] {
+  const initialSetting = extensionCompartment.of(cleanup ?? true ? [cleanupFootnotesAndNumbering] : [])
+
+  return [ initialSetting, modeSwitcher ]
+}

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -76,6 +76,7 @@ export interface EditorConfiguration {
   highlightWhitespace: boolean
   showMarkdownLineNumbers: boolean
   countChars: boolean
+  cleanupFootnotes: boolean
 }
 
 export function getDefaultConfig (): EditorConfiguration {
@@ -134,7 +135,8 @@ export function getDefaultConfig (): EditorConfiguration {
     margins: 'M',
     highlightWhitespace: false,
     showMarkdownLineNumbers: false,
-    countChars: false
+    countChars: false,
+    cleanupFootnotes: false
   }
 }
 

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -278,7 +278,8 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     theme: display.theme,
     highlightWhitespace: editor.showWhitespace,
     showMarkdownLineNumbers: editor.showMarkdownLineNumbers,
-    countChars: editor.countChars
+    countChars: editor.countChars,
+    cleanupFootnotes: editor.cleanupFootnotes
   } satisfies EditorConfigOptions
 })
 

--- a/source/win-preferences/schema/citations.ts
+++ b/source/win-preferences/schema/citations.ts
@@ -53,7 +53,13 @@ export function getCitationFields (): PreferencesFieldset[] {
           placeholder: trans('Path to file'),
           reset: '',
           filter: [{ extensions: ['csl'], name: 'CSL Style' }]
-        }
+        },
+        { type: 'separator' },
+        {
+          type: 'checkbox',
+          label: trans('Automatically cleanup footnotes'),
+          model: 'editor.cleanupFootnotes'
+        },
       ]
     }
   ]

--- a/test/footnotes.spec.ts
+++ b/test/footnotes.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Tests for the footnote commands
+ * CVM-Role:        TESTING
+ * Maintainers:     Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     This file tests the footnote command functions.
+ *
+ * END HEADER
+ */
+
+import { strictEqual } from 'assert'
+import { EditorState, Transaction } from '@codemirror/state'
+import { cleanupFootnotes } from 'source/common/modules/markdown-editor/commands/footnotes'
+import markdownParser from 'source/common/modules/markdown-editor/parser/markdown-parser'
+
+const cleanupFootnotesTests = [
+ // Test removing references without identifiers
+  {
+    content: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^6]: [CommonMark](https://commonmark.org/)
+[^7]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+`,
+    expected: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+`
+  },
+  // Test removing identifiers without references and renumbering
+  {
+    content: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html`,
+    expected: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown, PHP Markdown Extra[^2], or RStudio's RMarkdown[^3], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^3]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+`
+  },
+  // Test moving references to the end of the document
+  {
+    content: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^5], which is also why they aren't yet part of the CommonMark specification[^6]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se[^7]
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^6]: [CommonMark](https://commonmark.org/)
+[^7]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+
+# Section 2
+
+Body text below footnotes.`,
+    expected: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^5], which is also why they aren't yet part of the CommonMark specification[^6]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se[^7]
+
+# Section 2
+
+Body text below footnotes.
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^6]: [CommonMark](https://commonmark.org/)
+[^7]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+`,
+  },
+  // Test renumbering references with the same label
+  {
+    content: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^1], PHP Markdown Extra[^1], or RStudio's RMarkdown[^1], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^1], which is also why they aren't yet part of the CommonMark specification[^1]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se[^1]
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^1]: See https://pandoc.org/MANUAL.html#footnotes
+[^1]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^1]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^1]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^1]: [CommonMark](https://commonmark.org/)
+[^1]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+`,
+    expected: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^5], which is also why they aren't yet part of the CommonMark specification[^6]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se[^7]
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^6]: [CommonMark](https://commonmark.org/)
+[^7]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+`,
+  },
+  // Test renumbering references with the same label and removing non-matching ones
+  {
+    content: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^5], which is also why they aren't yet part of the CommonMark specification[^4]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se[^4]
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^4]: [CommonMark](https://commonmark.org/)
+[^7]: One common problem of Zettlr in the past was that it did not highlight footnotes specifically, and as they are not part of the GitHub flavored Markdown (which is the underlying mode we're using to render stuff here), the GFM mode would always treat them as reference style _links_.
+`,
+    expected: `\
+# Footnotes Test
+
+This file is meant as a way to test the rendering of footnotes. Footnotes are not a part of original Markdown[^1], but have since been introduced in a variety of flavours, such as Pandoc Markdown[^2], PHP Markdown Extra[^3], or RStudio's RMarkdown[^4], which is basically just Pandoc Markdown, because that's the engine RStudio is using under the hood to compile output documents.
+
+Footnotes, in a way, are simply reference-style links[^5], which is also why they aren't yet part of the CommonMark specification[^6]. In fact, the _only_ difference between footnotes and reference style links are that footnotes are always prepended with a \`^\`. You can also use inline-footnotes^[such as this], which save you some space. Nevertheless, this file's purpose is to mainly exhibit problems within footnotes per se
+
+[^1]: See https://daringfireball.net/projects/markdown/
+[^2]: See https://pandoc.org/MANUAL.html#footnotes
+[^3]: See https://michelf.ca/projects/php-markdown/extra/#footnotes
+[^4]: See https://bookdown.org/yihui/rmarkdown/markdown-syntax.html
+[^5]: See https://spec.commonmark.org/0.29/#link-reference-definitions
+[^6]: [CommonMark](https://commonmark.org/)
+`,
+  }
+]
+
+describe('MarkdownEditor#cleanupFootnotes()', function () {
+
+  cleanupFootnotesTests.forEach((test, idx) => {
+    it(`Cleanup Footnotes: Test ${idx + 1}`, function () {
+      const { content, expected } = test
+
+      const state = EditorState.create({
+        doc: content,
+        extensions: [
+          markdownParser(),
+        ]
+      })
+
+      let wasDispatched = false
+
+      const dispatch = (tx: Transaction) => {
+        wasDispatched = true
+
+        const newDoc = tx.newDoc.toString()
+        strictEqual(newDoc, expected, "Footnotes were cleaned up incorrectly.")
+      }
+
+      cleanupFootnotes({ state, dispatch })
+
+      strictEqual(wasDispatched, true, "A transaction must have been dispatched")
+    })
+  })
+})


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR mainly refactors the footnote cleanup handling so that it is debounced.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The footnote cleanup handling was moved to a `ViewPlugin` so that it can be debounced after some delay in typing. This improves user typing performance. 

The logic was also refactored to address some bugs related to footnote removal. A notable change is in how footnotes are sorted -- previously, they were concated into one long string and inserted into the region contained by the first and last footnote. However, this causes issues when text occurs between footnotes, where the in-between text would be removed. ~~The new handling tries to avoid this kind of destructive action, but this could be further tested.~~ All footnote references are now moved to the end of the document.

~~The citation handler was updated so that it uses a `Set` when searching for valid locator labels. This is a much faster approach than using the `Array.find()`.~~

~~The footnote parser regex was updated to use character exclusion rather than non-greedy matching, which is much slower in general.~~

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I don't use footnotes in my day-to-day, so my testing is quite limited to the dev environment files. I would appreciate others testing this to catch any other bugs!

In addition, I think it would be good to add a toggle for this behavior in the settings. I could see usecases where people do not want Zettlr automatically updated references.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
