### PR TITLE
[Fix] Sanitize existing tags to lowercase in `replaceTags`

### DIFF
--- a/source/common/util/replace-tags.ts
+++ b/source/common/util/replace-tags.ts
@@ -28,6 +28,8 @@ import type { ZettelkastenTag } from '@common/modules/markdown-utils/markdown-as
  * @return  {string}                  The new document
  */
 export default function replaceTags (markdown: string, oldTag: string, newTag: string): string {
+  const sanitizedOldTag = oldTag.toLowerCase()
+
   // Since tags can occur in a frontmatter as well as in the document text, we
   // have the following combinations of possibilities:
   // 1. If the oldTag contains spaces --> Can only be in the frontmatter
@@ -43,7 +45,7 @@ export default function replaceTags (markdown: string, oldTag: string, newTag: s
 
     if (prop !== undefined && prop instanceof YAMLSeq) {
       for (const item of prop.items) {
-        if (item.value.toLowerCase() === oldTag) {
+        if (item.value.toLowerCase() === sanitizedOldTag) {
           const [ start, valueEnd ] = item.range as [number, number]
           // Slice the correct position
           markdown = markdown.slice(0, start) + newTag + markdown.slice(valueEnd)
@@ -54,7 +56,7 @@ export default function replaceTags (markdown: string, oldTag: string, newTag: s
 
   // If the old tag contained a space, we are already done (since tags with
   // spaces can only occur in the frontmatter).
-  if (/\s/.test(oldTag)) { return markdown }
+  if (/\s/.test(sanitizedOldTag)) { return markdown }
 
   // Now, we can do a much simpler approach to replacing the tag in the rest of
   // the content with simple RegEx.
@@ -65,7 +67,7 @@ export default function replaceTags (markdown: string, oldTag: string, newTag: s
   // of the tags in the new document remain valid, even after replacing the tags
   const newTagHasSpaces = /\s/.test(newTag)
   for (const tagNode of tagNodes.reverse()) {
-    if (tagNode.value.toLowerCase() !== oldTag) {
+    if (tagNode.value.toLowerCase() !== sanitizedOldTag) {
       continue
     }
 

--- a/test/replace-tags.spec.ts
+++ b/test/replace-tags.spec.ts
@@ -16,12 +16,14 @@
 import replaceTags from '@common/util/replace-tags'
 import { strictEqual } from 'assert'
 
-const testDocument = `---
+const testDocument = `\
+---
 title: "A simple test document"
 author: Zettlr
 keywords:
 - one tag
 - second-tag
+- Mixed-case-Tag
 ---
 
 # A simple test document
@@ -31,7 +33,7 @@ of the replaceTags function to properly replace tags within files.
 
 It contains a YAML frontmatter that defines one keyword with a space in it that
 cannot occur anywhere else in the document; as well as the #second-tag that now
-also occurs within here.
+also occurs within here. And a #MiXeD-case-TaG.
 
 For example, if we have a [link](#second-tag), it shouldn't be replaced.
 Similarly with [link](example.com#second-tag).`
@@ -39,12 +41,16 @@ Similarly with [link](example.com#second-tag).`
 const replaceTagsTesters = [
   {
     // With spaces -> with spaces
-    oldTag: 'one tag', newTag: 'A new keyword', expected: `---
+    oldTag: 'one tag',
+    newTag: 'A new keyword',
+    expected: `\
+---
 title: "A simple test document"
 author: Zettlr
 keywords:
 - A new keyword
 - second-tag
+- Mixed-case-Tag
 ---
 
 # A simple test document
@@ -54,19 +60,23 @@ of the replaceTags function to properly replace tags within files.
 
 It contains a YAML frontmatter that defines one keyword with a space in it that
 cannot occur anywhere else in the document; as well as the #second-tag that now
-also occurs within here.
+also occurs within here. And a #MiXeD-case-TaG.
 
 For example, if we have a [link](#second-tag), it shouldn't be replaced.
 Similarly with [link](example.com#second-tag).`
   },
   {
     // No spaces -> no spaces
-    oldTag: 'second-tag', newTag: 'new-keyword', expected: `---
+    oldTag: 'second-tag',
+    newTag: 'new-keyword',
+    expected: `\
+---
 title: "A simple test document"
 author: Zettlr
 keywords:
 - one tag
 - new-keyword
+- Mixed-case-Tag
 ---
 
 # A simple test document
@@ -76,19 +86,23 @@ of the replaceTags function to properly replace tags within files.
 
 It contains a YAML frontmatter that defines one keyword with a space in it that
 cannot occur anywhere else in the document; as well as the #new-keyword that now
-also occurs within here.
+also occurs within here. And a #MiXeD-case-TaG.
 
 For example, if we have a [link](#second-tag), it shouldn't be replaced.
 Similarly with [link](example.com#second-tag).`
   },
   {
     // No spaces -> spaces
-    oldTag: 'second-tag', newTag: 'New keyword', expected: `---
+    oldTag: 'second-tag',
+    newTag: 'New keyword',
+    expected: `\
+---
 title: "A simple test document"
 author: Zettlr
 keywords:
 - one tag
 - New keyword
+- Mixed-case-Tag
 ---
 
 # A simple test document
@@ -98,19 +112,23 @@ of the replaceTags function to properly replace tags within files.
 
 It contains a YAML frontmatter that defines one keyword with a space in it that
 cannot occur anywhere else in the document; as well as the  that now
-also occurs within here.
+also occurs within here. And a #MiXeD-case-TaG.
 
 For example, if we have a [link](#second-tag), it shouldn't be replaced.
 Similarly with [link](example.com#second-tag).`
   },
   {
     // Spaces -> No spaces
-    oldTag: 'one tag', newTag: 'one-tag', expected: `---
+    oldTag: 'one tag',
+    newTag: 'one-tag',
+    expected: `\
+---
 title: "A simple test document"
 author: Zettlr
 keywords:
 - one-tag
 - second-tag
+- Mixed-case-Tag
 ---
 
 # A simple test document
@@ -120,7 +138,33 @@ of the replaceTags function to properly replace tags within files.
 
 It contains a YAML frontmatter that defines one keyword with a space in it that
 cannot occur anywhere else in the document; as well as the #second-tag that now
-also occurs within here.
+also occurs within here. And a #MiXeD-case-TaG.
+
+For example, if we have a [link](#second-tag), it shouldn't be replaced.
+Similarly with [link](example.com#second-tag).`
+  },
+  {
+    // Case insensitive
+    oldTag: 'Mixed-case-Tag',
+    newTag: 'all-lowercase-tag',
+    expected: `\
+---
+title: "A simple test document"
+author: Zettlr
+keywords:
+- one tag
+- second-tag
+- all-lowercase-tag
+---
+
+# A simple test document
+
+This #document contains some tags as well as some edge-cases to test the ability
+of the replaceTags function to properly replace tags within files.
+
+It contains a YAML frontmatter that defines one keyword with a space in it that
+cannot occur anywhere else in the document; as well as the #second-tag that now
+also occurs within here. And a #all-lowercase-tag.
 
 For example, if we have a [link](#second-tag), it shouldn't be replaced.
 Similarly with [link](example.com#second-tag).`


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes support for non-lowercased tags

Closes #6008

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
All tags are lowercased when comparing in the `replaceTags` function

Additional tests were added for case-insensitive replacement

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
