### PR TITLE
Refactor range in selection handling

### DIFF
--- a/source/common/modules/markdown-editor/renderers/base-renderer.ts
+++ b/source/common/modules/markdown-editor/renderers/base-renderer.ts
@@ -82,7 +82,7 @@ function renderWidgets (
       enter: (node) => {
         // Determine the number of overlapping selections. If these are non-
         // null, we must not render this widget
-        if (rangeInSelection(state, node.from, node.to)) {
+        if (rangeInSelection(state.selection, node.from, node.to)) {
           return
         }
 

--- a/source/common/modules/markdown-editor/renderers/render-headings.ts
+++ b/source/common/modules/markdown-editor/renderers/render-headings.ts
@@ -29,7 +29,7 @@ function hideHeadingMarks (view: EditorView): RangeSet<Decoration> {
     syntaxTree(view.state).iterate({
       from, to,
       enter (node) {
-        if(rangeInSelection(view.state, node.from, node.to, true)) {
+        if(rangeInSelection(view.state.selection, node.from, node.to, true)) {
           return
         }
 

--- a/source/common/modules/markdown-editor/renderers/render-links.ts
+++ b/source/common/modules/markdown-editor/renderers/render-links.ts
@@ -31,7 +31,7 @@ function hideLinkMarkers (view: EditorView): RangeSet<Decoration> {
         }
 
         // Do not hide any characters if a selection is inside here
-        if (rangeInSelection(view.state, node.from, node.to)) {
+        if (rangeInSelection(view.state.selection, node.from, node.to, true)) {
           return false
         }
 

--- a/source/common/modules/markdown-editor/renderers/render-math.ts
+++ b/source/common/modules/markdown-editor/renderers/render-math.ts
@@ -90,7 +90,7 @@ function createWidget (state: EditorState, node: SyntaxNodeRef): MathWidget|unde
   // stay, and keep its position updated depending on what happens in the doc)
 
   // Don't render if the selection is within the node
-  if (rangeInSelection(state, node.from, node.to, true)) {
+  if (rangeInSelection(state.selection, node.from, node.to, true)) {
     return undefined
   }
 

--- a/source/common/modules/markdown-editor/util/range-in-selection.ts
+++ b/source/common/modules/markdown-editor/util/range-in-selection.ts
@@ -13,28 +13,23 @@
  * END HEADER
  */
 
-import { type EditorState } from '@codemirror/state'
+import type { EditorSelection } from '@codemirror/state'
 
 /**
  * Checks if any of the selections within the given EditorState has overlap with
  * the provided range.
  *
- * @param   {EditorState}  state            The state to draw selections from
- * @param   {number}       rangeFrom        The start position of the range
- * @param   {number}       rangeTo          The end position of the range
- * @param   {boolean}      includeAdjacent  Whether to count adjacent selections
+ * @param   {EditorSelection}   selection         The selections to test
+ * @param   {number}            rangeFrom         The start position of the range
+ * @param   {number}            rangeTo           The end position of the range
+ * @param   {boolean}           includeAdjacent   Whether to count adjacent selections
  *
  * @return  {boolean}                       True if any selection overlaps
  */
-export function rangeInSelection (state: EditorState, rangeFrom: number, rangeTo: number, includeAdjacent = false): boolean {
-  return state.selection.ranges
-    .map(range => [ range.from, range.to ])
-    .filter(([ from, to ]) => {
-      if (includeAdjacent) {
-        return !(to < rangeFrom || from > rangeTo)
-      } else {
-        return !(to <= rangeFrom || from >= rangeTo)
-      }
-    })
-    .length > 0
+export function rangeInSelection (selection: EditorSelection, rangeFrom: number, rangeTo: number, includeAdjacent: boolean = false): boolean {
+  if (includeAdjacent) {
+    return !selection.ranges.some(range => range.to < rangeFrom || range.from > rangeTo)
+  } else {
+    return !selection.ranges.some(range => range.to <= rangeFrom || range.from >= rangeTo)
+  }
 }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors the range in selection handling, optimizing performance and setting some QOL improvements.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The `rangeInSelection` function was refactored to a simpler and more performant implementation, and the types were narrowed from the `EditorState` to just the `EditorSelection`.

Calls to `rangeInSelection` were updated to match the new type, and several calls were updated to set `includeAdjacent` to `true`, which provides some QOL editing improvements, in my opinion.

The parent node detection for `QuoteMark` was improved to find the highest level parent since blockquotes can be contained within other blockquotes. This prevents the case where the cursor is in a parent blockquote, and the quotemark for the child is still hidden. 

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
