### PR TITLE
[Enhancement] Style blockquotes with a vertical bar

### DIFF
--- a/source/common/modules/markdown-editor/plugins/code-background.ts
+++ b/source/common/modules/markdown-editor/plugins/code-background.ts
@@ -10,92 +10,95 @@ import { EditorView, layer, RectangleMarker } from '@codemirror/view'
 export const codeblockBackground = layer({
   above: false, // Render below text
   class: 'cm-codeBackgroundLayer',
-  update (update, _layer) {
+  update (update) {
     return update.docChanged || update.viewportChanged // Return true to redraw markers
   },
   markers (view) {
     // First, collect all code blocks
     const markers: RectangleMarker[] = []
     // Second, create RectangleMarkers for each of them
-    syntaxTree(view.state).iterate({
-      from: 0,
-      to: view.state.doc.length,
-      enter: (node) => {
-        // CodeBlock = Generic, four-space-indented code
-        // FencedCode = Code explicitly created with backticks
-        // CommentBlock = <!----> But without anything preceding the beginning
-        // YAMLFrontmatter = A YAML frontmatter
-        if (![ 'CodeBlock', 'FencedCode', 'CommentBlock', 'YAMLFrontmatter' ].includes(node.type.name)) {
-          return
-        }
-
-        try {
-          let start = node.from
-          let end = node.to
-
-          if (node.type.name === 'FencedCode' || node.type.name === 'YAMLFrontmatter') {
-            // For FencedCode and YAMLFrontmatter blocks we want to exclude the
-            // first and last lines that contain the delimiters.
-            const startLine = view.state.doc.lineAt(node.from).number
-            start = view.state.doc.line(startLine + 1).from
-            end = view.state.doc.lineAt(node.to).from
-          } else if (node.type.name === 'CodeBlock') {
-            // For CodeBlocks (which are just the generics produced by an
-            // indentation of four spaces) we need to highlight a bit more
-            start = view.state.doc.lineAt(node.from).from
-            end = view.state.doc.lineAt(node.to).to + 1
-          } else if (node.type.name === 'CommentBlock') {
-            end = view.state.doc.lineAt(node.to).to + 1
+    for (const { from, to } of view.visibleRanges) {
+      syntaxTree(view.state).iterate({
+        from,
+        to,
+        enter: (node) => {
+          // CodeBlock = Generic, four-space-indented code
+          // FencedCode = Code explicitly created with backticks
+          // CommentBlock = <!----> But without anything preceding the beginning
+          // YAMLFrontmatter = A YAML frontmatter
+          if (![ 'CodeBlock', 'FencedCode', 'CommentBlock', 'YAMLFrontmatter' ].includes(node.type.name)) {
+            return
           }
 
-          const localMarkers = RectangleMarker.forRange(
-            view,
-            'code code-block-line-background',
-            EditorSelection.range(start, end)
-          )
+          try {
+            let start = node.from
+            let end = node.to
 
-          // Unfortunately, `RectangleMarker.forRange` has some quirks. In order
-          // to get a proper styling, we have to do two things: First, remove
-          // zero-width markers (that happen since we include the trailing
-          // newline character to ensure that the last marker spans the entire
-          // line, and the next line has zero characters to draw a marker for).
-          // Then, in a second step, we have to re-create the markers once,
-          // passing 'top' and 'bottom' respectively for the first and last
-          // marker. This ensures that the borders are properly rounded
-          // regardless of how many actual markers this thing produces (which
-          // can be either two, for single-line code blocks, or three, for multi
-          // line code blocks).
-          const markersToAdd: RectangleMarker[] = localMarkers
-            .filter(marker => {
-              return marker.width !== null && marker.width > 0
-            })
-            .map((marker, i, arr) => {
-              const { top, left, width, height } = marker
-              const classes = [ 'code', 'code-block-line-background' ]
+            if (node.type.name === 'FencedCode' || node.type.name === 'YAMLFrontmatter') {
+              // For FencedCode and YAMLFrontmatter blocks we want to exclude the
+              // first and last lines that contain the delimiters.
+              const startLine = view.state.doc.lineAt(node.from).number
+              start = view.state.doc.line(startLine + 1).from
+              end = view.state.doc.lineAt(node.to).from
+            } else if (node.type.name === 'CodeBlock') {
+              // For CodeBlocks (which are just the generics produced by an
+              // indentation of four spaces) we need to highlight a bit more
+              start = view.state.doc.lineAt(node.from).from
+              end = view.state.doc.lineAt(node.to).to + 1
+            } else if (node.type.name === 'CommentBlock') {
+              end = view.state.doc.lineAt(node.to).to + 1
+            }
 
-              if (i === 0) {
-                classes.push('top')
-              }
+            const localMarkers = RectangleMarker.forRange(
+              view,
+              'code code-block-line-background',
+              EditorSelection.range(start, end)
+            )
 
-              if (i === arr.length - 1) {
-                classes.push('bottom')
-              }
+            // Unfortunately, `RectangleMarker.forRange` has some quirks. In order
+            // to get a proper styling, we have to do two things: First, remove
+            // zero-width markers (that happen since we include the trailing
+            // newline character to ensure that the last marker spans the entire
+            // line, and the next line has zero characters to draw a marker for).
+            // Then, in a second step, we have to re-create the markers once,
+            // passing 'top' and 'bottom' respectively for the first and last
+            // marker. This ensures that the borders are properly rounded
+            // regardless of how many actual markers this thing produces (which
+            // can be either two, for single-line code blocks, or three, for multi
+            // line code blocks).
+            const markersToAdd: RectangleMarker[] = localMarkers
+              .filter(marker => {
+                return marker.width !== null && marker.width > 0
+              })
+              .map((marker, i, arr) => {
+                const { top, left, width, height } = marker
+                const classes = [ 'code', 'code-block-line-background' ]
 
-              return new RectangleMarker(classes.join(' '), left, top, width, height)
-            })
+                if (i === 0) {
+                  classes.push('top')
+                }
 
-          markers.push(...markersToAdd)
-        } catch (err: any) {
-          // Sometimes, the RectangleMarker throws an error because it "cannot
-          // read properties of null (reading 'top')". The reason seems to be
-          // that the corresponding line DOM objects aren't drawn when the
-          // plugin attempts to draw the rectangle marker. This is noticeable in
-          // a slight flicker of the background. However, to me it seems
-          // negligible, and hence we're just swallowing the error.
+                if (i === arr.length - 1) {
+                  classes.push('bottom')
+                }
+
+                return new RectangleMarker(classes.join(' '), left, top, width, height)
+              })
+
+            markers.push(...markersToAdd)
+          } catch (err: any) {
+            // Sometimes, the RectangleMarker throws an error because it "cannot
+            // read properties of null (reading 'top')". The reason seems to be
+            // that the corresponding line DOM objects aren't drawn when the
+            // plugin attempts to draw the rectangle marker. This is noticeable in
+            // a slight flicker of the background. However, to me it seems
+            // negligible, and hence we're just swallowing the error.
+          }
+          return false
         }
-        return false
-      }
-    })
+      })
+    }
+
     // Third, return
     return markers
   }
@@ -109,55 +112,57 @@ export const codeblockBackground = layer({
 export const inlineCodeBackground = layer({
   above: false, // Render below text
   class: 'cm-inlineCodeBackgroundLayer',
-  update (update, _layer) {
+  update (update) {
     return update.docChanged || update.viewportChanged // Return true to redraw markers
   },
   markers (view) {
     // First, collect all code blocks
     const markers: RectangleMarker[] = []
     // Second, create RectangleMarkers for each of them
-    syntaxTree(view.state).iterate({
-      from: 0,
-      to: view.state.doc.length,
-      enter: (node) => {
-        if (![ 'InlineCode', 'Comment' ].includes(node.type.name)) {
-          return
-        }
-
-        // Additional check: Rendering of anything messes with the code
-        // backgrounds, so we want to disable them in those cases. Here: inline
-        // math.
-        if (view.state.sliceDoc(node.from, node.from + 1) === '$') {
-          return
-        }
-
-        try {
-          let start = node.from
-          let end = node.to
-
-          if (node.type.name === 'InlineCode') {
-            start += 1
-            end -= 1
+    for (const { from, to } of view.visibleRanges) {
+      syntaxTree(view.state).iterate({
+        from,
+        to,
+        enter: (node) => {
+          if (![ 'InlineCode', 'Comment' ].includes(node.type.name)) {
+            return
           }
 
-          const localMarkers = RectangleMarker.forRange(
-            view,
-            'code inline-code-background',
-            EditorSelection.range(start, end)
-          )
+          // Additional check: Rendering of anything messes with the code
+          // backgrounds, so we want to disable them in those cases. Here: inline
+          // math.
+          if (view.state.sliceDoc(node.from, node.from + 1) === '$') {
+            return
+          }
 
-          markers.push(...localMarkers)
-        } catch (err: any) {
-          // Sometimes, the RectangleMarker throws an error because it "cannot
-          // read properties of null (reading 'top')". The reason seems to be
-          // that the corresponding line DOM objects aren't drawn when the
-          // plugin attempts to draw the rectangle marker. This is noticeable in
-          // a slight flicker of the background. However, to me it seems
-          // negligible, and hence we're just swallowing the error.
+          try {
+            let start = node.from
+            let end = node.to
+
+            if (node.type.name === 'InlineCode') {
+              start += 1
+              end -= 1
+            }
+
+            const localMarkers = RectangleMarker.forRange(
+              view,
+              'code inline-code-background',
+              EditorSelection.range(start, end)
+            )
+
+            markers.push(...localMarkers)
+          } catch (err: any) {
+            // Sometimes, the RectangleMarker throws an error because it "cannot
+            // read properties of null (reading 'top')". The reason seems to be
+            // that the corresponding line DOM objects aren't drawn when the
+            // plugin attempts to draw the rectangle marker. This is noticeable in
+            // a slight flicker of the background. However, to me it seems
+            // negligible, and hence we're just swallowing the error.
+          }
+          return false
         }
-        return false
-      }
-    })
+      })
+    }
     // Third, return
     return markers
   }

--- a/source/common/modules/markdown-editor/plugins/visual-indent.ts
+++ b/source/common/modules/markdown-editor/plugins/visual-indent.ts
@@ -15,152 +15,113 @@
  * END HEADER
  */
 
-import { syntaxTree } from '@codemirror/language'
-import type { RangeSet, Range, Line } from '@codemirror/state'
+import { syntaxTree, foldedRanges } from '@codemirror/language'
+import { RangeSet, type Range } from '@codemirror/state'
 import {
   Decoration,
+  MatchDecorator,
   ViewPlugin,
   type EditorView,
   type ViewUpdate
 } from '@codemirror/view'
 import { SpaceWidget } from '../renderers/render-emphasis'
 
-function render (view: EditorView, measurements?: Map<string, number>): RangeSet<Decoration> {
-  // Original inspiration came from this plugin:
-  // https://gist.github.com/lishid/c10db431cb8a9e83905a3443cfdb53bb
-  // HOWEVER, that didn't quite do the job. After months of thinking, I finally
-  // had a good idea, which is what the below shows.
+// Since tab characters have no fixed with in the editor,
+// we need to render every tab with the equivalent number of space
+// characters to prevent jumping in the editor.
+// The jumping is caused by the tab character recalculating its
+// width as the line indentation is changed.
+const tabReplaceDeco = new MatchDecorator({
+  regexp: /\t/g,
+  boundary: /[^\t]/g,
+  decoration: (_match, view, _pos) => Decoration.replace({ widget: new SpaceWidget(view.state.tabSize) })
+})
 
-  const tabSize = view.state.tabSize
+function render (view: EditorView, measurements?: Map<string, number>): RangeSet<Decoration> {
   const ranges: Array<Range<Decoration>> = []
 
-  // Then, retrieve all lines that are indentable via this plugin. These are:
-  // All lines that are part of the current viewport and that are not part of a
-  // code block. Why no code block? First, code blocks will always be in
-  // monospace. (If you use Custom CSS to make them non-monospaced, you are a
-  // cruel human being and deserve to be punished.) Second, if we mess with the
-  // indentation and padding of lines within code blocks, we mess up the
-  // calculations that happen to apply the gray background to our code blocks,
-  // which will make it look like a visual bug.
-  const indentableLines = new Set<Line>()
   for (const { from, to } of view.visibleRanges) {
-    const firstLine = view.state.doc.lineAt(from).number
-    const lastLine = view.state.doc.lineAt(to).number
-    for (let i = firstLine; i <= lastLine; i++) {
-      const currentLine = view.state.doc.line(i)
-      const nodeAtPos = syntaxTree(view.state).resolve(currentLine.from, 1)
-      if (nodeAtPos.name !== 'CodeText') {
-        indentableLines.add(currentLine)
-      }
-    }
-  }
-
-  // Now that we know which lines need to be potentially indented, let's go
-  // through them one by one.
-  for (const line of [...indentableLines]) {
-    // Before we do ANYTHING ELSE, we MUST UNDER ALL CIRCUMSTANCES replace any
-    // tab characters with spaces using a replacement widget. "Why?" you may ask
-    // now. Well, because tab characters in CodeMirror behave very weirdly in
-    // conjunction with negative text-indents. "How so?", you will ask. Well,
-    // because of the way tab characters are *intended* (not indented) to be
-    // used: They don't have a fixed width. Rather, they are supposed to "snap"
-    // to invisible vertical columns on a page (today rather a container on a
-    // website). However, by applying text-indents below, we basically move the
-    // starting offset for these tab characters around, and they really don't
-    // like that. In effect, this results in what many have described as
-    // "jumping" behavior: Whenever the required text indent is recalculated (in
-    // the measuring phase below), we will read the text indent together with
-    // the current width of the tab character. As soon as the new text indent is
-    // applied, however, the browser will recalculate the actual width required
-    // for the tab in order to snap it to one of these columns. Since that is
-    // asynchronous with how we need to take our measurements, the next time WE
-    // measure the text indent, it has changed AGAIN. This means that for every
-    // measuring phase, we move the line around due to this behavior of tabs.
-    // Over the past year, I have tried several attempts. First, I tried to find
-    // ways of making tabs fixed-width, but there is no mechanism for that. Then
-    // I thought very long to no avail, but suddenly I had an idea. If tabs are
-    // the problem, why not completely remove them from the renderer? After all,
-    // the mechanism works flawlessly with spaces. This led to PR #5384.
-    // However, normalizing all files like this comes with an insane amount of
-    // added complexity that I never fully figured out. However, on Halloween
-    // 2024, I figured out the solution. And let me tell you: It is SO STUPID,
-    // SO SIMPLE, SO FUCKING OBVIOUS that I am absolutely ashamed of myself that
-    // it took me literally x months to get to it, even though all pieces were
-    // already in place: Simply replace every tab character with `tabSize`
-    // spaces using a replacement decoration. That's it. That's the entire
-    // story. It's simple, works, easy to maintain, and has the wanted effect.
-    for (let j = 0; j < line.text.length; j++) {
-      if (line.text.charAt(j) !== '\t') {
-        break
-      }
-
-      ranges.push(
-        Decoration
-          .replace({ widget: new SpaceWidget(tabSize) })
-          .range(line.from + j, line.from + j + 1)
-      )
-    }
-
-    // Now, after having averted the dance macabre
-    // (https://www.youtube.com/watch?v=7Gr63DiEUxw), here's the original
-    // algorithm -- unchanged, mind you!
-
-    // First determine how much we're offset based purely on whitespace.
-    let tabs = 0
-    let spaces = 0
-    for (const char of line.text) {
-      if (char === '\t') {
-        tabs++
-      } else if (char === ' ') {
-        spaces++
-      } else {
-        break
-      }
-    }
-
-    // Second, determine the offset based on list elements.
-    const match = /^\s*((?:[+*>-](?:\s\[[x\s]\])?|\d+\.)\s)/.exec(line.text)
-    const listMarker = match !== null ? match[1].length : 0
-
-    const columnLineTextStart = spaces + tabs + listMarker
-    // const visualLineTextStart = spaces + tabs * tabSize + listMarker
-
-    if (columnLineTextStart === 0) {
-      continue // Neither whitespace nor list elements on that line.
-    }
-
-    // Now that we know we need to indent this line, schedule a measurement so
-    // that in the next round of this code running we have an accurate
-    // indentation even for non-monospaced text. What we want to measure is
-    // exclusively what we are basing our indentation on. If we use the entire
-    // line as a key, we cause (a) duplicated measurements (`* One` and `* Two`
-    // require the same indentation) and (b) cause cache misses which results in
-    // jumpy behavior when the user adds novel characters to the line.
-    const measurementKey = line.text.slice(0, columnLineTextStart).replace('\t', ' '.repeat(tabSize))
-
-    view.requestMeasure({
-      read (view) {
-        const base = view.contentDOM.getBoundingClientRect().left
-        const after = view.coordsAtPos(line.from + columnLineTextStart)?.left ?? 0
-        if (after === 0) {
-          return // Could not retrieve coordinates
+    syntaxTree(view.state).iterate({
+      from,
+      to,
+      enter (node) {
+        if (node.name === 'FencedCode') {
+          return false
         }
-        // Note that this continuously updates our measurements after any layout
-        // changes
-        measurements?.set(measurementKey, after - base)
-      },
-      key: measurementKey
-    })
 
-    const indent = measurements?.get(measurementKey)
-    if (indent !== undefined) {
-      // NOTE: Each `.cm-line` has a padding of `0 2px 0 6px` as per CodeMirror's
-      // base styles from somewhere in the library. We need to account for that
-      // not to induce any problems.
-      const basePadding = 6
-      const deco = Decoration.line({ attributes: { style: `text-indent: -${indent-basePadding}px; padding-left: ${indent}px;` } })
-      ranges.push(deco.range(line.from))
-    }
+        if ([ 'Paragraph', 'Blockquote', 'CodeBlock', 'BulletList', 'OrderedList' ].includes(node.name)) {
+          const firstLine = view.state.doc.lineAt(node.from).number
+          const lastLine = view.state.doc.lineAt(node.to).number
+
+          for (let i = firstLine; i <= lastLine; i++) {
+            const line = view.state.doc.line(i)
+
+            // First determine count the indent based on leading whitespace
+            const whitespaceMatch = /^[ \t]*/.exec(line.text)
+            const leadingWhitespace = whitespaceMatch !== null ? whitespaceMatch[0].length : 0
+
+            // Second, determine the offset based on list or blockquote elements.
+            let formatCharOffset = 0
+            if (node.name === 'Blockquote' || node.name === 'Paragraph') {
+              const quoteMatch = /^([ ]{0,3}\>[ ]?)+/.exec(line.text)
+              formatCharOffset = quoteMatch !== null ? quoteMatch[0].length : 0
+            } else if (node.name === 'BulletList' || node.name === 'OrderedList') {
+              const listMatch = /^\s*((?:[+*>-](?:\s\[[x\s]\])?|\d+\.)\s)/.exec(line.text)
+              formatCharOffset = listMatch !== null ? listMatch[1].length : 0
+            }
+
+            const columnLineTextStart = leadingWhitespace + formatCharOffset
+
+            if (columnLineTextStart === 0) {
+              continue // Neither whitespace nor list elements on that line.
+            }
+
+            // Now that we know we need to indent this line, schedule a measurement so
+            // that in the next round of this code running we have an accurate
+            // indentation even for non-monospaced text. What we want to measure is
+            // exclusively what we are basing our indentation on. If we use the entire
+            // line as a key, we cause (a) duplicated measurements (`* One` and `* Two`
+            // require the same indentation) and (b) cause cache misses which results in
+            // jumpy behavior when the user adds novel characters to the line.
+            const measurementKey = line.text.slice(0, columnLineTextStart).replace('\t', ' '.repeat(view.state.tabSize))
+
+            view.requestMeasure({
+              read (view) {
+                const pos = line.from + columnLineTextStart
+
+                const folded = foldedRanges(view.state).iter(pos)
+                while (folded.value) {
+                  if (pos < folded.to) { return }
+                  folded.next()
+                }
+
+                const base = view.contentDOM.getBoundingClientRect().left
+                const after = view.coordsAtPos(pos)?.left ?? 0
+                if (after === 0) {
+                  return // Could not retrieve coordinates
+                }
+                // Note that this continuously updates our measurements after any layout
+                // changes
+                measurements?.set(measurementKey, after - base)
+              },
+              key: measurementKey
+            })
+
+            let indent = measurements?.get(measurementKey)
+            if (indent !== undefined) {
+              // NOTE: Each `.cm-line` has a padding of `0 2px 0 6px` as per CodeMirror's
+              // base styles from somewhere in the library. We need to account for that
+              // not to induce any problems.
+              const basePadding = 6
+              const deco = Decoration.line({ attributes: { style: `text-indent: -${indent-basePadding}px; padding-left: ${indent}px;` } })
+              ranges.push(deco.range(line.from))
+            }
+          }
+
+          return false
+        }
+      }
+    })
   }
 
   return Decoration.set(ranges, true)
@@ -168,14 +129,18 @@ function render (view: EditorView, measurements?: Map<string, number>): RangeSet
 
 export const softwrapVisualIndent = ViewPlugin.define(view => ({
   decorations: render(view),
+  tabDecorations: tabReplaceDeco.createDeco(view),
   // This is an additional property, required to ensure that each editor
   // instance has its own map, preventing any potential interference.
   measurements: new Map<string, number>(),
   update (u: ViewUpdate) {
     this.decorations = render(u.view, this.measurements)
+    this.tabDecorations = tabReplaceDeco.updateDeco(u, this.tabDecorations)
   }
 }), {
+
   decorations (value) {
-    return value.decorations
+    return RangeSet.join([ value.decorations, value.tabDecorations ])
   }
+
 })

--- a/source/common/modules/markdown-editor/theme/berlin.ts
+++ b/source/common/modules/markdown-editor/theme/berlin.ts
@@ -31,7 +31,6 @@ const commonRules: Record<string, any> = {
   '.cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end, .mermaid-chart.error': {
     fontFamily: 'Inconsolata, monospace'
   }, // END: Monospace elements
-  '.cm-quote': { fontStyle: 'italic' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     fontWeight: 'bold'
   },
@@ -53,6 +52,7 @@ export const themeBerlinLight = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   // Primary color
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.citeproc-citation, .code-block-line-background, .inline-code-background': { backgroundColor: 'var(--grey-0)' },
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   // Citation syntax
@@ -101,6 +101,7 @@ export const themeBerlinDark = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   '.cm-escape': { color: 'var(--grey-4)' },
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionDark

--- a/source/common/modules/markdown-editor/theme/bielefeld.ts
+++ b/source/common/modules/markdown-editor/theme/bielefeld.ts
@@ -40,6 +40,7 @@ export const themeBielefeldLight = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   // Primary color
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.citeproc-citation, .code-block-line-background, .inline-code-background': { backgroundColor: 'var(--grey-0)' },
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-citation-mark': { color: 'var(--grey-1)' },
@@ -86,6 +87,7 @@ export const themeBielefeldDark = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   '.cm-escape': { color: 'var(--grey-4)' },
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionDark

--- a/source/common/modules/markdown-editor/theme/bordeaux.ts
+++ b/source/common/modules/markdown-editor/theme/bordeaux.ts
@@ -40,6 +40,7 @@ export const themeBordeauxLight = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   // Primary color
   '.cm-code-mark:not(.cm-emphasis, .cm-strong, .cm-list), .cm-zkn-tag': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.cm-url, .cm-link, .cm-zkn-link': { textDecoration: 'underline' },
   '.citeproc-citation, .code-block-line-background, .inline-code-background': { backgroundColor: 'var(--grey-0)' },
   '.citeproc-citation': {
@@ -61,7 +62,6 @@ export const themeBordeauxLight = EditorView.theme({
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionLight
   },
-  '.cm-quote': { color: '#555' }
 }, { dark: false })
 
 export const themeBordeauxDark = EditorView.theme({
@@ -94,6 +94,7 @@ export const themeBordeauxDark = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   '.cm-escape': { color: 'var(--grey-4)' },
   '.cm-code-mark:not(.cm-emphasis, .cm-strong, .cm-list), .cm-zkn-tag': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.cm-url, .cm-link, .cm-zkn-link': { textDecoration: 'underline' },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
@@ -102,5 +103,5 @@ export const themeBordeauxDark = EditorView.theme({
   '.cm-highlight': {
     color: 'black !important',
   },
-  '.cm-quote, .cm-link, .cm-strong, .cm-emphasis': { color: '#93a1a1' }
+  '.cm-link, .cm-strong, .cm-emphasis': { color: '#93a1a1' }
 }, { dark: true })

--- a/source/common/modules/markdown-editor/theme/frankfurt.ts
+++ b/source/common/modules/markdown-editor/theme/frankfurt.ts
@@ -31,7 +31,6 @@ const commonRules: Record<string, any> = {
   '.cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end, .mermaid-chart.error': {
     fontFamily: 'Inconsolata, monospace'
   }, // END: Monospace elements
-  '.cm-quote': { fontStyle: 'italic' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     fontWeight: 'bold'
   },
@@ -53,6 +52,7 @@ export const themeFrankfurtLight = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   // Primary color
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.citeproc-citation, .code-block-line-background, .inline-code-background': { backgroundColor: 'var(--grey-0)' },
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-citation-mark': { fontFamily: 'monospace', color: 'var(--grey-1)' },
@@ -99,6 +99,7 @@ export const themeFrankfurtDark = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   '.cm-escape': { color: 'var(--grey-4)' },
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: blueSelectionDark

--- a/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
+++ b/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
@@ -31,7 +31,6 @@ const commonRules: Record<string, any> = {
   '.cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end, .mermaid-chart.error': {
     fontFamily: 'Inconsolata, monospace'
   }, // END: Monospace elements
-  '.cm-quote': { fontStyle: 'italic' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     fontWeight: 'bold'
   },
@@ -53,6 +52,7 @@ export const themeKarlMarxStadtLight = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   // Primary color
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   '.citeproc-citation, .code-block-line-background, .inline-code-background': { backgroundColor: 'var(--grey-0)' },
   '.citeproc-citation.error, .mermaid-chart.error': { color: 'var(--red-2)' },
   '.cm-citation-mark': { fontFamily: 'monospace', color: 'var(--grey-1)' },
@@ -99,6 +99,7 @@ export const themeKarlMarxStadtDark = EditorView.theme({
   '.cm-angle-bracket, .cm-definition-operator': { color: 'var(--grey-5)' },
   '.cm-escape': { color: 'var(--grey-4)' },
   '.cm-url, .cm-link, .cm-code-mark, .cm-zkn-tag, .cm-zkn-link': { color: primaryColor },
+  '.cm-quotemark': { borderLeftColor: primaryColor },
   // Copied with my blood from the DOM; the example on the website is wrong.
   '&.cm-focused .cm-scroller .cm-layer.cm-selectionLayer .cm-selectionBackground, ::selection': {
     background: selectionDark

--- a/source/common/modules/markdown-editor/theme/main-override.ts
+++ b/source/common/modules/markdown-editor/theme/main-override.ts
@@ -114,6 +114,10 @@ export const mainOverride = EditorView.baseTheme({
   },
   '&dark .cm-highlight': {
     backgroundColor: '#ffff0060',
+  },
+  '.cm-foldPlaceholder': {
+    backgroundColor: 'transparent',
+    borderStyle: 'none',
   }
 })
 

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -747,12 +747,6 @@ function maybeHighlightSearchResults (): void {
 body.dark .main-editor-wrapper {
   background-color: #2b2b2c;
   .CodeMirror .CodeMirror-gutters { background-color: #2b2b2c; }
-
-  //Ellipsis (...) When a header is folded
-  .cm-foldPlaceholder{
-      background-color: rgb(20, 20, 30);
-      border-style: none;
-    }
 }
 
 // CodeMirror fullscreen


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR styles blockquotes with a vertical bar to indicate quote level across all themes.

Closes #5960 

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The `SpaceWidget` and `BufferWidget` were refactored to accept a `classList` parameter, which is used to add optional classes to the widget element.

The `hideFormattingCharacters` function was refactored so that `QuoteMark` decorations are assigned a `cm-quotemark` class.

Styling was added to the  `cm-quotemark` and `cm-quote` classes through an editor theme. The `cm-quotemark` styling adds a vertical bar to quotemarks to more clearly indicate quote level, and the `cm-quote` styling reduces the opacity to make blockquotes stand out from regular text.

Each theme was updated to remove any specifc blockquote styling, and the quotemarks were styled according to the theme's `primaryColor`.

Finally, the `rangeInSelection` is passed `true` for taking into account adjacent ranges. This makes it so that formatting characters appear if the cursor is next to one, even when it is on the outside of the node. While testing, I felt that this improved the UI for showing formatting characters.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Themes:

<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 21" src="https://github.com/user-attachments/assets/726b7961-3a66-4c9e-8bac-fb1e16f0fe02" />
<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 47" src="https://github.com/user-attachments/assets/1f2eb4ab-33f6-4532-a857-315ac20ecc84" />

<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 26" src="https://github.com/user-attachments/assets/a0150284-1dc4-41c5-af83-261330f29944" />
<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 50" src="https://github.com/user-attachments/assets/2cc4d667-d51a-4ab7-a013-025410848733" />

<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 33" src="https://github.com/user-attachments/assets/67c507f2-349f-4792-af64-d84354fa4ddd" />
<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 54" src="https://github.com/user-attachments/assets/89012f40-8a70-44ef-9124-1316d0efb0eb" />

<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 37" src="https://github.com/user-attachments/assets/8e900767-3a72-4bf4-8744-b79a59eb1a63" />
<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 57" src="https://github.com/user-attachments/assets/7b14ca55-d15a-4877-8a94-87a2b850f17b" />

<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 27 41" src="https://github.com/user-attachments/assets/5d832529-37fa-4f08-9de7-2253da11f37c" />
<img width="431" height="424" alt="Screenshot 2025-10-25 at 11 28 01" src="https://github.com/user-attachments/assets/5035c3e5-9e03-477b-964c-a3e04ee5c6f6" />

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26