### PR TITLE
[Fix] fix image title offset calculations

### DIFF
--- a/source/common/modules/markdown-editor/parser/pandoc-link-parser.ts
+++ b/source/common/modules/markdown-editor/parser/pandoc-link-parser.ts
@@ -24,7 +24,7 @@ const PandocLinkDelimiter: DelimiterType = {}
 
 const linkClosingRe = /^\]\((?<url>.+)\)/
 
-const linkTitleRe = /(?:^|[ \t]+)(?:"((?:\\.|[^"])+)"|'((?:\\.|[^'])+)'|\(((?:\\.|[^\)])+)\))$/
+const linkTitleRe = /(?:^|[ \t]+)(?:"(?<double>(?:\\.|[^"])+)"|'(?<single>(?:\\.|[^'])+)'|\((?<parens>(?:\\.|[^\)])+)\))$/d
 
 export const pandocLinkParser: InlineParser = {
   name: 'pandoc-link-parser',
@@ -95,11 +95,11 @@ export const pandocLinkParser: InlineParser = {
     const urlContents = []
     const title = linkTitleRe.exec(destination)
 
-    if (title) {
+    if (title?.indices?.groups) {
       destination = url.substring(0, title.index)
 
-      const linkTitleText = title[1] ?? title[2] ?? title[3]
-      urlContents.push(ctx.elt('LinkTitle', pos + 4 + title.index, pos + 4 + title.index + linkTitleText.length))
+      const linkTitleIndices = title.indices.groups.double ?? title.indices.groups.single ?? title.indices.groups.parens
+      urlContents.push(ctx.elt('LinkTitle', pos + 2 + linkTitleIndices[0], pos + 2 + linkTitleIndices[1]))
     }
 
     urlContents.unshift(ctx.elt('URL', pos + 2, pos + 2 + destination.length))


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes image title parsing.

Closes  #6036

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The offset for parsing link/image titles ~~was increased from 2 to 4 because the regex does not include the formatting characters.~~ was refactored to use regex indices

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
