### PR TITLE
fix: respect indentation settings when pressing Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## GUI and Functionality
 
+- Fixed Tab key not respecting the "Indent using tabs instead of spaces"
+  setting. Additionally, Tab now always inserts spaces in YAML frontmatter
+  blocks to maintain valid YAML syntax.
 - **Feature**: New utilities for working with native Pandoc Divs and spans
   (#6032):
   - Added a new setting to switch between native highlights (`==mark==`) and


### PR DESCRIPTION
Replace insertTab with indentMore in maybeIndentList to ensure the
Tab key respects the user's indentation settings (spaces vs tabs).

Previously, pressing Tab outside of Markdown lists would always insert
a literal tab character, regardless of the 'Indent using tabs instead
of spaces' setting.

The insertTab function from @codemirror/commands always inserts a
literal tab character, while indentMore respects the configured
indentUnit (spaces or tabs based on settings).

Additionally, add special handling for YAML frontmatter blocks. Since
YAML requires spaces for indentation (tabs break YAML parsing), the
editor now always inserts spaces when the cursor is inside a YAML
frontmatter block, regardless of the user's tab settings.

Changes:
- Replace insertTab with indentMore for consistent indentation behavior
- Add isInYamlFrontmatter() helper to detect YAML frontmatter context
- Force space-based indentation in YAML frontmatter blocks

Now Tab consistently uses the configured indentation throughout the
document, except in YAML frontmatter where spaces are always used to
maintain valid YAML syntax.