### PR TITLE
fix: Allow unicode emojis in tags

### DIFF
--- a/source/common/modules/markdown-editor/parser/zkn-tag-parser.ts
+++ b/source/common/modules/markdown-editor/parser/zkn-tag-parser.ts
@@ -17,7 +17,9 @@ import { type InlineParser } from '@lezer/markdown'
 // Any character allowed before a tag
 const allowedCharsBefore = /^[ \t\n\(\{\[]$/
 
-const tagRE = /^##?[\w_-]+#?/u
+// Tags start with one or two '#' followed by letters, numbers, emojis,
+// underscores, or hyphens
+const tagRE = /^##?[\p{L}\p{N}\p{Emoji_Presentation}_-]+#?/u
 
 export const zknTagParser: InlineParser = {
   name: 'zkn-tags',


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
This PR fixes a recent issue that prevented having emojis in tags. If there was an emoji, the tag would not be parsed correctly.

## Changes
Fixed the tag regex to allow unicode emojis. Also refactored the regex to use unicode property escapes.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

<!-- Please provide any testing system -->
Tested on: WSL Ubuntu


Also closes: #6157 
