### PR TITLE
[Enhancement] Custom default profile improvements

### DIFF
--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -394,7 +394,7 @@ export default class AssetsProvider extends ProviderContract {
    *
    * @return  {Promise<any>}    The defaults (parsed from YAML)
    */
-  async getDefaultsFile (filename: string, verbatim: boolean = false): Promise<any|string> {
+  async getDefaultsFile (filename: string, verbatim: boolean = false): Promise<unknown|string> {
     const absPath = path.join(this._defaultsPath, filename)
     const yaml = await fs.readFile(absPath, { encoding: 'utf-8' })
     // Either return the string contents or a JavaScript object

--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -21,7 +21,7 @@ import broadcastIpcMessage from '@common/util/broadcast-ipc-message'
 import ProviderContract, { type IPCAPI } from '../provider-contract'
 import type LogProvider from '../log'
 import { getCustomProfiles } from '@providers/commands/exporter'
-import { SUPPORTED_READERS } from '@common/pandoc-util/pandoc-maps'
+import { PANDOC_READERS, PANDOC_WRITERS } from '@common/pandoc-util/pandoc-maps'
 import { parseReaderWriter } from '@common/pandoc-util/parse-reader-writer'
 
 export interface PandocProfileMetadata {
@@ -538,8 +538,8 @@ export default class AssetsProvider extends ProviderContract {
         const writer = yaml.writer !== undefined ? parseReaderWriter(yaml.writer as string) : parseReaderWriter('')
         const reader = yaml.reader !== undefined ? parseReaderWriter(yaml.reader as string) : parseReaderWriter('')
 
-        const validWriter = writer.isCustom || SUPPORTED_READERS.includes(writer.name)
-        const validReader = reader.isCustom || SUPPORTED_READERS.includes(reader.name)
+        const validWriter = writer.isCustom || PANDOC_WRITERS[writer.name] !== undefined
+        const validReader = reader.isCustom || PANDOC_READERS[reader.name] !== undefined
 
         const outputFile = yaml['output-file'] ?? ''
 

--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -535,10 +535,11 @@ export default class AssetsProvider extends ProviderContract {
         // A defaults file needs to fulfill three conditions in order to be
         // considered valid: (1) has a writer, (2) has a reader, (3) either
         // reader or writer must be a supported Markdown format.
-        const hasWriter = yaml.writer !== undefined
-        const hasReader = yaml.reader !== undefined
-        const validWriter = hasWriter && SUPPORTED_READERS.includes(parseReaderWriter(yaml.writer as string).name)
-        const validReader = hasReader && SUPPORTED_READERS.includes(parseReaderWriter(yaml.reader as string).name)
+        const writer = yaml.writer !== undefined ? parseReaderWriter(yaml.writer as string) : parseReaderWriter('')
+        const reader = yaml.reader !== undefined ? parseReaderWriter(yaml.reader as string) : parseReaderWriter('')
+
+        const validWriter = writer.isCustom || SUPPORTED_READERS.includes(writer.name)
+        const validReader = reader.isCustom || SUPPORTED_READERS.includes(reader.name)
 
         const outputFile = yaml['output-file'] ?? ''
 
@@ -547,7 +548,7 @@ export default class AssetsProvider extends ProviderContract {
           writer: yaml.writer,
           reader: yaml.reader,
           outputFile: outputFile,
-          isInvalid: !(hasWriter && hasReader && (validWriter || validReader)),
+          isInvalid: !(validWriter && validReader),
           isProtected: this._protectedDefaults.includes(file)
         })
       } catch (err) {

--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -545,8 +545,8 @@ export default class AssetsProvider extends ProviderContract {
 
         profiles.push({
           name: file,
-          writer: yaml.writer,
-          reader: yaml.reader,
+          writer: yaml.writer ?? '',
+          reader: yaml.reader ?? '',
           outputFile: outputFile,
           isInvalid: !(validWriter && validReader),
           isProtected: this._protectedDefaults.includes(file)

--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -394,7 +394,7 @@ export default class AssetsProvider extends ProviderContract {
    *
    * @return  {Promise<any>}    The defaults (parsed from YAML)
    */
-  async getDefaultsFile (filename: string, verbatim: boolean = false): Promise<unknown|string> {
+  async getDefaultsFile (filename: string, verbatim: boolean = false): Promise<any|string> {
     const absPath = path.join(this._defaultsPath, filename)
     const yaml = await fs.readFile(absPath, { encoding: 'utf-8' })
     // Either return the string contents or a JavaScript object

--- a/source/app/service-providers/assets/index.ts
+++ b/source/app/service-providers/assets/index.ts
@@ -38,6 +38,10 @@ export interface PandocProfileMetadata {
    */
   reader: string
   /**
+   * The output file, can be an empty string
+   */
+  outputFile: string
+  /**
    * Since Zettlr has a few requirements, we must have writers and readers.
    * While we strive to even support unknown readers and writers, those fields
    * at least have to have a value. If any hasn't, isInvalid will be true.
@@ -536,10 +540,13 @@ export default class AssetsProvider extends ProviderContract {
         const validWriter = hasWriter && SUPPORTED_READERS.includes(parseReaderWriter(yaml.writer as string).name)
         const validReader = hasReader && SUPPORTED_READERS.includes(parseReaderWriter(yaml.reader as string).name)
 
+        const outputFile = yaml['output-file'] ?? ''
+
         profiles.push({
           name: file,
           writer: yaml.writer,
           reader: yaml.reader,
+          outputFile: outputFile,
           isInvalid: !(hasWriter && hasReader && (validWriter || validReader)),
           isProtected: this._protectedDefaults.includes(file)
         })
@@ -549,6 +556,7 @@ export default class AssetsProvider extends ProviderContract {
           name: file,
           writer: '',
           reader: '',
+          outputFile: '',
           isInvalid: true,
           isProtected: this._protectedDefaults.includes(file)
         })

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -39,7 +39,6 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   }
   const defaults = await ctx.writeDefaults(options.profile.name, defaultKeys)
 
-  console.log('OG TARGET: ', target)
   // Check that the defaults profile did not change
   // `output-file`, and if it did, update the target.
   if (defaults['output-file'] !== target) {
@@ -52,7 +51,6 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
     }
   }
 
-  console.log('TARGET: ', target)
   // Run Pandoc
   const pandocOutput = await ctx.runPandoc(defaults)
 

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -30,17 +30,31 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   // First file determines the name of the exported file.
   const firstName = path.basename(options.sourceFiles[0].name, options.sourceFiles[0].ext)
   const title = (options.defaultsOverride?.title !== undefined) ? sanitize(options.defaultsOverride.title, { replacement: '-' }) : firstName
-  const target = path.join(options.targetDirectory, `${title}.${extension}`)
+  let target = path.join(options.targetDirectory, `${title}.${extension}`)
 
   // Get the corresponding defaults file
   const defaultKeys = {
     'input-files': sourceFiles,
     'output-file': target
   }
-  const defaultsFile = await ctx.writeDefaults(options.profile.name, defaultKeys)
+  const defaults = await ctx.writeDefaults(options.profile.name, defaultKeys)
 
+  console.log('OG TARGET: ', target)
+  // Check that the defaults profile did not change
+  // `output-file`, and if it did, update the target.
+  if (defaults['output-file'] !== target) {
+    const parsed = path.parse(defaults['output-file'] as string)
+    target = path.join(parsed.dir, parsed.name + `.${extension}`)
+
+    if (!path.isAbsolute(target)) {
+      target = path.join(options.targetDirectory, target)
+      defaults['output-file'] = target
+    }
+  }
+
+  console.log('TARGET: ', target)
   // Run Pandoc
-  const pandocOutput = await ctx.runPandoc(defaultsFile)
+  const pandocOutput = await ctx.runPandoc(defaults)
 
   // Make sure to propagate the results
   return {

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -39,16 +39,25 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   }
   const defaults = await ctx.writeDefaults(options.profile.name, defaultKeys)
 
-  // Check that the defaults profile did not change
-  // `output-file`, and if it did, update the target.
+  // Update `target` if the defaults profile changed`output-file`
   if (defaults['output-file'] !== target) {
-    const parsed = path.parse(defaults['output-file'] as string)
-    target = path.join(parsed.dir, parsed.name + `.${extension}`)
+    // Remove any internal `..` and `.` paths
+    target = path.normalize(defaults['output-file'] as string)
 
+    // If the target is a relative path, resolve it to the target directory
+    // and sanitize any potential path traversals.
     if (!path.isAbsolute(target)) {
-      target = path.join(options.targetDirectory, target)
-      defaults['output-file'] = target
+      target = path.resolve(options.targetDirectory, target)
+
+      // Make sure that the resolved path still falls under `targetDirectory`
+      // to prevent potentially insecure path traversals.
+      if (!target.startsWith(options.targetDirectory)) {
+        const parsed = path.parse(target)
+        target = path.join(options.targetDirectory, parsed.base)
+      }
     }
+
+    defaults['output-file'] = target
   }
 
   // Run Pandoc

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -37,7 +37,7 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
     'input-files': sourceFiles,
     'output-file': target
   }
-  const defaults = await ctx.writeDefaults(options.profile.name, defaultKeys)
+  const defaults = await ctx.loadDefaults(options.profile.name, defaultKeys)
 
   // Update `target` if the defaults profile changed`output-file`
   if (defaults['output-file'] !== target) {

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -17,6 +17,7 @@ import sanitize from 'sanitize-filename'
 import type { ExporterOptions, ExporterPlugin, ExporterOutput, ExporterAPI } from './types'
 import { WRITER2EXT } from '@common/pandoc-util/pandoc-maps'
 import { parseReaderWriter } from '@common/pandoc-util/parse-reader-writer'
+import normalizePath from 'source/common/util/normalize-path'
 
 export const plugin: ExporterPlugin = async function (options: ExporterOptions, sourceFiles: string[], ctx: ExporterAPI): Promise<ExporterOutput> {
   if (typeof options.profile === 'string') {
@@ -41,23 +42,7 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
 
   // Update `target` if the defaults profile changed`output-file`
   if (defaults['output-file'] !== target) {
-    // Remove any internal `..` and `.` paths
-    target = path.normalize(defaults['output-file'] as string)
-
-    // If the target is a relative path, resolve it to the target directory
-    // and sanitize any potential path traversals.
-    if (!path.isAbsolute(target)) {
-      target = path.resolve(options.targetDirectory, target)
-
-      // Make sure that the resolved path still falls under `targetDirectory`
-      // to prevent potentially insecure path traversals.
-      if (!target.startsWith(options.targetDirectory)) {
-        const parsed = path.parse(target)
-        target = path.join(options.targetDirectory, parsed.base)
-      }
-    }
-
-    defaults['output-file'] = target
+    defaults['output-file'] = normalizePath(defaults['output-file'] as string, options.targetDirectory)
   }
 
   // Run Pandoc

--- a/source/app/service-providers/commands/exporter/default-exporter.ts
+++ b/source/app/service-providers/commands/exporter/default-exporter.ts
@@ -42,7 +42,8 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
 
   // Update `target` if the defaults profile changed`output-file`
   if (defaults['output-file'] !== target) {
-    defaults['output-file'] = normalizePath(defaults['output-file'] as string, options.targetDirectory)
+    target = normalizePath(defaults['output-file'] as string, options.targetDirectory)
+    defaults['output-file'] = target
   }
 
   // Run Pandoc

--- a/source/app/service-providers/commands/exporter/index.ts
+++ b/source/app/service-providers/commands/exporter/index.ts
@@ -259,7 +259,7 @@ async function writeDefaults (
       defaults[key] = properties[key]
     } else {
       logger.info(`Default property \`${key}\` is already set: \`${defaults[key]}\``)
-      logger.info(`Ignoring plugin property \`${key}: ${properties[key]}\``)
+      logger.info(`Ignoring plugin property \`${key}\`: \`${properties[key]}\``)
     }
   }
 

--- a/source/app/service-providers/commands/exporter/index.ts
+++ b/source/app/service-providers/commands/exporter/index.ts
@@ -94,7 +94,7 @@ export async function makeExport (
       return await runPandoc(logger, defaults, options.cwd)
     },
     writeDefaults: async (filename: string, overrides: Record<string, unknown> = {}) => {
-      return await writeDefaults(filename, overrides, config, assets, options.defaultsOverride)
+      return await writeDefaults(filename, overrides, logger, config, assets, options.defaultsOverride)
     },
     listDefaults: async () => {
       return await assets.listDefaults()
@@ -164,6 +164,7 @@ async function runPandoc (logger: LogProvider, defaultsFile: string, cwd?: strin
 async function writeDefaults (
   filename: string, // The profile to use
   properties: Record<string, unknown>, // Contains properties that will be written to the defaults
+  logger: LogProvider,
   config: ConfigProvider,
   assets: AssetsProvider,
   defaultsOverride?: DefaultsOverride
@@ -179,7 +180,7 @@ async function writeDefaults (
   // the user preferences.
   const parsedReader = parseReaderWriter(defaults.reader as string)
   const readsMarkdown = EXT2READER['md'].includes(parsedReader.name)
-  
+
   // The user can choose to use [[link|title]] or [[title|link]] syntax. In
   // order for the Lua filter to work properly and respect the link removal
   // setting upon export, we need to set the appropriate extension if it is not
@@ -251,10 +252,15 @@ async function writeDefaults (
   const filters = await assets.listFilters(true)
   defaults.filters = defaults.filters.concat(filters)
 
-  // After we have added our default keys, let the plugin add their keys, which
-  // enables them to override certain keys if necessary.
+  // After we have added our default keys, let the plugin add keys, which
+  // may be overridden by the default file if already set.
   for (const key in properties) {
-    defaults[key] = properties[key]
+    if (defaults[key] === undefined) {
+      defaults[key] = properties[key]
+    } else {
+      logger.info(`Default property \`${key}\` is already set: \`${defaults[key]}\``)
+      logger.info(`Ignoring plugin property \`${key}: ${properties[key]}\``)
+    }
   }
 
   const YAMLOptions = {

--- a/source/app/service-providers/commands/exporter/index.ts
+++ b/source/app/service-providers/commands/exporter/index.ts
@@ -23,7 +23,7 @@ import { promises as fs } from 'fs'
 import isFile from '@common/util/is-file'
 
 // Exporters
-import type { DefaultsOverride, ExporterAPI, ExporterOptions, ExporterOutput, PandocRunnerOutput } from './types'
+import type { DefaultsOverride, ExporterAPI, ExporterOptions, ExporterOutput, PandocDefaults, PandocRunnerOutput } from './types'
 import { plugin as DefaultExporter } from './default-exporter'
 import { plugin as PDFExporter } from './pdf-exporter'
 import { plugin as TextbundleExporter } from './textbundle-exporter'
@@ -90,10 +90,10 @@ export async function makeExport (
 
   // This is basically the "plugin API"
   const ctx: ExporterAPI = {
-    runPandoc: async (defaults: string) => {
+    runPandoc: async (defaults: PandocDefaults) => {
       return await runPandoc(logger, defaults, options.cwd)
     },
-    writeDefaults: async (filename: string, overrides: Record<string, unknown> = {}) => {
+    writeDefaults: async (filename: string, overrides: PandocDefaults = {}) => {
       return await writeDefaults(filename, overrides, logger, config, assets, options.defaultsOverride)
     },
     listDefaults: async () => {
@@ -112,7 +112,10 @@ export async function makeExport (
   }
 }
 
-async function runPandoc (logger: LogProvider, defaultsFile: string, cwd?: string): Promise<PandocRunnerOutput> {
+async function runPandoc (logger: LogProvider, defaults: PandocDefaults, cwd?: string): Promise<PandocRunnerOutput> {
+  const defaultsFile = path.join(app.getPath('temp'), 'defaults.yml')
+  await fs.writeFile(defaultsFile, YAML.stringify(defaults), { encoding: 'utf8' })
+
   const output: PandocRunnerOutput = {
     code: 0,
     stdout: [],
@@ -153,7 +156,11 @@ async function runPandoc (logger: LogProvider, defaultsFile: string, cwd?: strin
   output.stdout = output.stdout.join('').split('\n').filter(line => line.trim() !== '')
 
   if (output.stdout.length > 0) {
-    logger.info('This Pandoc run produced additional output.', output.stdout)
+    logger.info('This Pandoc run produced additional output.', output.stdout.join('\n'))
+  }
+
+  if (output.stderr.length > 0) {
+    logger.warning('This Pandoc run produced additional output.', output.stderr.join('\n'))
   }
 
   return output
@@ -163,14 +170,13 @@ async function runPandoc (logger: LogProvider, defaultsFile: string, cwd?: strin
 
 async function writeDefaults (
   filename: string, // The profile to use
-  properties: Record<string, unknown>, // Contains properties that will be written to the defaults
+  properties: PandocDefaults, // Contains properties that will be written to the defaults
   logger: LogProvider,
   config: ConfigProvider,
   assets: AssetsProvider,
   defaultsOverride?: DefaultsOverride
-): Promise<string> {
-  const defaultsFile = path.join(app.getPath('temp'), 'defaults.yml')
-  const defaults = await assets.getDefaultsFile(filename)
+): Promise<PandocDefaults> {
+  const defaults: PandocDefaults = await assets.getDefaultsFile(filename)
 
   const cfg = config.get()
   const { cslLibrary, cslStyle, stripTags, stripLinks, enforceMarkSupport } = cfg.export
@@ -203,7 +209,7 @@ async function writeDefaults (
   // respects a file-defined bibliography, this is our best shot.
   // const bibliography = global.citeproc.getSelectedDatabase()
   if (isFile(cslLibrary)) {
-    if ('bibliography' in defaults) {
+    if (defaults.bibliography !== undefined) {
       // Ensure the bibliography is an array, not a single string.
       if (!Array.isArray(defaults.bibliography)) {
         defaults.bibliography = [defaults.bibliography]
@@ -224,11 +230,11 @@ async function writeDefaults (
   // users can also add these manually to their files if they prefer. This way
   // any file's metadata will overwrite anything defined programmatically here
   // in the defaults.
-  if (!('metadata' in defaults)) {
+  if (defaults.metadata === undefined) {
     defaults.metadata = {}
   }
 
-  if (!('zettlr' in defaults.metadata)) {
+  if (defaults.metadata.zettlr === undefined) {
     defaults.metadata.zettlr = {}
   }
 
@@ -245,7 +251,7 @@ async function writeDefaults (
   }
 
   // Add all filters which are within the userData/lua-filter directory.
-  if (!('filters' in defaults)) {
+  if (defaults.filters === undefined) {
     defaults.filters = []
   }
 
@@ -258,17 +264,11 @@ async function writeDefaults (
     if (defaults[key] === undefined) {
       defaults[key] = properties[key]
     } else {
-      logger.info(`Default property \`${key}\` is already set: \`${defaults[key]}\``)
+      logger.info(`Default property \`${key}\` is already set: \`${YAML.stringify(defaults[key], { indent: 4, simpleKeys: false })}\``)
       logger.info(`Ignoring plugin property \`${key}\`: \`${properties[key]}\``)
     }
   }
 
-  const YAMLOptions = {
-    indent: 4,
-    simpleKeys: false
-  }
-  await fs.writeFile(defaultsFile, YAML.stringify(defaults, YAMLOptions), { encoding: 'utf8' })
-
   // Return the path to the defaults file
-  return defaultsFile
+  return defaults
 }

--- a/source/app/service-providers/commands/exporter/index.ts
+++ b/source/app/service-providers/commands/exporter/index.ts
@@ -93,8 +93,8 @@ export async function makeExport (
     runPandoc: async (defaults: PandocDefaults) => {
       return await runPandoc(logger, defaults, options.cwd)
     },
-    writeDefaults: async (filename: string, overrides: PandocDefaults = {}) => {
-      return await writeDefaults(filename, overrides, logger, config, assets, options.defaultsOverride)
+    loadDefaults: async (filename: string, overrides: PandocDefaults = {}) => {
+      return await loadDefaults(filename, overrides, logger, config, assets, options.defaultsOverride)
     },
     listDefaults: async () => {
       return await assets.listDefaults()
@@ -168,7 +168,7 @@ async function runPandoc (logger: LogProvider, defaults: PandocDefaults, cwd?: s
 
 // REFERENCE: Full defaults file here: https://pandoc.org/MANUAL.html#default-files
 
-async function writeDefaults (
+async function loadDefaults (
   filename: string, // The profile to use
   properties: PandocDefaults, // Contains properties that will be written to the defaults
   logger: LogProvider,
@@ -260,8 +260,19 @@ async function writeDefaults (
 
   // After we have added our default keys, let the plugin add keys, which
   // may be overridden by the default file if already set.
+  const alwaysOverrideKeys = [
+    'input-files'
+  ]
+
   for (const key in properties) {
-    if (defaults[key] === undefined) {
+    // Some keys should always be overridden by the plugin values to provide the
+    // expected functionality.
+    if (alwaysOverrideKeys.includes(key)) {
+      defaults[key] = properties[key]
+      logger.warning(`Overriding \`${key}\`: \`${properties[key]}\``)
+      logger.warning(`Ignoring default property \`${key}\`: \`${defaults[key]}\``)
+    // If the defaults file does not define a key, set it to the plugin value.
+    } else if (defaults[key] === undefined) {
       defaults[key] = properties[key]
     } else {
       logger.info(`Default property \`${key}\` is already set: \`${YAML.stringify(defaults[key], { indent: 4, simpleKeys: false })}\``)

--- a/source/app/service-providers/commands/exporter/index.ts
+++ b/source/app/service-providers/commands/exporter/index.ts
@@ -48,19 +48,22 @@ export function getCustomProfiles (): PandocProfileMetadata[] {
       name: 'Textbundle.yaml', // Fake name
       reader: 'markdown', // Not completely the truth
       writer: 'textbundle', // Not even supported by Pandoc
-      isInvalid: false // IT'S ALL FAKE!
+      isInvalid: false, // IT'S ALL FAKE!
+      outputFile: '',
     },
     {
       name: 'Textpack.yaml',
       reader: 'markdown',
       writer: 'textpack',
-      isInvalid: false
+      isInvalid: false,
+      outputFile: '',
     },
     {
       name: 'Simple PDF.yaml',
       reader: 'markdown',
       writer: 'simple-pdf',
-      isInvalid: false
+      isInvalid: false,
+      outputFile: '',
     }
   ]
 }

--- a/source/app/service-providers/commands/exporter/pdf-exporter.ts
+++ b/source/app/service-providers/commands/exporter/pdf-exporter.ts
@@ -47,18 +47,34 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   // Write to an intermediary HTML file which we will convert to PDF below.
   const defaults = await ctx.writeDefaults(allDefaults[0].name, defaultKeys)
 
-  // Check that the defaults profile did not change
-  // `output-file`, and if it did, update the target.
-  if (defaults['output-file'] !== pdfFilePath) {
-    const parsed = path.parse(defaults['output-file'] as string)
-    pdfFilePath = path.join(parsed.dir, parsed.name + '.pdf')
-    htmlFilePath = path.join(parsed.dir, parsed.name + '.html')
+  // Since the PDF exporter is a two-stage process, `htmlFilePath` is what
+  // is actually passed to pandoc, however, a user provided `output-file`
+  // likely refers to the path of the output PDF. So, if `output-file` has
+  // changed, normalize the path based on the PDF and set `output-file` to
+  // the updated `htmlFilePath`.
+  if (defaults['output-file'] !== htmlFilePath) {
+    // Remove any internal `..` and `.` paths
+    pdfFilePath = path.normalize(defaults['output-file'] as string)
 
+    // If the target is a relative path, resolve it to the target directory
+    // and sanitize any potential path traversals.
     if (!path.isAbsolute(pdfFilePath)) {
-      pdfFilePath = path.join(options.targetDirectory, pdfFilePath)
-      htmlFilePath = path.join(options.targetDirectory, htmlFilePath)
-      defaults['output-file'] = htmlFilePath
+      pdfFilePath = path.resolve(options.targetDirectory, pdfFilePath)
+
+      // Make sure that the resolved path still falls under `targetDirectory`
+      // to prevent potentially insecure path traversals.
+      if (!pdfFilePath.startsWith(options.targetDirectory)) {
+        const parsed = path.parse(pdfFilePath)
+        pdfFilePath = path.join(options.targetDirectory, parsed.base)
+      }
     }
+
+    // This is a temporary file, so potentially duplicating the extension as
+    // `.pdf.html` doesn't really matter. We probably could disregard updating
+    // this path entirely, but here it is done for consistency.
+    htmlFilePath = pdfFilePath + '.html'
+
+    defaults['output-file'] = htmlFilePath
   }
 
   // Run Pandoc

--- a/source/app/service-providers/commands/exporter/pdf-exporter.ts
+++ b/source/app/service-providers/commands/exporter/pdf-exporter.ts
@@ -45,7 +45,7 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   }
 
   // Write to an intermediary HTML file which we will convert to PDF below.
-  const defaults = await ctx.writeDefaults(allDefaults[0].name, defaultKeys)
+  const defaults = await ctx.loadDefaults(allDefaults[0].name, defaultKeys)
 
   // Since the PDF exporter is a two-stage process, `htmlFilePath` is what
   // is actually passed to pandoc, however, a user provided `output-file`

--- a/source/app/service-providers/commands/exporter/pdf-exporter.ts
+++ b/source/app/service-providers/commands/exporter/pdf-exporter.ts
@@ -21,6 +21,7 @@ import { promises as fs } from 'fs'
 import { BrowserWindow } from 'electron'
 import type { ExporterOptions, ExporterPlugin, ExporterOutput, ExporterAPI } from './types'
 import sanitize from 'sanitize-filename'
+import normalizePath from 'source/common/util/normalize-path'
 
 export const plugin: ExporterPlugin = async function (options: ExporterOptions, sourceFiles: string[], ctx: ExporterAPI): Promise<ExporterOutput> {
   // First file determines the name of the output path, EXCEPT a title is
@@ -53,21 +54,7 @@ export const plugin: ExporterPlugin = async function (options: ExporterOptions, 
   // changed, normalize the path based on the PDF and set `output-file` to
   // the updated `htmlFilePath`.
   if (defaults['output-file'] !== htmlFilePath) {
-    // Remove any internal `..` and `.` paths
-    pdfFilePath = path.normalize(defaults['output-file'] as string)
-
-    // If the target is a relative path, resolve it to the target directory
-    // and sanitize any potential path traversals.
-    if (!path.isAbsolute(pdfFilePath)) {
-      pdfFilePath = path.resolve(options.targetDirectory, pdfFilePath)
-
-      // Make sure that the resolved path still falls under `targetDirectory`
-      // to prevent potentially insecure path traversals.
-      if (!pdfFilePath.startsWith(options.targetDirectory)) {
-        const parsed = path.parse(pdfFilePath)
-        pdfFilePath = path.join(options.targetDirectory, parsed.base)
-      }
-    }
+    pdfFilePath = normalizePath(defaults['output-file'] as string, options.targetDirectory)
 
     // This is a temporary file, so potentially duplicating the extension as
     // `.pdf.html` doesn't really matter. We probably could disregard updating

--- a/source/app/service-providers/commands/exporter/types.d.ts
+++ b/source/app/service-providers/commands/exporter/types.d.ts
@@ -137,7 +137,7 @@ export interface ExporterAPI {
    * @return  {Promise<string>}                  Resolves with an absolute path to the written file
    *                                             and the parsed content of the defaults file.
    */
-  writeDefaults: (writer: string, properties: PandocDefaults = {}) => Promise<PandocDefaults>
+  loadDefaults: (writer: string, properties: PandocDefaults = {}) => Promise<PandocDefaults>
   listDefaults: () => Promise<PandocProfileMetadata[]>
 }
 

--- a/source/app/service-providers/commands/exporter/types.d.ts
+++ b/source/app/service-providers/commands/exporter/types.d.ts
@@ -15,6 +15,14 @@
 
 import { type PandocProfileMetadata } from '@providers/assets'
 
+export type PandocDefaults = Record<string, unknown> & {
+  filters?: Array<string>
+  metadata?: Record<string, unknown> & {
+    zettlr?: Record<string, unknown>
+  }
+  bibliography?: string|Array<string>
+}
+
 // The exporter only needs a few properties, so by defining a minimal type here
 // we can make the exporter more flexible to accept also objects that only
 // contain path information
@@ -117,7 +125,7 @@ export interface ExporterAPI {
    *
    * @return  {Promise<PandocRunnerOutput>}                Any output produced by Pandoc.
    */
-  runPandoc: (defaultsFile: string) => Promise<PandocRunnerOutput>
+  runPandoc: (defaults: PandocDefaults) => Promise<PandocRunnerOutput>
 
   /**
    * Retrieves a user-customised defaults file, adds the given properties and
@@ -126,9 +134,10 @@ export interface ExporterAPI {
    * @param   {string}                   filename    The filename for which the defaults apply
    * @param   {Record<string, unknown>}  properties  Any additional properties to add to the defaults.
    *
-   * @return  {Promise<string>}                      Resolves with an absolute path to the written file.
+   * @return  {Promise<string>}                  Resolves with an absolute path to the written file
+   *                                             and the parsed content of the defaults file.
    */
-  writeDefaults: (writer: string, properties: Record<string, unknown> = {}) => Promise<string>
+  writeDefaults: (writer: string, properties: PandocDefaults = {}) => Promise<PandocDefaults>
   listDefaults: () => Promise<PandocProfileMetadata[]>
 }
 

--- a/source/common/pandoc-util/parse-reader-writer.ts
+++ b/source/common/pandoc-util/parse-reader-writer.ts
@@ -24,6 +24,10 @@ export interface PandocReaderWriter {
    */
   name: PandocReader|PandocWriter|string
   /**
+   * Whether the reader is a custom lua reader.
+   */
+  isCustom: boolean
+  /**
    * Extensions that have been explicitly enabled (e.g., `+raw_html`). NOTE that
    * this is separate from extensions that are by default enabled or disabled.
    */
@@ -73,12 +77,9 @@ export type PandocWriter = typeof pandocWriters[number]
  * @return  {PandocReaderWriter}                The parsed info
  */
 export function parseReaderWriter (readerWriter: string): PandocReaderWriter {
-  if (!readerWriter.includes('-') && !readerWriter.includes('+')) {
-    return { name: readerWriter, enabledExtensions: [], disabledExtensions: [] }
-  }
-
   const parsed: PandocReaderWriter = {
     name: readerWriter.split(/[+-]/g)[0],
+    isCustom: readerWriter.endsWith('.lua'),
     enabledExtensions: [],
     disabledExtensions: []
   }

--- a/source/common/pandoc-util/parse-reader-writer.ts
+++ b/source/common/pandoc-util/parse-reader-writer.ts
@@ -79,9 +79,13 @@ export type PandocWriter = typeof pandocWriters[number]
 export function parseReaderWriter (readerWriter: string): PandocReaderWriter {
   const parsed: PandocReaderWriter = {
     name: readerWriter.split(/[+-]/g)[0],
-    isCustom: readerWriter.endsWith('.lua'),
+    isCustom: false,
     enabledExtensions: [],
     disabledExtensions: []
+  }
+
+  if (parsed.name.endsWith('.lua')) {
+    parsed.isCustom = true
   }
 
   for (const match of readerWriter.matchAll(/([+-][a-z0-9_]+)/gi)) {

--- a/source/common/util/normalize-path.ts
+++ b/source/common/util/normalize-path.ts
@@ -1,0 +1,45 @@
+/**
+ * BEGIN HEADER
+ *
+ * Contains:        Utility function
+ * CVM-Role:        <none>
+ * Maintainer:      benniekiss
+ * License:         GNU GPL v3
+ *
+ * Description:     This file contains a utility function to normalize file paths
+ *
+ * END HEADER
+ */
+
+import path from 'path'
+
+/**
+ * Normalize a file path, removing internal `..` and `.` segments.
+ *
+ * If `root` is provied, and the normalized path is relative, the returned path
+ * will be resolved against `root`. It is guaranteed that the returned path will
+ * be a child under `root`.
+ *
+ * @param   {string}  fp    The path to be tested
+ * @param   {string?} root  If `fp` is relative, it will be resolved against `root`.
+ *
+ * @return  {string}        The normalized path
+ */
+export default function normalizePath (fp: string, root?: string): string {
+  let target = path.normalize(fp)
+
+  // If the target is a relative path, resolve it to the root path
+  // and sanitize any potential path traversals.
+  if (!path.isAbsolute(target) && root !== undefined) {
+    target = path.resolve(root, target)
+
+    // Make sure that the resolved path still falls under `root`
+    // to prevent potentially insecure path traversals.
+    if (!target.startsWith(root)) {
+      const parsed = path.parse(target)
+      target = path.join(root, parsed.base)
+    }
+  }
+
+  return target
+}

--- a/source/win-assets/DefaultsTab.vue
+++ b/source/win-assets/DefaultsTab.vue
@@ -152,7 +152,7 @@ const visibleItems = computed(() => {
       // Retrieve which one we need to check
       const readerWriter = (props.which === 'import') ? e.writer : e.reader
       const parsedReaderWriter = parseReaderWriter(readerWriter)
-      return SUPPORTED_READERS.includes(parsedReaderWriter.name)
+      return parsedReaderWriter.name.endsWith('.lua') || SUPPORTED_READERS.includes(parsedReaderWriter.name)
     })
 })
 

--- a/source/win-assets/DefaultsTab.vue
+++ b/source/win-assets/DefaultsTab.vue
@@ -152,7 +152,7 @@ const visibleItems = computed(() => {
       // Retrieve which one we need to check
       const readerWriter = (props.which === 'import') ? e.writer : e.reader
       const parsedReaderWriter = parseReaderWriter(readerWriter)
-      return parsedReaderWriter.name.endsWith('.lua') || SUPPORTED_READERS.includes(parsedReaderWriter.name)
+      return parsedReaderWriter.isCustom || SUPPORTED_READERS.includes(parsedReaderWriter.name)
     })
 })
 

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -125,8 +125,10 @@ const availableFormats = computed(() => {
 
   profileMetadata.value
     // Remove files that cannot read any of Zettlr's internal formats ...
-    .filter(e => {
-      return SUPPORTED_READERS.includes(parseReaderWriter(e.reader).name)
+    .filter(prof => {
+      const name = parseReaderWriter(prof.reader).name
+
+      return name.endsWith('.lua') || SUPPORTED_READERS.includes(name)
     })
     // ... and add the others to the available options
     .forEach(elem => { selectOptions[elem.name] = getDisplayText(elem) })

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -126,9 +126,9 @@ const availableFormats = computed(() => {
   profileMetadata.value
     // Remove files that cannot read any of Zettlr's internal formats ...
     .filter(prof => {
-      const name = parseReaderWriter(prof.reader).name
+      const reader = parseReaderWriter(prof.reader)
 
-      return name.endsWith('.lua') || SUPPORTED_READERS.includes(name)
+      return reader.isCustom || SUPPORTED_READERS.includes(reader.name)
     })
     // ... and add the others to the available options
     .forEach(elem => { selectOptions[elem.name] = getDisplayText(elem) })

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -251,6 +251,7 @@ body {
 
     .outputfile-admonition {
       margin: 5px;
+      font-size: 100%;
     }
 
     .radio-group-container {

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -9,12 +9,16 @@
         v-bind:options="availableFormats"
       ></SelectControl>
       <ZtrAdmonition v-if="outputFilename" type="info" class="outputfile-admonition">
-        {{ outputFileLabel }}: {{ outputFilename }}
+        {{ outputFileLabel }}: <strong>{{ outputFilename }}</strong>
+      </ZtrAdmonition>
+      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="outputfile-admonition">
+        {{ outputFileIsAbsoluteLable }}
       </ZtrAdmonition>
       <!-- The choice of working directory vs. temporary applies to all exporters -->
       <hr>
       <RadioControl
         v-model="exportDirectory"
+        v-bind:disabled="outputFilenameIsAbsolute"
         v-bind:options="{
           'temp': tempDirLabel,
           'cwd': cwdLabel,
@@ -61,7 +65,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import type { AssetsProviderIPCAPI, PandocProfileMetadata } from '@providers/assets'
 import { SUPPORTED_READERS } from '@common/pandoc-util/pandoc-maps'
 import { trans } from '@common/i18n-renderer'
-import { pathBasename } from '@common/util/renderer-path-polyfill'
+import { pathBasename, isAbsolutePath } from '@common/util/renderer-path-polyfill'
 import { useConfigStore } from 'source/pinia'
 import { parseReaderWriter } from 'source/common/pandoc-util/parse-reader-writer'
 import type { CustomExportIPCAPI, ExportIPCAPI } from 'source/app/service-providers/commands/export'
@@ -73,8 +77,8 @@ const autoOpenLabel = trans('Open after export')
 const tempDirLabel = trans('Temporary directory')
 const cwdLabel = trans('Current directory')
 const askLabel = trans('Select directory')
-const outputFileLabel = trans('Output file')
-
+const outputFileLabel = trans('Output set by profile')
+const outputFileIsAbsoluteLable = trans('Directory selection is disabled because the output is an absolute path')
 
 // This is used to limit the number of selected
 // profile to filename mappings in the config
@@ -127,6 +131,7 @@ const lastUsedProfile = computed(() => configStore.config.export.lastUsedProfile
 const exportButtonLabel = computed(() => isExporting.value ? trans('Exporting…') : trans('Export'))
 const filename = computed(() => pathBasename(props.filePath))
 const outputFilename = ref('')
+const outputFilenameIsAbsolute = ref(false)
 
 const availableFormats = computed(() => {
   const selectOptions: Record<string, string> = {}
@@ -169,6 +174,7 @@ watch(format, function (value) {
   const filePath: string = props.filePath
 
   outputFilename.value = prof?.outputFile ?? ''
+  outputFilenameIsAbsolute.value = isAbsolutePath(outputFilename.value)
 
   const newProfiles = selectedProfiles.value
     // Remove any previous items with the same path

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -8,9 +8,6 @@
         v-bind:label="formatLabel"
         v-bind:options="availableFormats"
       ></SelectControl>
-      <ZtrAdmonition v-if="outputFilename" type="info" class="outputfile-admonition">
-        {{ outputFileLabel }}: <strong>{{ outputFilename }}</strong>
-      </ZtrAdmonition>
       <!-- The choice of working directory vs. temporary applies to all exporters -->
       <hr>
       <RadioControl
@@ -22,8 +19,8 @@
           'ask': askLabel
         }"
       ></RadioControl>
-      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="disable-directory-admonition">
-        {{ outputFileIsAbsoluteLable }}
+      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="info" class="disable-directory-admonition">
+        {{ outputFileIsAbsoluteLable }}: <strong>{{ outputFilename }}</strong>
       </ZtrAdmonition>
       <hr>
       <CheckboxControl
@@ -77,8 +74,7 @@ const autoOpenLabel = trans('Open after export')
 const tempDirLabel = trans('Temporary directory')
 const cwdLabel = trans('Current directory')
 const askLabel = trans('Select directory')
-const outputFileLabel = trans('Output set by profile')
-const outputFileIsAbsoluteLable = trans('Directory selection is disabled because the output is an absolute path')
+const outputFileIsAbsoluteLable = trans('Directory selection is disabled because the profile specifies an absolute path')
 
 // This is used to limit the number of selected
 // profile to filename mappings in the config
@@ -255,15 +251,10 @@ body {
         }
     }
 
-    .outputfile-admonition {
-      margin: 5px;
-      font-size: 100%;
-      word-break: break-all;
-    }
-
     .disable-directory-admonition {
       margin: 5px;
       font-size: 100%;
+      overflow-wrap: anywhere;
     }
 
     .radio-group-container {

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -258,6 +258,7 @@ body {
     .outputfile-admonition {
       margin: 5px;
       font-size: 100%;
+      word-break: break-all;
     }
 
     .radio-group-container {

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -8,6 +8,9 @@
         v-bind:label="formatLabel"
         v-bind:options="availableFormats"
       ></SelectControl>
+      <ZtrAdmonition v-if="outputFilename" type="info" class="outputfile-admonition">
+        {{ outputFileLabel }}: {{ outputFilename }}
+      </ZtrAdmonition>
       <!-- The choice of working directory vs. temporary applies to all exporters -->
       <hr>
       <RadioControl
@@ -53,6 +56,7 @@ import PopoverWrapper from '@common/vue/PopoverWrapper.vue'
 import RadioControl from '@common/vue/form/elements/RadioControl.vue'
 import SelectControl from '@common/vue/form/elements/SelectControl.vue'
 import CheckboxControl from '@common/vue/form/elements/CheckboxControl.vue'
+import ZtrAdmonition from '@common/vue/ZtrAdmonition.vue'
 import { ref, computed, watch, onMounted } from 'vue'
 import type { AssetsProviderIPCAPI, PandocProfileMetadata } from '@providers/assets'
 import { SUPPORTED_READERS } from '@common/pandoc-util/pandoc-maps'
@@ -69,6 +73,8 @@ const autoOpenLabel = trans('Open after export')
 const tempDirLabel = trans('Temporary directory')
 const cwdLabel = trans('Current directory')
 const askLabel = trans('Select directory')
+const outputFileLabel = trans('Output file')
+
 
 // This is used to limit the number of selected
 // profile to filename mappings in the config
@@ -120,6 +126,8 @@ const lastUsedProfile = computed(() => configStore.config.export.lastUsedProfile
 
 const exportButtonLabel = computed(() => isExporting.value ? trans('Exporting…') : trans('Export'))
 const filename = computed(() => pathBasename(props.filePath))
+const outputFilename = ref('')
+
 const availableFormats = computed(() => {
   const selectOptions: Record<string, string> = {}
 
@@ -159,6 +167,8 @@ watch(format, function (value) {
 
   const profile: string  = prof?.name ?? cmd?.command ?? lastUsedProfile.value
   const filePath: string = props.filePath
+
+  outputFilename.value = prof?.outputFile ?? ''
 
   const newProfiles = selectedProfiles.value
     // Remove any previous items with the same path
@@ -237,6 +247,10 @@ body {
       select {
           margin-top: 5px;
         }
+    }
+
+    .outputfile-admonition {
+      margin: 5px;
     }
 
     .radio-group-container {

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -11,9 +11,6 @@
       <ZtrAdmonition v-if="outputFilename" type="info" class="outputfile-admonition">
         {{ outputFileLabel }}: <strong>{{ outputFilename }}</strong>
       </ZtrAdmonition>
-      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="disable-directory-admonition">
-        {{ outputFileIsAbsoluteLable }}
-      </ZtrAdmonition>
       <!-- The choice of working directory vs. temporary applies to all exporters -->
       <hr>
       <RadioControl
@@ -25,6 +22,9 @@
           'ask': askLabel
         }"
       ></RadioControl>
+      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="disable-directory-admonition">
+        {{ outputFileIsAbsoluteLable }}
+      </ZtrAdmonition>
       <hr>
       <CheckboxControl
         v-model="autoOpenExport"

--- a/source/win-main/PopoverExport.vue
+++ b/source/win-main/PopoverExport.vue
@@ -11,7 +11,7 @@
       <ZtrAdmonition v-if="outputFilename" type="info" class="outputfile-admonition">
         {{ outputFileLabel }}: <strong>{{ outputFilename }}</strong>
       </ZtrAdmonition>
-      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="outputfile-admonition">
+      <ZtrAdmonition v-if="outputFilenameIsAbsolute" type="warning" class="disable-directory-admonition">
         {{ outputFileIsAbsoluteLable }}
       </ZtrAdmonition>
       <!-- The choice of working directory vs. temporary applies to all exporters -->
@@ -259,6 +259,11 @@ body {
       margin: 5px;
       font-size: 100%;
       word-break: break-all;
+    }
+
+    .disable-directory-admonition {
+      margin: 5px;
+      font-size: 100%;
     }
 
     .radio-group-container {

--- a/source/win-project-properties/App.vue
+++ b/source/win-project-properties/App.vue
@@ -54,8 +54,8 @@
         v-bind:label="exportFormatLabel"
         v-bind:value-type="'record'"
         v-bind:model-value="(exportFormatList as any[])"
-        v-bind:column-labels="[exportFormatUseLabel, exportFormatNameLabel, conversionLabel]"
-        v-bind:key-names="['selected', 'name', 'conversion']"
+        v-bind:column-labels="[exportFormatUseLabel, exportFormatNameLabel, conversionLabel, outputLabel]"
+        v-bind:key-names="['selected', 'name', 'conversion', 'outputFile']"
         v-bind:editable="[0]"
         v-bind:striped="true"
         v-on:update:model-value="selectExportProfile($event)"
@@ -185,6 +185,7 @@ const exportFormatLabel = trans('Export project to:')
 const exportFormatUseLabel = trans('Use')
 const exportFormatNameLabel = trans('Format')
 const conversionLabel = trans('Conversion')
+const outputLabel = trans('Output File')
 const exportFilesLabel = trans('Files to be included in the export')
 const projectBuildWarning = trans('Please select at least one profile to build this project.')
 const projectTitleLabel = trans('Project Title')
@@ -339,19 +340,23 @@ const exportFormatList = computed<ExportProfile[]>(() => {
     const readerFull = hasReaderExtensions ? reader + ` (${e.reader})` : reader
     const writerFull = hasWriterExtensions ? writer + ` (${e.writer})` : writer
 
+    const outputFile = e.outputFile
+
     const conversionString = (e.isInvalid) ? 'Invalid' : [ readerFull, writerFull ].join(' → ')
 
     return {
       selected: projectSettings.value.profiles.includes(e.name),
       name: getDisplayText(e.name),
-      conversion: conversionString
+      conversion: conversionString,
+      outputFile: outputFile,
     }
   }).concat(
     customCommands.map(c => {
       return {
         selected: projectSettings.value.profiles.includes(c.command),
         name: c.displayName,
-        conversion: c.command
+        conversion: c.command,
+        outputFile: '',
       }
     })
   )

--- a/test/pandoc-reader-writer.spec.ts
+++ b/test/pandoc-reader-writer.spec.ts
@@ -17,15 +17,19 @@ import { parseReaderWriter, readerWriterToString, PandocReaderWriter } from 'sou
 import assert from 'assert'
 
 const parseTests: Array<{ input: string, expected: PandocReaderWriter }> = [
-  { input: 'markdown-smart', expected: { name: 'markdown', enabledExtensions: [], disabledExtensions: ['smart'] } },
-  { input: 'markdown-smart+pipe_tables', expected: { name: 'markdown', enabledExtensions: ['pipe_tables'], disabledExtensions: ['smart'] } },
-  { input: 'markdown-pipe_tables-smart', expected: { name: 'markdown', enabledExtensions: [], disabledExtensions: ['pipe_tables', 'smart'] } },
+  { input: 'markdown-smart', expected: { name: 'markdown', isCustom: false, enabledExtensions: [], disabledExtensions: ['smart'] } },
+  { input: 'markdown-smart+pipe_tables', expected: { name: 'markdown', isCustom: false, enabledExtensions: ['pipe_tables'], disabledExtensions: ['smart'] } },
+  { input: 'markdown-pipe_tables-smart', expected: { name: 'markdown', isCustom: false, enabledExtensions: [], disabledExtensions: ['pipe_tables', 'smart'] } },
+  { input: 'custom.lua', expected: { name: 'custom.lua', isCustom: true, enabledExtensions: [], disabledExtensions: [] } },
+  { input: 'custom.lua+smart-pipe_tables', expected: { name: 'custom.lua', isCustom: true, enabledExtensions: ['smart'], disabledExtensions: ['pipe_tables'] } },
 ]
 
 const stringifyTests: Array<{ input: PandocReaderWriter, expected: string }> = [
-  { input: { name: 'markdown', enabledExtensions: [], disabledExtensions: ['smart'] }, expected: 'markdown-smart' },
-  { input: { name: 'markdown', enabledExtensions: ['pipe_tables'], disabledExtensions: ['smart'] }, expected: 'markdown+pipe_tables-smart' },
-  { input: { name: 'markdown', enabledExtensions: [], disabledExtensions: ['smart', 'pipe_tables'] }, expected: 'markdown-smart-pipe_tables' },
+  { input: { name: 'markdown', isCustom: false, enabledExtensions: [], disabledExtensions: ['smart'] }, expected: 'markdown-smart' },
+  { input: { name: 'markdown', isCustom: false, enabledExtensions: ['pipe_tables'], disabledExtensions: ['smart'] }, expected: 'markdown+pipe_tables-smart' },
+  { input: { name: 'markdown', isCustom: false, enabledExtensions: [], disabledExtensions: ['smart', 'pipe_tables'] }, expected: 'markdown-smart-pipe_tables' },
+  { input: { name: 'custom.lua', isCustom: true, enabledExtensions: [], disabledExtensions: [] }, expected: 'custom.lua' },
+  { input: { name: 'custom.lua', isCustom: true, enabledExtensions: ['smart'], disabledExtensions: ['pipe_tables'] }, expected: 'custom.lua+smart-pipe_tables' },
 ]
 
 describe('Pandoc#readerWriter()', function () {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR enables setting custom lua readers in default profiles, and it allows specifying custom output and input file locations using `output-file` and `input-files`.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The profile reader filter was extended to allow readers ending in `.lua`. This enables support for custom readers 

When generating the defaults file for export, the plugin values no longer override those already set in the profile. From what I could find, the only plugin values provided are `input-files` and `output-file`. I ran into this problem because I have an export profile that uses a custom `output-file` location, but since it was getting overriden, the profile was not working correctly.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
