### PR TITLE
[Fix] Improve math parsing validation

### DIFF
--- a/source/common/modules/markdown-editor/parser/math-parser.ts
+++ b/source/common/modules/markdown-editor/parser/math-parser.ts
@@ -66,7 +66,7 @@ export const inlineMathParser: InlineParser = {
     if (!isInlineDisplayMath && (/\s/.test(ctx.slice(pos - 1, pos)) || /\d/.test(ctx.slice(pos + 1, pos + 2)))) {
       // However, if this is an invalid closing delimiter, we need to check if
       // it would be a valid  opening delimiter and add it to the tree if it is.
-      const invalidOpening = !isInlineDisplayMath && /\s/.test(ctx.slice(pos + 1, pos + 2))
+      const invalidOpening = /\s/.test(ctx.slice(pos + 1, pos + 2))
 
       // Either return -1 due to an invalid delimiter, or return the end position of the delimiter
       return  invalidOpening ? -1 : ctx.addDelimiter(MathDelimiter, pos, pos + delimLength, true, false)


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes two issues with inline single-delimiter math parsing I experienced while drafting a snippet in the main editor:

1. When a line contains a dollar sign, and the next line starts with a dollar sign, the content between is interpreted as math text.

2. When the closing delimiter is followed by a digit, the content is still interpreted as math despite the delimiter being invalid, according to pandoc docs.

It also better aligns the block math parser with pandoc so that blank lines are no longer valid within math blocks.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The whitespace tests were moved so that the tests are only performed when needed. This reduces unnecessary calculations.

The following changes are from what I understand of the [pandoc docs on the delimiters](https://pandoc.org/MANUAL.html#extension-tex_math_dollars): 

The whitespace checks were refactored to a regex test for any whitespace character using `\s`. I changed this because I interpreted the pandoc docs, `must have a non-space character`, to mean any whitespace.

An additional test was added for closing delimiters to ensure they are not followed by a digit.

The whitespace and following-digit tests are ignored if the delimiter is for display math, `$$`, which do not have limitations on preceding or following characters.

The math block parser had an additional check added to make sure that no lines within the block are blank.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
 
<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
