### PR TITLE
[Fix] Pilcrow cleanup

### DIFF
--- a/source/common/modules/markdown-editor/plugins/highlight-whitespace.ts
+++ b/source/common/modules/markdown-editor/plugins/highlight-whitespace.ts
@@ -41,6 +41,7 @@ class PilcrowWidget extends WidgetType {
   toDOM () {
     const span = document.createElement('span')
     span.className = 'cm-pilcrow'
+    span.textContent = '¶'
     span.setAttribute('aria-hidden', 'true')
 
     return span
@@ -99,8 +100,7 @@ const pilcrowPlugin = ViewPlugin.fromClass(class {
 })
 
 const pilcrowTheme = EditorView.baseTheme({
-  '.cm-pilcrow::after': {
-    content: '"¶"',
+  '.cm-pilcrow': {
     color: '#aaa',
     opacity: '0.5'
   }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR cleans up the pilcrow rendering, ~~fixing an issue where a literal pilcrow would be inserted into the text when selecting and deleting multiple lines.~~

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
~~Instead of applying the pilcrow character via `textContent`, it is applied via the CSS `content` parameter. This prevents it from being inserted into the actual text body when multiple lines are selected and then deleted. I am not sure why this is happening, but with this fix, I am unable to reproduce the problem.~~

`span.setAttribute('aria-hidden', 'true')` was added to the widget to not interrupt screen readers.

The `side` paremeter of the pilcrow widget was increased to `10000`, the max value, so that it appears after any other widget that may appear at the end of the line. I noticed this when using snippets.

Pilcrows are now only added after lines in regular text, ignoring items such as code blocks.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
