### PR TITLE
[Enhancement] Allow custom dictionaries with non-bcp47 names

### DIFF
--- a/source/common/util/enum-dict-files.ts
+++ b/source/common/util/enum-dict-files.ts
@@ -17,7 +17,6 @@
 
 import { type Candidate } from './find-lang-candidates'
 import path from 'path'
-import * as bcp47 from 'bcp-47/index.js'
 import fs from 'fs'
 import { app } from 'electron'
 import isDir from './is-dir'
@@ -42,25 +41,23 @@ export default function enumDictFiles (paths = [ path.join(app.getPath('userData
       if (!isDir(path.join(p, dir))) {
         continue
       }
-      let schema = bcp47.parse(dir)
-      if (schema.language !== undefined) {
-        // Additional check to make sure the dictionaries are complete.
-        let aff = path.join(p, dir, dir + '.aff')
-        let dic = path.join(p, dir, dir + '.dic')
+      // Additional check to make sure the dictionaries are complete.
+      let aff = path.join(p, dir, dir + '.aff')
+      let dic = path.join(p, dir, dir + '.dic')
+      if (!isFile(aff) || !isFile(dic)) {
+        // Second try: index-based names
+        aff = path.join(p, dir, 'index.aff')
+        dic = path.join(p, dir, 'index.dic')
         if (!isFile(aff) || !isFile(dic)) {
-          // Second try: index-based names
-          aff = path.join(p, dir, 'index.aff')
-          dic = path.join(p, dir, 'index.dic')
-          if (!isFile(aff) || !isFile(dic)) {
-            continue
-          }
-        }
-        // Only add the found dictionary if it is not already present. Useful
-        // to override the shipped dictionaries.
-        if (candidates.find(elem => elem.tag === dir) === undefined) {
-          candidates.push({ tag: dir, aff, dic })
+          continue
         }
       }
+      // Only add the found dictionary if it is not already present. Useful
+      // to override the shipped dictionaries.
+      if (candidates.find(elem => elem.tag === dir) === undefined) {
+        candidates.push({ tag: dir, aff, dic })
+      }
+
     }
   }
   return candidates


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR allows dictionaries to be named with non-BCP 47 language code names.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The language code check was removed.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
I have a lot of domain-specific dictionaries, so limiting the available dictionaries to only those with appropriate language codes was too restricting. 

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
