### PR TITLE
[Performance] Refactor code-background plugin

### DIFF
--- a/source/common/modules/markdown-editor/editor.css
+++ b/source/common/modules/markdown-editor/editor.css
@@ -103,6 +103,7 @@
 
   /* A few elements always need to be displayed monospaced */
   .cm-comment,
+  .cm-block-comment,
   .cm-fenced-code,
   .cm-table
   .cm-formatting-task,
@@ -129,7 +130,7 @@
     cursor: pointer;
     border-radius: 3px;
     padding: 0 4px;
-  
+
     span {
       font-size: 20px;
       font-weight: normal;

--- a/source/common/modules/markdown-editor/plugins/code-background.ts
+++ b/source/common/modules/markdown-editor/plugins/code-background.ts
@@ -25,8 +25,13 @@ export const codeblockBackground = layer({
             return
           }
 
-          const start = view.state.doc.lineAt(node.from).from
-          const end = view.state.doc.lineAt(node.to).to + 1
+          let start = node.from
+          let end = node.to
+
+          if (node.name === 'CodeText') {
+            start = view.state.doc.lineAt(node.from).from
+            end = view.state.doc.lineAt(node.to).to + 1
+          }
 
           // In order to get a proper styling, we have to do two things:
           // First, remove zero-width markers (that happen since we include

--- a/source/common/modules/markdown-editor/theme/berlin.ts
+++ b/source/common/modules/markdown-editor/theme/berlin.ts
@@ -19,7 +19,7 @@ const selectionDark = 'rgba(90, 170, 80, 0.8)'
 
 const commonRules: Record<string, any> = {
   // Monospaced elements (quite a lot)
-  '.cm-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
     fontFamily: 'Inconsolata, monospace'
   },
   '.cm-gutters': {
@@ -46,7 +46,7 @@ export const themeBerlinLight = EditorView.theme({
     color: 'var(--grey-5)',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, "Segoe UI", Arial, sans-serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-attribute-name': { color: 'var(--blue-0)' },
   '.cm-attribute-value': { color: 'var(--green-0)' },
@@ -79,7 +79,7 @@ export const themeBerlinDark = EditorView.theme({
     color: 'var(--grey-0)',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, "Segoe UI", Arial, sans-serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     color: primaryColor
   },

--- a/source/common/modules/markdown-editor/theme/bielefeld.ts
+++ b/source/common/modules/markdown-editor/theme/bielefeld.ts
@@ -33,7 +33,7 @@ export const themeBielefeldLight = EditorView.theme({
     color: 'var(--grey-5)',
     fontFamily: '"Liberation Mono", monospace'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-attribute-name': { color: 'var(--blue-0)' },
   '.cm-attribute-value': { color: 'var(--green-0)' },
@@ -65,7 +65,7 @@ export const themeBielefeldDark = EditorView.theme({
     color: 'var(--grey-0)',
     fontFamily: '"Liberation Mono", monospace'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     color: primaryColor
   },

--- a/source/common/modules/markdown-editor/theme/bordeaux.ts
+++ b/source/common/modules/markdown-editor/theme/bordeaux.ts
@@ -33,7 +33,7 @@ export const themeBordeauxLight = EditorView.theme({
     color: 'var(--grey-5)',
     fontFamily: 'Inconsolata, monospace'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-attribute-name': { color: 'var(--blue-0)' },
   '.cm-attribute-value': { color: 'var(--green-0)' },
@@ -72,7 +72,7 @@ export const themeBordeauxDark = EditorView.theme({
     // color: 'var(--grey-0)',
     fontFamily: 'Inconsolata, monospace'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     color: primaryColor
   },

--- a/source/common/modules/markdown-editor/theme/frankfurt.ts
+++ b/source/common/modules/markdown-editor/theme/frankfurt.ts
@@ -19,7 +19,7 @@ const blueSelectionDark = 'rgba(29, 55, 134, 0.8)'
 
 const commonRules: Record<string, any> = {
   // Monospaced elements (quite a lot)
-  '.cm-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
     fontFamily: 'Inconsolata, monospace'
   },
   '.cm-gutters': {
@@ -46,7 +46,7 @@ export const themeFrankfurtLight = EditorView.theme({
     color: 'var(--grey-5)',
     fontFamily: 'Crimson, serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-attribute-name': { color: 'var(--blue-0)' },
   '.cm-attribute-value': { color: 'var(--green-0)' },
@@ -78,7 +78,7 @@ export const themeFrankfurtDark = EditorView.theme({
     color: 'var(--grey-0)',
     fontFamily: 'Crimson, serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     color: primaryColor
   },

--- a/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
+++ b/source/common/modules/markdown-editor/theme/karl-marx-stadt.ts
@@ -19,7 +19,7 @@ const selectionDark = 'rgba(163, 35, 35, 0.7)'
 
 const commonRules: Record<string, any> = {
   // Monospaced elements (quite a lot)
-  '.cm-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math, .cm-code-mark, .cm-monospace, .cm-hr, .code-block-line': {
     fontFamily: 'Inconsolata, monospace'
   },
   '.cm-gutters': {
@@ -46,7 +46,7 @@ export const themeKarlMarxStadtLight = EditorView.theme({
     color: 'var(--grey-5)',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, "Segoe UI", Arial, sans-serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-5)' },
   '.cm-tag-name': { color: 'var(--orange-2)' },
   '.cm-attribute-name': { color: 'var(--blue-0)' },
   '.cm-attribute-value': { color: 'var(--green-0)' },
@@ -78,7 +78,7 @@ export const themeKarlMarxStadtDark = EditorView.theme({
     color: 'var(--grey-0)',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, "Segoe UI", Arial, sans-serif'
   },
-  '.cm-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
+  '.cm-comment, .cm-block-comment, .cm-fenced-code, .cm-inline-math': { color: 'var(--grey-0)' },
   '.cm-hr, .cm-yaml-frontmatter-start, .cm-yaml-frontmatter-end': {
     color: primaryColor
   },

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -717,6 +717,7 @@ function maybeHighlightSearchResults (): void {
       .cm-variable-name  { color: @cyan; }
       .cm-variable       { color: @cyan; }
       .cm-comment        { color: @base1; }
+      .cm-block-comment  { color: @base1; }
       .cm-attribute-name { color: @orange; }
       .cm-property       { color: @magenta; }
       .cm-keyword,


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors the code-background plugin to only draw the layer for the visible ranges. The code was also simplified.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The layers are only drawn for visible ranges rather than the whole document to improve performance.

The node test logic was simplified. For the codeblocks, we check for either `CodeText` or `CommentBlock` because code blocks, fenced code, and yaml blocks all keep content within `CodeText` nodes. This allows us to simplify the range calculation, as well.

The `try...catch` blocks were removed as I believe they are no longer necessary since [this commit](https://github.com/codemirror/view/commit/7235126c19c9f285a94a79dd79c3502ae2086be6) in `codemirror/view` 

The `code` class is no longer assigned using the layer. I do not think this is necessary, as the `code` class is assigned by the other code syntax extension.

Commented out code and outdated comments were removed.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
