### PR TITLE
chore: bump github actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Setup
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.ref }}
     - name: Setup NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone repository (${{ github.ref_name }} branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0 # Required for the tag verification step.
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -130,11 +130,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -165,7 +165,7 @@ jobs:
         if: ${{ github.ref_name == env.NIGHTLY_BRANCH }}
         run: mv ./release/Zettlr-${{ env.old_version }}-x64.exe ./release/Zettlr-${{ env.version }}-x64.exe
       - name: Cache installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: win32_x64
           path: |
@@ -185,11 +185,11 @@ jobs:
     steps:
       # Check out master for a regular release, or develop branch for a nightly
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -222,7 +222,7 @@ jobs:
         if: ${{ github.ref_name == env.NIGHTLY_BRANCH }}
         run: mv ./release/Zettlr-${{ env.old_version }}-x64.dmg ./release/Zettlr-${{ env.version }}-x64.dmg
       - name: Cache image file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: darwin_x64
           path: |
@@ -236,11 +236,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -273,7 +273,7 @@ jobs:
         if: ${{ github.ref_name == env.NIGHTLY_BRANCH }}
         run: mv ./release/Zettlr-${{ env.old_version }}-arm64.dmg ./release/Zettlr-${{ env.version }}-arm64.dmg
       - name: Cache image file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: darwin_arm64
           path: |
@@ -295,11 +295,11 @@ jobs:
     steps:
       # Check out master for a regular release, or develop branch for a nightly
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -328,7 +328,7 @@ jobs:
         run: |
           mv ./release/Zettlr-${{ env.old_version }}-x86_64.AppImage ./release/Zettlr-${{ env.version }}-x86_64.AppImage
       - name: Cache installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux_x64
           path: |
@@ -346,11 +346,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -375,7 +375,7 @@ jobs:
         run: |
           mv ./release/Zettlr-${{ env.old_version }}-arm64.AppImage ./release/Zettlr-${{ env.version }}-arm64.AppImage
       - name: Cache installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux_arm64
           path: |
@@ -406,9 +406,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -424,27 +424,27 @@ jobs:
         run: mkdir ./release
       # Download all resulting assets from the previous steps.
       - name: Retrieve installers (Windows x86_64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: win32_x64
           path: ./release
       - name: Retrieve installers (macOS x86_64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: darwin_x64
           path: ./release
       - name: Retrieve installers (macOS arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: darwin_arm64
           path: ./release
       - name: Retrieve installers (Linux x86_64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linux_x64
           path: ./release
       - name: Retrieve installers (Linux arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linux_arm64
           path: ./release
@@ -479,7 +479,7 @@ jobs:
           cp ./resources/icons/png/512x512.png ./release/logo.png
       - name: Upload nightlies to the server
         if: ${{ github.ref_name == env.NIGHTLY_BRANCH }}
-        uses: easingthemes/ssh-deploy@v3.0.1
+        uses: easingthemes/ssh-deploy@v5.1.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.NIGHTLY_SSH_PRIVATE_KEY }}
           # --delete so that no old releases remain on the server. Each iteration is approx. 1GB in size.

--- a/.github/workflows/bump-transitive.yml
+++ b/.github/workflows/bump-transitive.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository (develop branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'develop'
           fetch-depth: 0
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           # No cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,12 +21,12 @@ jobs:
     name: Unit Tests / Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Always fetch the branch that triggered the event (develop or master)
         ref: ${{ github.ref }}
     - name: Setup NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -52,7 +52,7 @@ jobs:
           git add -A
           git diff-index --quiet HEAD || git commit -m "chore(i18n): Update translations"
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: develop

--- a/.github/workflows/lint-po.yml
+++ b/.github/workflows/lint-po.yml
@@ -27,12 +27,12 @@ jobs:
     name: Lint PO-Files
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Always fetch the branch that triggered the event (develop or master)
         ref: ${{ github.ref }}
     - name: Setup NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
       - name: Setup NodeJS ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -52,7 +52,7 @@ jobs:
       - name: Test build
         run: yarn test
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: develop


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR updates all GitHub Actions to their latest versions that for most of the actions just bumps their node.js runtime as the older versions are getting deprecated.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
- Migated to Node.js 24 runtime
  - **`actions/checkout`**: `v4` → `v6`
  - **`actions/setup-node`**: `v4` → `v6`
  - **`actions/upload-artifact`**: `v4` → `v6`
  - **`actions/download-artifact`**: `v4` → `v7`
- Migrated to Node.js 20 runtime
  - **`easingthemes/ssh-deploy`**: `v3.0.1` → `v5.1.0`
  - **`ad-m/github-push-action`**: `v0.6.0` → `v1.0.0`

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
- [`actions/checkout`](https://github.com/actions/checkout) - [v6 Release](https://github.com/actions/checkout/releases/tag/v6.0.0) | [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [`actions/setup-node`](https://github.com/actions/setup-node) - [v6 Release](https://github.com/actions/setup-node/releases/tag/v6.0.0)
- [`actions/upload-artifact`](https://github.com/actions/upload-artifact) - [v6 Release](https://github.com/actions/upload-artifact/releases/tag/v6.0.0) | [Migration Guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
- [`actions/download-artifact`](https://github.com/actions/download-artifact) - [v7 Release](https://github.com/actions/download-artifact/releases/tag/v7.0.0)
- [`easingthemes/ssh-deploy`](https://github.com/easingthemes/ssh-deploy) - [v5.1.0 Release](https://github.com/easingthemes/ssh-deploy/releases/tag/v5.1.0)
- [`ad-m/github-push-action`](https://github.com/ad-m/github-push-action) - [v1.0.0 Release](https://github.com/ad-m/github-push-action/releases/tag/v1.0.0)

<!-- Please provide any testing system -->
Tested on: forked repo
