### PR TITLE
[Fix] use `line.moveBase`, not `ctx.nextLine` in pandoc div parser

### DIFF
--- a/source/common/modules/markdown-editor/parser/pandoc-div-span-parser.ts
+++ b/source/common/modules/markdown-editor/parser/pandoc-div-span-parser.ts
@@ -158,7 +158,15 @@ export const pandocDivParser: BlockParser = {
     return null // composite blocks require returning `null` on success
   },
 
-  endLeaf: (_ctx, line, _leaf) => {
+  endLeaf: (ctx, line, _leaf) => {
+    // Opening marks can come one after the other without requiring
+    // a blank line in between. So we only interrupt if the line matches
+    // the opening mark if the parent is a `PandocDiv`. Otherrwise,
+    // only the closing mark can interrupt other nodes.
+    if (ctx.parentType().name === 'PandocDiv') {
+      return pandocDivClosingRe.test(line.text) || pandocDivOpeningRe.test(line.text)
+    }
+
     return pandocDivClosingRe.test(line.text)
   }
 }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR fixes a parsing issue in the pandoc div parser related to how the parsing was moved forward after the block was detected.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Instead of using `ctx.nextLine`, we call `line.moveBase` with the tracked offset to move parsing forward. This is the correct way, as the docs explicitly state not to use `ctx.nextLine` in composite block parsers (oops). 

This fixes a parsing issue where an empty div would not parse the closing mark correctly:

```
::: {#ref}
:::
```

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
