### PR TITLE
fix(linter): use correct node name for YAML frontmatter detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ## Under the Hood
 
+- Fixed YAML frontmatter linter not detecting any errors due to incorrect syntax
+  tree node name lookup.
 - Increased config retrieval speed in the renderers (#6140). This can speed up
   some UI interactions.
 

--- a/source/common/modules/markdown-editor/linters/yaml-frontmatter-lint.ts
+++ b/source/common/modules/markdown-editor/linters/yaml-frontmatter-lint.ts
@@ -38,7 +38,7 @@ function findYamlFrontmatterNode (state: EditorState): SyntaxNodeRef|undefined {
         return false // Quickly end the iteration
       }
 
-      if (node.name === 'FencedCode') {
+      if (node.name === 'YAMLFrontmatter') {
         // The startNode identifies a YAML Frontmatter block ...
         const startNode = node.node.getChild('YAMLFrontmatterStart')
         // ... and the CodeText node contains the actual YAML frontmatter code.


### PR DESCRIPTION
The YAML frontmatter linter was non-functional because
findYamlFrontmatterNode() searched for a node named 'FencedCode', but the
frontmatter parser creates nodes named 'YAMLFrontmatter'.

This mismatch meant the linter never found frontmatter content and
always returned an empty diagnostics array, causing all YAML syntax
errors (such as tabs used as indentation) to be silently ignored.

Change the node name check to 'YAMLFrontmatter' to match what
frontmatter-parser.ts actually creates, enabling proper YAML error
detection and reporting.