### PR TITLE
[Enhancement] Improve pdf viewer resize UX

### DIFF
--- a/source/win-main/file-viewers/PDFViewer.vue
+++ b/source/win-main/file-viewers/PDFViewer.vue
@@ -4,7 +4,8 @@
     class="pdf-viewer-container"
     role="region"
     v-bind:aria-label="`PDFViewer: Currently viewing file ${pathBasename(props.file.path)}`"
-    v-on:click="acceptsClicks = true"
+    v-on:pointerenter="acceptsClicks = true"
+    v-on:pointerleave="acceptsClicks = false"
   >
     <iframe
       ref="iframe"
@@ -40,7 +41,7 @@
 import type { OpenDocument } from 'source/types/common/documents'
 import type { EditorCommands } from '../App.vue'
 import makeValidUri from 'source/common/util/make-valid-uri'
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import { pathBasename } from 'source/common/util/renderer-path-polyfill'
 
 const props = defineProps<{
@@ -55,17 +56,6 @@ const iframe = ref<HTMLIFrameElement|null>(null)
 const pdfViewerContainer = ref<HTMLDivElement|null>(null)
 const acceptsClicks = ref(false)
 
-function toggleAcceptClicksOff () {
-  acceptsClicks.value = false
-}
-
-onMounted(() => {
-  document.addEventListener('focusin', toggleAcceptClicksOff)
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener('focusin', toggleAcceptClicksOff)
-})
 </script>
 
 <style lang="css" scoped>
@@ -73,6 +63,7 @@ div.pdf-viewer-container {
   width: 100%;
   height: 100%;
   user-select: auto;
+  overflow: hidden;
 
   iframe {
     width: 100%;
@@ -82,7 +73,6 @@ div.pdf-viewer-container {
 
     &.pointer-events {
       pointer-events: auto;
-      border-color: var(--system-accent-color);
     }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR changes how the PDF viewer determines whether to accept  `pointer-events` to improve UX when resizing the editor pane.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
Instead of watching for focus changes, `acceptClicks` is now toggled on `pointerenter` and `pointerleave`. This improves UX in two ways: the user no longer has to remember to unfocus the viewer before resizing, and the user no longer has to click to focus the viewer before using the UI.

The border around the active viewer has been removed because it no longer serves a purpose.

`overflow: hidden` was added to the iframe parent element to prevent scroll bars from appearing on the parent.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

PR (still with the border present): 

https://github.com/user-attachments/assets/0f33063c-1a20-4759-95e2-05e8ec0228dd

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->
