### PR TITLE
[FIX] fix snippet test YEAR bug

### DIFF
--- a/test/snippets.spec.ts
+++ b/test/snippets.spec.ts
@@ -55,29 +55,29 @@ const TEST_SNIPPETS = [
   },
   // Test 3
   {
-    template: 'Test ${1:nested placeholder ${2:$CURRENT_YEAR_SHORT} variable} replacement',
+    template: 'Test ${1:nested placeholder ${2:$CURRENT_YEAR} variable} replacement',
     expected: {
-      string: `Test nested placeholder 25 variable replacement`,
+      string: `Test nested placeholder ${YEAR} variable replacement`,
       selections: [
         {
           main: 0,
           ranges: [{
             anchor: 5,
-            head: 35
+            head: 37
           }]
         },
         {
           main: 0,
           ranges: [{
             anchor: 24,
-            head: 26
+            head: 28
           }]
         },
         {
           main: 0,
           ranges: [{
-            anchor: 47,
-            head: 47
+            anchor: 49,
+            head: 49
           }]
         },
       ]


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
Happy new year, this PR fixes a bug in the snippet test code where the year number was hardcoded to `25`.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Use variable substitution to determine the year dynamically in the variable-replacement snippet test.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I had already added the variable `YEAR`, but did not actually implement it in the test string :P

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
