### PR TITLE
Add scroll-past-end extension to editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## GUI and Functionality
 
+- **Feature**: The editor now allows scrolling past the end of documents for a
+  more comfortable writing experience.
 - **Feature**: New utilities for working with native Pandoc Divs and spans
   (#6032):
   - Added a new setting to switch between native highlights (`==mark==`) and


### PR DESCRIPTION
Enable scrolling past the end of documents so users can position the
last line in the middle of the viewport without adding empty lines.

This implements a custom ViewPlugin that adds bottom padding equal to
half the editor height. The padding updates dynamically when the editor
is resized. Unlike CodeMirror's built-in scrollPastEnd() which allows
scrolling to the top of the editor, this implementation centers the
last line in the viewport for a more comfortable writing experience.

---

Maybe it's just me, but I feel weird writing at the bottom of the screen - I want my focus to be in the center of the screen.

I'm wondering:

- Is this the right place or would `markdown-editor/plugins` be better?
- Is it okay to have this as the default behavior or should this be configurable? For me it's obviously fine like this, but who knows.