### PR TITLE
[Fix] Reduce config retrieval throttling

### DIFF
--- a/source/pinia/config.ts
+++ b/source/pinia/config.ts
@@ -31,12 +31,12 @@ function retrieveConfig (): ConfigOptions {
 export const useConfigStore = defineStore('config', () => {
   const config = ref<ConfigOptions>(retrieveConfig())
 
-  // Throttle the retrieve function to once a second. We want the config to
+  // Throttle the retrieve function to once per 50ms. We want the config to
   // update some values extremely frequently, and with the throttle in place, we
   // ensure that the (sometimes heavy) config updaters don't cause lag.
   const throttledRetrieve = _.throttle(() => {
     config.value = retrieveConfig()
-  }, 1000)
+  }, 50)
 
   // Listen to subsequent changes
   ipcRenderer.on('config-provider', (event, { command }) => {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR reduces the config retrieval throttling from `1 second` to `50ms` to improve UX and fix some minor issues.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The retrieval throttling was reduced from `1 second` to `50ms`. The long throttle caused UX side effects, such as a [1-second delay when switching tabs in the sidebar](https://github.com/Zettlr/Zettlr/issues/6018#issuecomment-3760127240). It also caused an issue I was experiencing where quickly checking or unchecking spellcheck dictionaries would not be registered, ~~and unselecting all dictionaries was not possible.~~ *[EDIT: this last part was an erroneous issue]* This is no longer the case with the reduced throttle.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
The throttle was initially put in place to reduce lag from rapid config updates. I wasn't able to produce any lag with `50ms`, but if there is, the value should be increased by smaller increments, as `1 second` is too long.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version --> macOS 26
