### PR TITLE
[Enhancement] Refactor Hunspell and LanguageTool linters

### DIFF
--- a/source/app/service-providers/commands/update-user-dictionary.ts
+++ b/source/app/service-providers/commands/update-user-dictionary.ts
@@ -14,6 +14,7 @@
 
 import type { AppServiceContainer } from 'source/app/app-service-container'
 import ZettlrCommand from './zettlr-command'
+import type { DictionaryRecord } from '../dictionary'
 
 export default class UpdateUserDictionary extends ZettlrCommand {
   constructor (app: AppServiceContainer) {
@@ -26,7 +27,7 @@ export default class UpdateUserDictionary extends ZettlrCommand {
     * @param  {Object} arg An array containing a new user dictionary.
     * @return {Boolean} Whether or not the call succeeded
     */
-  async run (evt: string, arg: string[]): Promise<boolean> {
+  async run (evt: string, arg: DictionaryRecord[]): Promise<boolean> {
     return this._app.dictionary.setUserDictionary(arg)
   }
 }

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -167,6 +167,9 @@ export interface ConfigOptions {
         ignoredRules: LanguageToolIgnoredRuleEntry[]
         provider: 'official'|'custom'
         customServer: string
+        charsPerRequest: number
+        charsPerMinute: number
+        requestsPerMinute: number
         username: string
         apiKey: string
       }
@@ -389,6 +392,9 @@ export function getConfigTemplate (): ConfigOptions {
           ignoredRules: [],
           provider: 'official',
           customServer: '',
+          charsPerRequest: 0, // 0 disables the limit
+          charsPerMinute: 0, // 0 disables the limit
+          requestsPerMinute: 0, // 0 disables the limit
           username: '',
           apiKey: ''
         }

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -251,6 +251,7 @@ export interface ConfigOptions {
     showMarkdownLinkButton: boolean
     showMarkdownImageButton: boolean
     showMarkdownMakeTaskListButton: boolean
+    showMarkdownLintButton: boolean
     showInsertTableButton: boolean
     showInsertFootnoteButton: boolean
     showDocumentInfoText: boolean
@@ -521,6 +522,7 @@ export function getConfigTemplate (): ConfigOptions {
       showMarkdownLinkButton: true,
       showMarkdownImageButton: true,
       showMarkdownMakeTaskListButton: true,
+      showMarkdownLintButton: true,
       showInsertTableButton: true,
       showInsertFootnoteButton: true,
       showDocumentInfoText: true,

--- a/source/app/service-providers/dictionary/index.ts
+++ b/source/app/service-providers/dictionary/index.ts
@@ -140,7 +140,6 @@ export default class DictionaryProvider extends ProviderContract {
    * @returns
    */
   sanitizeDictionary (words: string[]): DictionaryRecord[] {
-    this._logger.info(`WORDS: ${words}`)
     return words
       // Strip flags and optional data fields
       .map(word => {

--- a/source/app/service-providers/dictionary/index.ts
+++ b/source/app/service-providers/dictionary/index.ts
@@ -32,6 +32,10 @@ import ProviderContract from '../provider-contract'
 import type LogProvider from '../log'
 import type ConfigProvider from '@providers/config'
 
+export interface DictionaryRecord { word: string, affix?: string }
+
+const hunspellRe = /^(?<word>(?:(?:\\.|[^/])(?!\w{2}:))*)(?<flags>.*)$/
+
 /**
  * This class loads and unloads dictionaries according to the configuration set
  * by the user on runtime. It provides functions that allow to search all
@@ -42,7 +46,7 @@ export default class DictionaryProvider extends ProviderContract {
   private readonly _loadedDicts: string[]
   private readonly _userDictionaryPath: string
   private readonly _emitter: EventEmitter
-  private _userDictionary: string[]
+  private _userDictionary: DictionaryRecord[]
   private _fileLock: boolean
   private _unwrittenChanges: boolean
   private _cachedAutocorrect: string[]
@@ -58,7 +62,7 @@ export default class DictionaryProvider extends ProviderContract {
     // Path to the user dictionary
     this._userDictionaryPath = path.join(app.getPath('userData'), 'user.dic')
     // The user dictionary
-    this._userDictionary = ['Zettlr']
+    this._userDictionary = [{ word: 'Zettlr' }]
 
     this._cachedAutocorrect = []
 
@@ -72,31 +76,40 @@ export default class DictionaryProvider extends ProviderContract {
     this._fileLock = false
     this._unwrittenChanges = false
 
-    ipcMain.handle('dictionary-provider', (event, message) => {
+    ipcMain.handle('dictionary-provider', async (event, message) => {
       const terms: string[] = message.terms
       const { command } = message
       if (command === 'get-user-dictionary') {
-        return this._userDictionary.map(elem => elem)
+        return [...this._userDictionary]
       } else if (command === 'set-user-dictionary') {
-        const dict = message.payload
-        if (!Array.isArray(dict) || !dict.every(d => typeof d === 'string')) {
+        const dict = message.payload as DictionaryRecord[]
+        if (!Array.isArray(dict) || !dict.every(d => 'word' in d)) {
           throw new Error('[Dictionary Provider] Cannot set user dictionary: Argument was not a string array.')
         }
-        this.setUserDictionary(dict)
+        await this.setUserDictionary(dict)
       } else if (command === 'check') {
-        return terms.map(t => this.check(t))
+        return Promise.all(terms.map(t => this.check(t)))
       } else if (command === 'suggest') {
-        return terms.map(t => this.suggest(t))
+        const limit: number = message.limit
+        return Promise.all(terms.map(t => this.suggest(t, limit)))
       } else if (command === 'add') {
-        return terms.map(t => this.add(t))
+        return Promise.all(terms.map(t => this.add(t)))
+      } else if (command === 'ignore') {
+        return Promise.all(terms.map(t => this.ignore(t)))
+      } else if (command === 'remove') {
+        return Promise.all(terms.map(t => this.remove(t)))
       } else if (command === 'open-dictionary-folder') {
         shell.showItemInFolder(path.join(app.getPath('userData'), '/dict'))
       }
     })
 
     // Reload as soon as the config has been updated
-    this._config.on('update', (_opt: string) => {
+    this._config.on('update', (opt: string) => {
       // Reload the dictionaries (if applicable) ...
+      if (opt !== 'selectedDicts') {
+        return
+      }
+
       this.synchronizeHunspellDictionaries()
         .catch(err => {
           this._logger.error(`[Dictionary Provider] Could not (re)load dictionaries: ${err.message as string}`, err)
@@ -109,7 +122,6 @@ export default class DictionaryProvider extends ProviderContract {
   async boot (): Promise<void> {
     this._logger.verbose('Dictionary provider booting up ...')
     await this.synchronizeHunspellDictionaries()
-    await this.loadUserDictionary()
     this._cacheAutoCorrectValues()
   }
 
@@ -122,25 +134,52 @@ export default class DictionaryProvider extends ProviderContract {
   }
 
   /**
+   * Removes hunspell flags from the word list
+   *
+   * @param words
+   * @returns
+   */
+  sanitizeDictionary (words: string[]): DictionaryRecord[] {
+    this._logger.info(`WORDS: ${words}`)
+    return words
+      // Strip flags and optional data fields
+      .map(word => {
+        const record: DictionaryRecord = { word: '', affix: undefined }
+
+        const match = hunspellRe.exec(word)
+        if (match?.groups) {
+          record.word = match?.groups.word
+          record.affix = match?.groups.flags
+        }
+
+        return record
+      })
+      .filter(record => record.word)
+  }
+
+  /**
      * Replaces the current user dictionary with a new one
      * @param {Array} dict The new dictionary.
      * @return {Boolean} Whether or not the call succeeded.
      */
-  setUserDictionary (dict: string[]): boolean {
+  async setUserDictionary (dict: DictionaryRecord[]): Promise<boolean> {
     if (!Array.isArray(dict)) {
       return false
     }
 
-    this._userDictionary = dict
-    this._userDictionary = [...new Set(this._userDictionary)]
-    this._userDictionary = this._userDictionary.filter(word => word.trim() !== '')
-    this.persistUserDictionary()
-      .catch(err => {
-        this._logger.error(`[Dictionary Provider] Could not persist user dictionary: ${String(err.message)}`, err)
-      })
+    const newDictionary = dict.filter(elem => elem.word.trim() !== '')
+    const oldDictionary = this._userDictionary
 
-    // Send an invalidation message to the renderer
-    broadcastIpcMessage('dictionary-provider', { command: 'invalidate-dict' })
+    const addedWords = newDictionary.filter(x => !this._userDictionary.find(elem => elem.word === x.word))
+    const removedWords = oldDictionary.filter(x => !newDictionary.find(elem => elem.word === x.word))
+
+    for (const rec of addedWords) {
+      await this.add(rec.word, rec.affix)
+    }
+
+    for (const rec of removedWords) {
+      await this.remove(rec.word)
+    }
 
     return true
   }
@@ -200,6 +239,13 @@ export default class DictionaryProvider extends ProviderContract {
 
     let changeWanted = false
 
+    const userDic = await this.loadUserDictionary()
+    if (userDic === undefined) {
+      this._loadedDicts.splice(0)
+      this.hunspell.splice(0)
+      changeWanted = true
+    }
+
     // This function can also be called during runtime to exchange some dicts,
     // so make sure we don't reload these monstrous things all too often.
     // 1. Which dicts do we have to load?
@@ -233,21 +279,31 @@ export default class DictionaryProvider extends ProviderContract {
 
       try {
         aff = await fs.readFile(dictMeta.aff)
-      } catch (err: any) {
+      } catch (err: unknown) {
         this._logger.error(`[Dictionary Provider] Could not load affix file for ${dict}`, err)
         continue
       }
 
       try {
         dic = await fs.readFile(dictMeta.dic)
-      } catch (err: any) {
-        this._logger.error(`[Dictionary Provider] Could not load .dic-file for ${dict}`, err)
+      } catch (err: unknown) {
+        this._logger.error(`[Dictionary Provider] Could not load .dic file for ${dict}`, err)
         continue
       }
 
-      this._loadedDicts.push(dict)
-      this.hunspell.push(new Nodehun(aff, dic))
-    } // END for
+      try {
+        const hun = new Nodehun(aff, dic)
+        if (userDic !== undefined) {
+          await hun.addDictionary(userDic)
+        }
+
+        this.hunspell.push(hun)
+        this._loadedDicts.push(dict)
+      } catch (err: unknown) {
+        this._logger.error(`[Dictionary Provider] Could not load hunspell dictionary ${dict}`, err)
+        continue
+      }
+    }
 
     if (changeWanted) {
       // Don't be noisy: Only emit if necessary
@@ -269,7 +325,7 @@ export default class DictionaryProvider extends ProviderContract {
    * Loads the user dictionary from file.
    * @return {Promise} Will resolve after the dictionary has been loaded.
    */
-  async loadUserDictionary (): Promise<void> {
+  async loadUserDictionary (): Promise<Buffer<ArrayBufferLike>|undefined> {
     try {
       await fs.lstat(this._userDictionaryPath)
     } catch (err) {
@@ -277,18 +333,30 @@ export default class DictionaryProvider extends ProviderContract {
       await this.persistUserDictionary()
     }
 
-    const fileContents = await fs.readFile(this._userDictionaryPath, 'utf8')
-    this._userDictionary = fileContents.split('\n')
+    try {
+      const dic = await fs.readFile(this._userDictionaryPath)
 
-    // String.split() returns an array with one empty string if the file is
-    // empty, so we need to perform in total two operations: Make a set out of
-    // it (remove duplicates) and remove empty strings
-    this._userDictionary = [...new Set(this._userDictionary)]
-    this._userDictionary = this._userDictionary.filter(elem => elem.trim() !== '')
+      const fileContents = dic.toString('utf-8')
+        .split('\n')
+        .filter((elem, index) => index > 0 ? elem.trim() !== '' : !/\d/.test(elem))
 
-    // If the user dictionary is empty, the split will not create an array
-    // Send an invalidation message to the renderer so that it reloads all words
-    broadcastIpcMessage('dictionary-provider', { command: 'invalidate-dict' })
+      const dictionary = new Set(fileContents)
+      const prevUserDic = new Set(this._userDictionary.map(record => record.word + (record.affix ?? '')))
+
+      this._logger.info(`[Dictionary Provider] Loaded the user dictionary: ${this._userDictionaryPath}`)
+
+      // The dictionary did not change
+      if (dictionary.symmetricDifference(prevUserDic).size === 0) {
+        return
+      }
+
+      this._userDictionary = this.sanitizeDictionary([...dictionary])
+
+      return dic
+    } catch (err: unknown) {
+      this._logger.error(`[Dictionary Provider] Could not load the user dictionary: ${this._userDictionaryPath}`, err)
+      return
+    }
   }
 
   /**
@@ -302,10 +370,15 @@ export default class DictionaryProvider extends ProviderContract {
     }
 
     // Initiate the filelock, write, release the lock
-    const data = this._userDictionary.join('\n')
+    const data = this._userDictionary
+      .map(elem => elem.word + (elem.affix !== undefined ? elem.affix : ''))
+      .join('\n')
+
+    // The first line has to contain an approximate number of terms in the dictionary.
+    const fileContents = this._userDictionary.length + '\n' + data
     this._fileLock = true
     this._unwrittenChanges = false // NOTE that this has to come before the writing
-    await fs.writeFile(this._userDictionaryPath, data)
+    await fs.writeFile(this._userDictionaryPath, fileContents)
     this._fileLock = false
 
     // After we're done, check if someone tried to call the function in the
@@ -321,7 +394,7 @@ export default class DictionaryProvider extends ProviderContract {
    * @param  {String} term The word/term to check
    * @return {Boolean}      True if the word was confirmed by any dictionary, or false.
    */
-  check (term: string): boolean {
+  async check (term: string): Promise<boolean> {
     // Don't check until all are loaded
     if (this._config.get().selectedDicts.length !== this.hunspell.length) {
       return true
@@ -340,12 +413,8 @@ export default class DictionaryProvider extends ProviderContract {
       return true
     }
 
-    if (this._userDictionary.includes(term)) {
-      return true
-    }
-
     for (const dictionary of this.hunspell) {
-      if (dictionary.spellSync(term)) {
+      if (await dictionary.spell(term)) {
         return true
       }
     }
@@ -355,44 +424,111 @@ export default class DictionaryProvider extends ProviderContract {
 
   /**
    * Returns an array of possible suggestions for the given word.
-   * @param  {String} term The term or word to check for.
+   * @param  {String} term  The term or word to check for.
+   * @param  {number} limit Limit the number of suggestions per dictionary to this number
    * @return {Array}      An array containing all returned possible alternatives.
    */
-  suggest (term: string): string[] {
-    if (this.hunspell.length === 0) {
-      return []
-    }
-
-    // Return no suggestions
-    if (this._config.get().selectedDicts.length !== this.hunspell.length) {
-      return []
-    }
-
+  async suggest (term: string, limit?: number): Promise<string[] >{
     const suggestions: string[] = []
-    for (const dictionary of this.hunspell) {
-      suggestions.push(...(dictionary.suggestSync(term) ?? []))
+
+    // Wait for all dictionaries to load.
+    if (this._config.get().selectedDicts.length !== this.hunspell.length) {
+      return suggestions
     }
 
-    return suggestions
+    if (this.hunspell.length === 0) {
+      return suggestions
+    }
+
+    for (const dictionary of this.hunspell) {
+      const values = await dictionary.suggest(term) ?? []
+      suggestions.push(...values.slice(0, limit))
+    }
+
+    return [...new Set(suggestions)]
   }
 
   /**
    * Adds the given term to the user dictionary
    * @param {String} term The term to add
    */
-  add (term: string): boolean {
+  async add (term: string, affix?: string): Promise<boolean> {
     term = term.trim()
     if (term === '') {
       return false
     }
 
     // Adds the given term to the user dictionary
-    if (!this._userDictionary.includes(term)) {
-      this._userDictionary.push(term)
+    if (!this._userDictionary.find(elem => elem.word === term)) {
+      this._userDictionary.push({ word: term, affix })
       this.persistUserDictionary()
         .catch(err => {
           this._logger.error(`[Dictionary Provider] Could not persist user dictionary: ${String(err.message)}`, err)
         })
+
+      for (const dictionary of this.hunspell) {
+        await dictionary.add(term)
+      }
+
+      // Send an invalidation message to the renderer so that it reloads all words
+      broadcastIpcMessage('dictionary-provider', { command: 'invalidate-dict' })
+
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Adds the given term to the runtime dictionary
+   *
+   * @param {String} term The term to add
+   */
+  async ignore (term: string): Promise<boolean> {
+    term = term.trim()
+    if (term === '') {
+      return false
+    }
+
+    // Adds the given term to the user dictionary
+    if (!this._userDictionary.find(elem => elem.word === term)) {
+      for (const dictionary of this.hunspell) {
+        await dictionary.add(term)
+      }
+
+      // Send an invalidation message to the renderer so that it reloads all words
+      broadcastIpcMessage('dictionary-provider', { command: 'invalidate-dict' })
+
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Remove the given term from the user dictionary
+   * @param {String} term The term to remove
+   */
+  async remove (term: string): Promise<boolean> {
+    term = term.trim()
+    if (term === '') {
+      return false
+    }
+
+    const elem = this._userDictionary.find(elem => elem.word === term)
+    if (elem) {
+      const idx = this._userDictionary.indexOf(elem)
+
+      this._userDictionary.splice(idx, 1)
+      this.persistUserDictionary()
+        .catch(err => {
+          this._logger.error(`[Dictionary Provider] Could not persist user dictionary: ${String(err.message)}`, err)
+        })
+
+      for (const dictionary of this.hunspell) {
+        await dictionary.remove(term)
+      }
+
       // Send an invalidation message to the renderer so that it reloads all words
       broadcastIpcMessage('dictionary-provider', { command: 'invalidate-dict' })
 

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -39,7 +39,9 @@ import { defaultContextMenu } from './plugins/default-context-menu'
 import { readabilityMode } from './plugins/readability'
 import { hookDocumentAuthority } from './plugins/remote-doc'
 import { lintGutter, linter } from '@codemirror/lint'
-import { spellcheck } from './linters/spellcheck'
+import { linterConfig } from './linters/utils'
+import { hunspell } from './linters/hunspell'
+import { languageTool } from './linters/language-tool'
 import { mdLint } from './linters/md-lint'
 import { countField, countPlugin } from './plugins/statistics-fields'
 import { tocField } from './plugins/toc-field'
@@ -53,7 +55,6 @@ import { softwrapVisualIndent } from './plugins/visual-indent'
 import { backgroundLayers } from './plugins/code-background'
 import { emacs } from '@replit/codemirror-emacs'
 import { distractionFree } from './plugins/distraction-free'
-import { languageTool } from './linters/language-tool'
 import { statusbar } from './statusbar'
 import { renderers } from './renderers'
 import { mdPasteDropHandlers } from './plugins/md-paste-drop-handlers'
@@ -272,7 +273,8 @@ export function getMarkdownExtensions (options: CoreExtensionOptions): Extension
   // turned on and off with the dictionary settings, and the yamlFrontmatterNode
   // because if that thing has an error, that thing has an error.
   const mdLinterExtensions = [
-    spellcheck,
+    linterConfig,
+    hunspell,
     yamlFrontmatterLint
   ]
 

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -32,9 +32,11 @@ import {
   type EditorSelection,
   EditorState,
   Text,
+  type ChangeDesc,
   type StateEffect,
   type Extension,
-  type SelectionRange
+  type SelectionRange,
+  ChangeSet,
 } from '@codemirror/state'
 import { foldEffect, foldState, syntaxTree } from '@codemirror/language'
 
@@ -98,6 +100,9 @@ import { useDarkModeEditor, darkModeEffect } from './theme/dark-mode'
 import { editorMetadataFacet } from './plugins/editor-metadata'
 import { projectInfoUpdateEffect, type ProjectInfo } from './plugins/project-info-field'
 import { moveSection } from './commands/move-section'
+import { hunspellChangesEffect, hunspellChangesField } from './linters/hunspell'
+import { ltChangesEffect, ltChangesField } from './linters/language-tool'
+import { forEachDiagnostic, setDiagnosticsEffect, type Diagnostic } from '@codemirror/lint'
 import { parsePandocAttributes } from 'source/common/pandoc-util/parse-pandoc-attributes'
 import { closeSearchPanel, openSearchPanel, searchPanelOpen } from '@codemirror/search'
 import { clickListeners } from './plugins/click-listeners'
@@ -179,6 +184,15 @@ export interface EditorViewPersistentState {
    * A decoration set containing currently folded ranges.
    */
   foldedRanges: DecorationSet
+
+  /**
+   * Linter diagnostics
+   */
+  linters: {
+    diagnostics: Diagnostic[]
+    spellcheckChanges: ChangeDesc
+    languagetoolChanges: ChangeDesc
+  }
 }
 
 export default class MarkdownEditor extends EventEmitter {
@@ -381,9 +395,19 @@ export default class MarkdownEditor extends EventEmitter {
     if (persistentState !== undefined) {
       // Now that the correct document has been loaded, there will be content
       // and we can restore the persisted information.
-      const { scrollSnapshot, selection, foldedRanges } = persistentState
+      const { scrollSnapshot, selection, foldedRanges, linters } = persistentState
 
       const effects: StateEffect<any>[] = [scrollSnapshot]
+
+      effects.push(setDiagnosticsEffect.of(linters.diagnostics))
+
+      linters.spellcheckChanges.iterChangedRanges((_,__, fromB, toB) => {
+        effects.push(hunspellChangesEffect.of({ from: fromB, to: toB }))
+      })
+
+      linters.languagetoolChanges.iterChangedRanges((_,__, fromB, toB) => {
+        effects.push(ltChangesEffect.of({ from: fromB, to: toB }))
+      })
 
       const cursor = foldedRanges.iter()
       while (cursor.value) {
@@ -425,10 +449,26 @@ export default class MarkdownEditor extends EventEmitter {
    * @return  {EditorViewPersistentState}  The persistent state object.
    */
   public get persistentState (): EditorViewPersistentState {
+    const scrollSnapshot = this._instance.scrollSnapshot()
+    const selection = this._instance.state.selection
+    const foldedRanges = this._instance.state.field(foldState, false) ?? Decoration.set([])
+
+    const diagnostics: Diagnostic[] = []
+    forEachDiagnostic(this._instance.state, (d) => diagnostics.push(d))
+
+    const docLength = this._instance.state.doc.length
+    const spellcheckChanges = this._instance.state.field(hunspellChangesField, false) ?? ChangeSet.empty(docLength).desc
+    const languagetoolChanges = this._instance.state.field(ltChangesField, false) ?? ChangeSet.empty(docLength).desc
+
     return {
-      scrollSnapshot: this._instance.scrollSnapshot(),
-      selection: this._instance.state.selection,
-      foldedRanges: this._instance.state.field(foldState, false) ?? Decoration.set([])
+      scrollSnapshot,
+      selection,
+      foldedRanges,
+      linters: {
+        diagnostics,
+        spellcheckChanges,
+        languagetoolChanges,
+      }
     }
   }
 

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -106,6 +106,7 @@ import { forEachDiagnostic, setDiagnosticsEffect, type Diagnostic } from '@codem
 import { parsePandocAttributes } from 'source/common/pandoc-util/parse-pandoc-attributes'
 import { closeSearchPanel, openSearchPanel, searchPanelOpen } from '@codemirror/search'
 import { clickListeners } from './plugins/click-listeners'
+import { refreshLinterEffect } from './linters/utils'
 
 export interface DocumentWrapper {
   path: string
@@ -648,6 +649,28 @@ export default class MarkdownEditor extends EventEmitter {
         break
       case 'markdownMakeTaskList':
         applyTaskList(this._instance)
+        break
+      case 'markdownLint':
+        // When forcing a lint, reset the stored changes to run over
+        // the entire document.
+        const range = { from: 0, to: this._instance.state.doc.length }
+
+        this._instance.dispatch({
+          effects: [
+            ltChangesEffect.of(range),
+            hunspellChangesEffect.of(range)
+          ]
+        })
+
+        // `forceLint` does not seem to do what we need here, possibly because
+        // we override `needsRefresh`. So instead, we dispatch the effect which
+        // triggers `needsRefresh`
+        this._instance.dispatch({
+          effects: [
+            refreshLinterEffect.of(true),
+          ]
+        })
+
         break
       default:
         console.warn('Unimplemented command:', cmd)

--- a/source/common/modules/markdown-editor/linters/hunspell.ts
+++ b/source/common/modules/markdown-editor/linters/hunspell.ts
@@ -153,12 +153,29 @@ async function checkWord (word: string, index: number, nodeStart: number, autoco
   }
 
   actions.push({
-    name: trans('Add Word'),
+    name: trans('Add'),
     markClass: 'cm-hunspellAddWordAction',
     apply (view) {
       ipcRenderer.invoke(
         'dictionary-provider',
         { command: 'add', terms: [saneTerm] }
+      ).catch(err => console.error(err))
+
+      view.dispatch({ effects: [
+        hunspellChangesEffect.of({ from: 0, to: view.state.doc.length }),
+        hideLinterToolTipEffect.of(true),
+        refreshLinterEffect.of(true)
+      ] })
+    }
+  })
+
+  actions.push({
+    name: trans('Ignore'),
+    markClass: 'cm-hunspellIgnoreWordAction',
+    apply (view) {
+      ipcRenderer.invoke(
+        'dictionary-provider',
+        { command: 'ignore', terms: [saneTerm] }
       ).catch(err => console.error(err))
 
       view.dispatch({ effects: [

--- a/source/common/modules/markdown-editor/linters/hunspell.ts
+++ b/source/common/modules/markdown-editor/linters/hunspell.ts
@@ -179,7 +179,7 @@ async function checkWord (word: string, index: number, nodeStart: number, autoco
   }
 }
 
-const { effect: hunspellChangesEffect, field: hunspellChangesField } = changesFieldEffectFactory()
+export const { effect: hunspellChangesEffect, field: hunspellChangesField } = changesFieldEffectFactory()
 
 /**
  * Defines a spellchecker that runs over the text content of the document and

--- a/source/common/modules/markdown-editor/linters/hunspell.ts
+++ b/source/common/modules/markdown-editor/linters/hunspell.ts
@@ -13,22 +13,15 @@
  * END HEADER
  */
 
-import { linter, type Diagnostic } from '@codemirror/lint'
+import { linter, type Diagnostic, type Action } from '@codemirror/lint'
 import { extractTextnodes, markdownToAST } from '@common/modules/markdown-utils'
 import { configField } from '../util/configuration'
 import { trans } from '@common/i18n-renderer'
+import { changesFieldEffectFactory, prepareDiagnostics, hideLinterToolTipEffect, refreshLinterEffect, TEXTNODE_FILTER } from './utils'
 import { ensureSyntaxTree } from '@codemirror/language'
+import { EditorView } from '@codemirror/view'
 
 const ipcRenderer = window.ipc
-
-// Below's monstrosity is taken from https://stackoverflow.com/a/43243160
-// const emojiRegex = /(?:[\u00A9\u00AE\u203C\u2049\u2122\u2139\u2194-\u2199\u21A9-\u21AA\u231A-\u231B\u2328\u23CF\u23E9-\u23F3\u23F8-\u23FA\u24C2\u25AA-\u25AB\u25B6\u25C0\u25FB-\u25FE\u2600-\u2604\u260E\u2611\u2614-\u2615\u2618\u261D\u2620\u2622-\u2623\u2626\u262A\u262E-\u262F\u2638-\u263A\u2640\u2642\u2648-\u2653\u2660\u2663\u2665-\u2666\u2668\u267B\u267F\u2692-\u2697\u2699\u269B-\u269C\u26A0-\u26A1\u26AA-\u26AB\u26B0-\u26B1\u26BD-\u26BE\u26C4-\u26C5\u26C8\u26CE-\u26CF\u26D1\u26D3-\u26D4\u26E9-\u26EA\u26F0-\u26F5\u26F7-\u26FA\u26FD\u2702\u2705\u2708-\u270D\u270F\u2712\u2714\u2716\u271D\u2721\u2728\u2733-\u2734\u2744\u2747\u274C\u274E\u2753-\u2755\u2757\u2763-\u2764\u2795-\u2797\u27A1\u27B0\u27BF\u2934-\u2935\u2B05-\u2B07\u2B1B-\u2B1C\u2B50\u2B55\u3030\u303D\u3297\u3299]|(?:\uD83C[\uDC04\uDCCF\uDD70-\uDD71\uDD7E-\uDD7F\uDD8E\uDD91-\uDD9A\uDDE6-\uDDFF\uDE01-\uDE02\uDE1A\uDE2F\uDE32-\uDE3A\uDE50-\uDE51\uDF00-\uDF21\uDF24-\uDF93\uDF96-\uDF97\uDF99-\uDF9B\uDF9E-\uDFF0\uDFF3-\uDFF5\uDFF7-\uDFFF]|\uD83D[\uDC00-\uDCFD\uDCFF-\uDD3D\uDD49-\uDD4E\uDD50-\uDD67\uDD6F-\uDD70\uDD73-\uDD7A\uDD87\uDD8A-\uDD8D\uDD90\uDD95-\uDD96\uDDA4-\uDDA5\uDDA8\uDDB1-\uDDB2\uDDBC\uDDC2-\uDDC4\uDDD1-\uDDD3\uDDDC-\uDDDE\uDDE1\uDDE3\uDDE8\uDDEF\uDDF3\uDDFA-\uDE4F\uDE80-\uDEC5\uDECB-\uDED2\uDEE0-\uDEE5\uDEE9\uDEEB-\uDEEC\uDEF0\uDEF3-\uDEF6]|\uD83E[\uDD10-\uDD1E\uDD20-\uDD27\uDD30\uDD33-\uDD3A\uDD3C-\uDD3E\uDD40-\uDD45\uDD47-\uDD4B\uDD50-\uDD5E\uDD80-\uDD91\uDDC0]))/
-// The L matches any letter from any alphabet, including chinese, Japanese,
-// Russian, etc. Additionally, we have quote characters so that "don't" (with
-// typographically correct quotes) is also recognized.
-const anyLetterRE = /[\p{L}'’‘]+/gu
-const noneLetterRE = /^['’‘]+$/
-const nonLetters = '\'’‘'
 
 // The cache is a simple hashmap. NOTE: This is shared across all spellcheckers,
 // which reduces the memory footprint but prevents differences in spellchecker
@@ -69,8 +62,6 @@ function sanitizeTerm (term: string): string {
  * @param  {string[]}  terms  The words to check
  */
 async function batchCheck (terms: string[]): Promise<void> {
-  terms = terms.map(term => sanitizeTerm(term))
-
   // Don't double check terms that are already cached
   terms = terms.filter(t => !spellcheckCache.has(t))
 
@@ -143,56 +134,114 @@ async function checkWord (word: string, index: number, nodeStart: number, autoco
     return undefined
   }
 
+  const saneTerm = sanitizeTerm(word)
+
+  const suggestions = await ipcRenderer.invoke(
+    'dictionary-provider',
+    { command: 'suggest', terms: [saneTerm], limit: 3 }
+  )
+
+  const actions: Action[] = []
+  for (const value of suggestions[0]) {
+    actions.push({
+      name: value,
+      markClass: 'cm-hunspellSuggestionAction',
+      apply (view, from, to) {
+        view.dispatch({ changes: { from, to, insert: value } })
+      }
+    })
+  }
+
+  actions.push({
+    name: trans('Add Word'),
+    markClass: 'cm-hunspellAddWordAction',
+    apply (view) {
+      ipcRenderer.invoke(
+        'dictionary-provider',
+        { command: 'add', terms: [saneTerm] }
+      ).catch(err => console.error(err))
+
+      view.dispatch({ effects: [
+        hunspellChangesEffect.of({ from: 0, to: view.state.doc.length }),
+        hideLinterToolTipEffect.of(true),
+        refreshLinterEffect.of(true)
+      ] })
+    }
+  })
+
   return {
     from: nodeStart + index,
     to: nodeStart + index + word.length,
     message: trans('Spelling mistake'),
     severity: 'error',
-    source: 'spellcheck' // Useful for later filtering of all diagnostics present
+    source: 'spellcheck', // Useful for later filtering of all diagnostics present
+    actions: actions
   }
 }
+
+const { effect: hunspellChangesEffect, field: hunspellChangesField } = changesFieldEffectFactory()
 
 /**
  * Defines a spellchecker that runs over the text content of the document and
  * highlights misspelled words
  */
-export const spellcheck = linter(async view => {
-  const diagnostics: Diagnostic[] = []
+const hunspellLinter = linter(async view => {
   const autocorrectValues = view.state.field(configField).autocorrect.replacements.map(x => x.value)
-  const ast = markdownToAST(view.state.doc.toString(), ensureSyntaxTree(view.state, view.state.doc.length))
-  const textNodes = extractTextnodes(ast)
 
-  const wordsToCheck: Array<{ word: string, index: number, nodeStart: number }> = textNodes
-    // First, extract all words from the node's value
-    .flatMap(node => {
-      const words: Array<{ index: number, word: string }> = []
-      for (const match of node.value.matchAll(anyLetterRE)) {
-        // Remove words that only consists, e.g., of quotes
-        if (!noneLetterRE.test(match[0])) {
-          // Remove none-letters from the beginnings and ends of words
-          let word = match[0]
-          while (nonLetters.includes(word[0])) {
-            word = word.slice(1)
+  const { ranges, diagnostics } = prepareDiagnostics(view.state, hunspellChangesField, 'spellcheck', 1, TEXTNODE_FILTER)
+  const ast = markdownToAST(view.state.sliceDoc(), ensureSyntaxTree(view.state, view.state.doc.length))
+
+  for (const { from, to } of ranges) {
+    const textNodes = extractTextnodes(ast, (node) => { return !(node.from > to || node.to < from) })
+
+    if (!(textNodes.length > 0)) { continue }
+
+    const locale: string = window.config.get('appLang')
+    const segmenter = new Intl.Segmenter(locale, { granularity: 'word' })
+
+    const wordsToCheck: { word: string, index: number, nodeStart: number }[] = textNodes
+      // First, extract all words from the node's value
+      .flatMap(node => {
+        const words: { index: number, word: string, nodeStart: number }[] = []
+
+        for (const { segment, index, isWordLike } of segmenter.segment(node.value)) {
+          if (isWordLike === true) {
+            words.push({ word: segment, index: index, nodeStart: node.from })
           }
-          while (nonLetters.includes(word[word.length - 1])) {
-            word = word.slice(0, word.length - 1)
-          }
-          words.push({ word, index: match.index })
         }
+
+        return words
+      })
+
+    // Now make sure everything is cached beforehand with two IPC calls
+    await batchCheck(wordsToCheck.map(x => sanitizeTerm(x.word)))
+
+    for (const { word, index, nodeStart } of wordsToCheck) {
+      const diagnostic = await checkWord(word, index, nodeStart, autocorrectValues)
+      if (diagnostic !== undefined) {
+        diagnostics.push(diagnostic)
       }
-
-      return words.map(x => ({ ...x, nodeStart: node.from }))
-    })
-
-  // Now make sure everything is cached beforehand with two IPC calls
-  await batchCheck(wordsToCheck.map(x => x.word))
-
-  for (const { word, index, nodeStart } of wordsToCheck) {
-    const diagnostic = await checkWord(word, index, nodeStart, autocorrectValues)
-    if (diagnostic !== undefined) {
-      diagnostics.push(diagnostic)
     }
   }
 
+  view.dispatch({ effects: [
+    hunspellChangesEffect.of(null),
+  ] })
+
   return diagnostics
 })
+
+const hunspellTheme = EditorView.theme({
+  '.cm-diagnosticAction.cm-hunspellAddWordAction': {
+    backgroundColor: '#06839f'
+  },
+  '.cm-diagnosticAction.cm-hunspellIgnoreWordAction': {
+    backgroundColor: '#af5151'
+  }
+})
+
+export const hunspell = [
+  hunspellLinter,
+  hunspellChangesField,
+  hunspellTheme,
+]

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -23,6 +23,7 @@ import { EditorView, type ViewUpdate } from '@codemirror/view'
 import { trans } from 'source/common/i18n-renderer'
 import type { LanguageToolIgnoredRuleEntry } from '@providers/config/get-config-template'
 import { ensureSyntaxTree } from '@codemirror/language'
+import type { DictionaryRecord } from 'source/app/service-providers/dictionary'
 
 const ipcRenderer = window.ipc
 
@@ -35,9 +36,9 @@ function refreshUserDictionary (): void {
   ipcRenderer.invoke(
     'dictionary-provider',
     { command: 'get-user-dictionary' }
-  ).then((dictionary: string[]) => {
-    for (const word of dictionary) {
-      userDictionary.add(word)
+  ).then((dictionary: DictionaryRecord[]) => {
+    for (const rec of dictionary) {
+      userDictionary.add(rec.word)
     }
   }).catch(console.error)
 }

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -13,16 +13,19 @@
  * END HEADER
  */
 
-import { linter, type Diagnostic, type Action } from '@codemirror/lint'
+import { linter, type Diagnostic, type Action, setDiagnostics } from '@codemirror/lint'
 import { extractTextnodes, markdownToAST } from '@common/modules/markdown-utils'
 import { configField } from '../util/configuration'
-import type { LanguageToolLinterRequest, LanguageToolLinterResponse } from '@providers/commands/language-tool'
-import { StateEffect, StateField, type Transaction } from '@codemirror/state'
+import type { LanguageToolAPIMatch, LanguageToolLinterRequest, LanguageToolLinterResponse } from '@providers/commands/language-tool'
+import { type EditorState, StateEffect, StateField } from '@codemirror/state'
 import extractYamlFrontmatter from 'source/common/util/extract-yaml-frontmatter'
-import { EditorView, type ViewUpdate } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 import { trans } from 'source/common/i18n-renderer'
 import type { LanguageToolIgnoredRuleEntry } from '@providers/config/get-config-template'
+import { changesFieldEffectFactory, getDiagnostics, hideLinterToolTipEffect, prepareDiagnostics, refreshLinterEffect, TEXTNODE_FILTER } from './utils'
 import { ensureSyntaxTree } from '@codemirror/language'
+import type { TextNode } from '../../markdown-utils/markdown-ast'
+import { genericTextNode } from '../../markdown-utils/markdown-ast/generic-text-node'
 import type { DictionaryRecord } from 'source/app/service-providers/dictionary'
 
 const ipcRenderer = window.ipc
@@ -135,97 +138,24 @@ export const languageToolState = StateField.define<LanguageToolStateField>({
         value.disabledRules = e.value.disabledRules ?? value.disabledRules
       }
     }
+
     return value
   }
 })
 
-// Hide the tooltip when the `Ignore Rule` action is selected.
-function hideOn (tr: Transaction): boolean | null {
-  for (const e of tr.effects) {
-    if (e.is(updateLTState)) {
-      if (e.value.disabledRules) {
-        return true
-      }
-    }
-  }
-
-  return null
-}
-
-// Re-run the linter when `ignoreRules` are updated.
-function needsRefresh (update: ViewUpdate): boolean {
-  for (const tr of update.transactions) {
-    for (const e of tr.effects) {
-      if (e.is(updateLTState)) {
-        if (e.value.disabledRules) {
-          return true
-        }
-      }
-    }
-  }
-
-  return false
-}
-
 /**
- * Defines a spellchecker that runs over the text content of the document and
- * highlights misspelled words
+ * This helper function converts a list of LanguageTool API matches into a list of linter Diagnostics
  */
-const ltLinter = linter(async view => {
-  if (!view.state.field(configField).lintLanguageTool) {
-    return []
-  }
-
-  view.dispatch({ effects: updateLTState.of({ running: true }) })
-
+function generateLTDiagnostics (state: EditorState, matches: LanguageToolAPIMatch[], textNodes: TextNode[], offset: number): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
-
-  const ast = markdownToAST(view.state.doc.toString(), ensureSyntaxTree(view.state, view.state.doc.length))
-  // Extract TextNodes to later filter diagnostics that only cover these nodes.
-  const textNodes = extractTextnodes(ast)
-
-  const response: LanguageToolLinterResponse = await ipcRenderer.invoke('application', {
-    command: 'run-language-tool',
-    payload: {
-      // Send the entire document to the API as `text`
-      data: { annotation: [{ text: view.state.sliceDoc() }] },
-      language: view.state.field(languageToolState).overrideLanguage
-    } satisfies LanguageToolLinterRequest
-  })
-
-  view.dispatch({ effects: updateLTState.of({ running: false }) })
-
-  if (response === undefined) {
-    return [] // Could not fetch a response, but it's benign
-  } else if (typeof response === 'string') {
-    view.dispatch({ effects: updateLTState.of({ running: false, lastError: response }) })
-    return [] // There was an error
-  }
-
-  const [ ltSuggestions, supportedLanguages ] = response
-
-  view.dispatch({
-    effects: updateLTState.of({
-      running: false,
-      lastDetectedLanguage: ltSuggestions.language.detectedLanguage.code,
-      supportedLanguages
-    })
-  })
-
-  if (ltSuggestions.matches.length === 0) {
-    return [] // Hooray, nothing wrong!
-  }
-
-  // At this point, we have only valid suggestions that we can now insert into
-  // the document.
-  for (const match of ltSuggestions.matches) {
-    const matchFrom: number = match.offset
-    const matchTo: number = match.offset + match.length
+  for (const match of matches) {
+    const matchFrom: number = offset + match.offset
+    const matchTo: number = offset + match.offset + match.length
 
     // Only include diagnostics overlapping with TextNodes.
     if (!textNodes.some(node => (matchFrom >= node.from && matchTo <= node.to))) { continue }
 
-    const word = view.state.sliceDoc(matchFrom, matchTo)
+    const word = state.sliceDoc(matchFrom, matchTo)
     const issueType = match.rule.issueType
     // skip matches for words in the local dictionary
     if (issueType === 'misspelling' && userDictionary.has(word)) { continue }
@@ -263,9 +193,6 @@ const ltLinter = linter(async view => {
       }
     }
 
-    // TODO: Add a class and styling once
-    // https://github.com/codemirror/lint/commit/50bd1188fe15d92b03cc5c1ea4ffbee44f28a090
-    // lands in a release
     actions.push({
       name: trans('Disable Rule'),
       markClass: 'cm-ltDisableAction',
@@ -294,7 +221,12 @@ const ltLinter = linter(async view => {
         const disabledRules = [...view.state.field(languageToolState).disabledRules]
         disabledRules.push(match.rule.id)
 
-        view.dispatch({ effects: updateLTState.of({ disabledRules: disabledRules }) })
+        view.dispatch({ effects: [
+          updateLTState.of({ disabledRules: disabledRules }),
+          ltChangesEffect.of({ from: 0, to: view.state.doc.length }),
+          hideLinterToolTipEffect.of(true),
+          refreshLinterEffect.of(true)
+        ] })
       }
     })
 
@@ -304,10 +236,196 @@ const ltLinter = linter(async view => {
   }
 
   return diagnostics
-}, {
-  delay: 2000, // Increase the delay to reduce server strain
-  hideOn,
-  needsRefresh
+}
+
+/**
+ * This helper chunks a range based on TextNode boundaries. It keeps each chunk
+ * below `maxSize`, and it splits individual TextNodes if they are too large.
+ */
+function chunkContext (from: number, to: number, maxSize: number, textNodes: TextNode[], splitNodes: boolean = true, granularity: 'sentence'|'word' = 'sentence'): { start: number, end?: number }[] {
+  const chunks: { start: number, end?: number }[] = []
+
+  let length = to - from
+  // The range is too large, so we must chunk it
+  if (maxSize > 0 && length >= maxSize) {
+    const n_chunks = Math.ceil(length / maxSize)
+    const chunkLength = Math.floor(length / n_chunks)
+
+    let start = from
+    // We don't want to exceed our range limits
+    let end = Math.min(start + chunkLength, to)
+    let chunk: { start: number, end?: number } = { start }
+
+    for (const node of textNodes) {
+      let start = node.from
+
+      // If the node fits within the context,
+      // extend the chunk end and continue
+      if (node.to <= end) {
+        chunk.end = node.to
+        continue
+      // Check if the node start is within the context.
+      // If it is, extend the chunk up to this node.
+      // Otherwise, the formatting between nodes
+      // will be discarded if it exceeds the context.
+      } else if (start <= end) {
+        chunk.end = start
+      }
+
+      chunks.push(chunk)
+
+      // If the node itself is larger than the context, then it too
+      // needs to be chunked. We first determine the chunk boundaries
+      // based on sentences and convert them to TextNodes. When we
+      // recurse, we set the `granularity` to `word`, in case sentences
+      // exceed the context and they need to be chunked, as well.
+      if (splitNodes && node.to - node.from >= maxSize) {
+        const locale: string = window.config.get('appLang')
+        const segmenter = new Intl.Segmenter(locale, { granularity })
+
+        const newNodes: TextNode[] = []
+        for (const { segment, index, isWordLike } of segmenter.segment(node.value)) {
+          const newFrom = node.from + index
+          const newTo = newFrom + segment.length
+          if (granularity === 'sentence' || isWordLike === true) {
+            newNodes.push(genericTextNode(newFrom, newTo, segment))
+          }
+        }
+
+        chunks.push(...chunkContext(node.from, node.to, maxSize, newNodes, false, 'word'))
+        start = node.to
+      }
+
+      end = Math.min(start + chunkLength, to)
+
+      chunk = { start, end }
+    }
+
+    if (chunk.end !== undefined) {
+      chunks.push(chunk)
+    }
+  // The range is within `maxSize`, so there's nothing to do
+  } else {
+    chunks.push({ start: from, end: to })
+  }
+
+  return chunks
+}
+
+export const { effect: ltChangesEffect, field: ltChangesField } = changesFieldEffectFactory()
+
+/**
+ * Defines a spellchecker that runs over the text content of the document and
+ * highlights misspelled words
+ */
+const ltLinter = linter(async view => {
+  const { lintLanguageTool, languageToolCharsPerRequest } = view.state.field(configField)
+
+  if (!lintLanguageTool) {
+    return []
+  }
+
+  // If the linter was already running, it's probably in the middle
+  // of processing several chunks from a previous dispatch. It will
+  // cancel itself if it detects that the doc has changed since it
+  // started
+  if (view.state.field(languageToolState).running) {
+    return getDiagnostics(view.state, 'language-tool')
+  }
+
+  view.dispatch({ effects: updateLTState.of({ running: true })  })
+
+  const state = view.state
+  const ast = markdownToAST(state.sliceDoc(), ensureSyntaxTree(state, state.doc.length))
+
+  const { ranges, diagnostics } = prepareDiagnostics(state, ltChangesField, 'language-tool', 6, TEXTNODE_FILTER)
+
+  for (let range = 0; range < ranges.length; range++) {
+    const { from, to } = ranges[range]
+
+    // Extract TextNodes that fall within our range to later filter diagnostics that only cover these nodes.
+    const textNodes = extractTextnodes(ast, (node) => node.from < to && node.to > from)
+    // If there are no TextNodes in this region, move on to the next.
+    if (!(textNodes.length > 0)) { continue }
+
+    // Language Tool has a per-request character limit in the public APIs, so we
+    // need to chunk long documents in order for them to be processed at all.
+    const chunks = chunkContext(from, to, languageToolCharsPerRequest, textNodes)
+
+    let numRetries = 0
+    for (let chunk = 0; chunk < chunks.length; chunk++) {
+      const { start, end } = chunks[chunk]
+
+      const text = state.sliceDoc(start, end)
+
+      const response: LanguageToolLinterResponse = await ipcRenderer.invoke('application', {
+        command: 'run-language-tool',
+        payload: {
+          // Send the entire document to the API as `text`
+          data: { annotation: [{ text }] },
+          language: view.state.field(languageToolState).overrideLanguage
+        } satisfies LanguageToolLinterRequest
+      })
+
+      if (response === undefined || typeof response === 'string') {
+        view.dispatch({ effects: updateLTState.of({ lastError: response }) })
+
+        // Return after failing too many times
+        if (numRetries > 3) {
+          return diagnostics
+        }
+
+        // Try the chunk again
+        chunk--
+        continue
+      }
+
+      numRetries = 0
+
+      const [ ltSuggestions, supportedLanguages ] = response
+
+      if (ltSuggestions.matches.length === 0) {
+        continue // Hooray, nothing wrong!
+      }
+
+      diagnostics.push(...generateLTDiagnostics(state, ltSuggestions.matches, textNodes, start))
+
+      // When using `setDiagnostics`, we have to return a
+      // complete set, not just the ones from this linter
+      const allDiagnostics = getDiagnostics(view.state, 'language-tool', false).concat(diagnostics)
+      const remainingRanges = [{ from: start, to }  ,...ranges.slice(range + 1) ]
+
+      // Make sure that the doc hasn't changed since we started linting.
+      // This is how the native codemirror implementation does the check
+      if (view.state.doc === state.doc) {
+        view.dispatch(
+          // Return the diagnostics as soon as possible
+          setDiagnostics(view.state, allDiagnostics),
+          {
+            effects: [
+              ltChangesEffect.of(remainingRanges),
+              updateLTState.of({
+                lastDetectedLanguage: ltSuggestions.language.detectedLanguage.code,
+                supportedLanguages
+              }),
+            ]
+          }
+        )
+      } else {
+        console.log('[Language Tool] Cancelling LanguageTool lint...')
+        view.dispatch({ effects: updateLTState.of({ running: false }) })
+
+        return []
+      }
+    }
+  }
+
+  view.dispatch({ effects: [
+    updateLTState.of({ running: false }),
+    ltChangesEffect.of(null),
+  ] })
+
+  return diagnostics
 })
 
 const languagetoolTheme = EditorView.theme({
@@ -319,5 +437,6 @@ const languagetoolTheme = EditorView.theme({
 export const languageTool = [
   ltLinter,
   languageToolState,
-  languagetoolTheme
+  languagetoolTheme,
+  ltChangesField
 ]

--- a/source/common/modules/markdown-editor/linters/language-tool.ts
+++ b/source/common/modules/markdown-editor/linters/language-tool.ts
@@ -376,6 +376,7 @@ const ltLinter = linter(async view => {
         }
 
         // Try the chunk again
+        numRetries++
         chunk--
         continue
       }

--- a/source/common/modules/markdown-editor/linters/utils.ts
+++ b/source/common/modules/markdown-editor/linters/utils.ts
@@ -239,7 +239,6 @@ export function prepareDiagnostics (
   const changes = state.field(field)
   changes.iterChangedRanges((_, __, fromB, toB) => {
     // we expand the context to ensure a better lint
-    console.log("PROCESSING CHANGE: ", fromB, toB)
     const { from, to } = getNodePosition(state, fromB, toB, context, filter)
     ranges.push({ from, to })
   })

--- a/source/common/modules/markdown-editor/linters/utils.ts
+++ b/source/common/modules/markdown-editor/linters/utils.ts
@@ -1,0 +1,324 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Linter Utilities
+ * CVM-Role:        Linter
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     These utilites are used to prepare text ranges
+ *                  and filter diagnostics for linting.
+ *
+ * END HEADER
+ */
+import {
+  StateField,
+  StateEffect,
+  ChangeSet,
+  type StateEffectType,
+  type Transaction,
+  type ChangeDesc,
+  type EditorState,
+  type ChangeSpec
+} from '@codemirror/state'
+import { forEachDiagnostic, linter, setDiagnosticsEffect, type Diagnostic } from '@codemirror/lint'
+import { ensureSyntaxTree } from '@codemirror/language'
+import type { Tree, TreeCursor } from '@lezer/common'
+import type { ViewUpdate } from '@codemirror/view'
+
+export type LintRange = { from: number, to: number }
+
+/**
+ * This function moves a cursor to the next node, and if `filter`
+ * is provided, it will move it to the next node matching one in `filter`.
+ *
+ * @param   {TreeCursor}   cursor  The TreeCursor
+ * @param   {Set<string>}  filter  A set of strings with node names
+ *
+ * @return  {boolean}              Whether the node was moved successfully.
+ */
+function filterCursor (cursor: TreeCursor, direction: -1 | 1, filter?: Set<string>): boolean {
+  const moveCursor = direction === -1 ? cursor.prev.bind(cursor) : cursor.next.bind(cursor)
+
+  while (filter && !filter.has(cursor.name)) {
+    if (!moveCursor(false)) { return false }
+  }
+
+  return true
+}
+
+/**
+ * This function takes a range and expands it to the nearest
+ * node boundary before `from` and after `to`
+ *
+ * @param   {EditorState} state    The Editor State
+ * @param   {number}      from     The beginning of the selection
+ * @param   {number}      to       The end of the selection
+ * @param   {number}      context  Expand the selection by `context`
+ *                                 number of nodes before `from` and after `to`
+ * @param   {Set<string>} [filter] Optional. A set of strings to filter nodes by.
+ * @param   {Tree}        [tree]   Optional. A pre-computed Tree object.
+ *
+ * @return  {LintRange[}                The selection expanded to the nearest node boundaries
+ */
+function getNodePosition (state: EditorState, from: number, to: number, context: number = 0, filter?: Set<string>, tree?: Tree | null): LintRange {
+  tree = tree ?? ensureSyntaxTree(state, state.doc.length, 1000)
+
+  // if we don't have the tree, bail out with the whole document.
+  if (!tree) {
+    return { from: 0, to: state.doc.length }
+  }
+
+  const cursorA: TreeCursor = tree.topNode.cursor()
+  if (!cursorA.childBefore(from)) {
+    cursorA.firstChild()
+  }
+  filterCursor(cursorA, -1, filter)
+
+  const cursorB: TreeCursor = tree.topNode.cursor()
+  if (!cursorB.childAfter(to)) {
+    cursorB.lastChild()
+  }
+  filterCursor(cursorB, 1, filter)
+
+  while (context-- > 0) {
+    const hasPrev = cursorA.prev(false)
+    const hasNext = cursorB.next(false)
+    // if we are at the end in both directions, fail early
+    if (!hasPrev && !hasNext) { break }
+
+    filterCursor(cursorA, -1, filter)
+    filterCursor(cursorB, 1, filter)
+  }
+
+  return { from: cursorA.from, to: cursorB.to }
+}
+
+/**
+ * Test whether a range overlaps any range in a list of ranges.
+ *
+ * @param   {LintRange}    r       The range to test
+ * @param   {LintRange[]}  ranges  A list of ranges to test against
+ *
+ * @return  {boolean}          Whether the range overlaps any range in ranges.
+ */
+function rangesOverlap (r: LintRange, ranges: LintRange[]): boolean {
+  return ranges.some(range => {
+    // zero-width range
+    if (r.from === r.to) {
+      // only count as overlap if range actually contains the point r.from
+      return r.from < range.to && r.to > range.from
+    }
+    return !(r.to < range.from || r.from > range.to)
+  })
+}
+
+/**
+ * Merge overlapping ranges in a list of ranges
+ *
+ * @param   {LintRange[]}  ranges  A list of { from, to } ranges.
+ *
+ * @return  {LintRange[]}          A new list of merged ranges.
+ */
+function mergeRanges (ranges: LintRange[]): LintRange[] {
+  if (ranges.length <= 1) {
+    return [...ranges]
+  }
+
+  const sorted = [...ranges].sort((a, b) => a.from - b.from)
+  const merged: LintRange[] = [{ ...sorted[0] }]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = merged[merged.length - 1]
+    const next = sorted[i]
+
+    if (next.from <= prev.to + 1) {
+      prev.to = Math.max(prev.to, next.to)
+    } else {
+      merged.push({ ...next })
+    }
+  }
+
+  return merged
+}
+
+/**
+ * Get the diagnostics for an EditorState, optionally filtered based on `source`
+ *
+ * @param   {EditorState}   state     The editor state
+ * @param   {string}        [source]  An optional filter
+ * @param   {boolean}       [include] Whether the source filter is inclusive or exclusive
+ *
+ * @returns {Diagnostic[]}
+ */
+export function getDiagnostics (state: EditorState, source?: string, include: boolean = true): Diagnostic[] {
+  const diagnostics: Diagnostic[] = []
+
+  const isFiltered = source === undefined ? () => true : (s: string) => s.includes(source) === include
+
+  // `forEachDiagnostic` tracks the new position of the diagnostic, so
+  // we can just push the diagnostic with the updated `from` and `to`.
+  forEachDiagnostic(state, (d, from, to) => {
+    // if `source` was provided, filter the diagnostics which match
+    if (d.source !== undefined && isFiltered(d.source)) {
+      diagnostics.push({ ...d, from, to })
+    }
+  })
+
+  return diagnostics
+}
+
+export const TEXTNODE_FILTER = new Set([
+  'Paragraph',
+  'Blockquote'
+])
+
+/**
+ * This factory function returns a StateEffect and Statefield to control linting contexts.
+ *
+ * @return  {{ effect: StateEffectType<LintRange|null>, field: StateField<ChangeDesc> }}
+ */
+export function changesFieldEffectFactory (): { effect: StateEffectType<LintRange|LintRange[]|null>, field: StateField<ChangeDesc> } {
+  const setChangesEffect = StateEffect.define<LintRange|LintRange[]|null>()
+
+  const lintChangesField = StateField.define<ChangeDesc>({
+    // create a ChangeSet that covers the entire document so that
+    // the entire document is linted on startup.
+    create: (state) => ChangeSet.of({ from: 0, to: state.doc.length, insert: state.doc.toString() }, state.doc.length).desc,
+    update (value, transaction: Transaction) {
+      const changes = transaction.changes.desc
+      const doc = transaction.startState.doc
+
+      for (let e of transaction.effects) {
+        if (e.is(setChangesEffect)) {
+          let spec: ChangeSpec|ChangeSpec[]
+          if (e.value === null) {
+            spec = ChangeSet.empty(doc.length)
+          } else if (Array.isArray(e.value)) {
+            spec = e.value.map(({ from, to }) => {
+              return { from, to, insert: doc.sliceString(from, to) }
+            })
+          } else {
+            const { from, to } = e.value
+            spec = { from, to, insert: doc.sliceString(from, to) }
+          }
+
+          value = ChangeSet.of(spec, doc.length).desc
+        }
+      }
+
+      return value.composeDesc(changes)
+    }
+  })
+
+  return { effect: setChangesEffect, field: lintChangesField }
+}
+
+/**
+ * Prepare ranges and diagnostics for linting.
+ *
+ * @param   {EditorState}             state         The codemirror editor state
+ * @param   {StateField<ChangeDesc>}  field         A `StateField` which returns a `ChangeDesc`
+ * @param   {string}                  [source]      Optional. A diagnostic source to filter
+ * @param   {number}                  [context]     Optional. Expand the selection by `context` number of nodes. Passed to `getNodePosition`
+ * @param   {Set<string>}             [filter]      Optional. A set of strings to filter nodes by. Passed to `getNodePosition`
+ *
+ * @return  {{ ranges: LintRange[], diagnostics: Diagnostic[] }}  The new ranges to lint and the remaining valid diagnostics
+ */
+export function prepareDiagnostics (
+  state: EditorState,
+  field: StateField<ChangeDesc>,
+  source?: string,
+  context?: number,
+  filter?: Set<string>,
+): { ranges: LintRange[], diagnostics: Diagnostic[] } {
+  const diagnostics: Diagnostic[] = []
+  let ranges: LintRange[] = []
+
+  const changes = state.field(field)
+  changes.iterChangedRanges((_, __, fromB, toB) => {
+    // we expand the context to ensure a better lint
+    console.log("PROCESSING CHANGE: ", fromB, toB)
+    const { from, to } = getNodePosition(state, fromB, toB, context, filter)
+    ranges.push({ from, to })
+  })
+
+  // `forEachDiagnostic` tracks the new position of the diagnostic, so
+  // we can just push the diagnostic with the updated `from` and `to`.
+  getDiagnostics(state, source)
+    .forEach(d => {
+      if (!rangesOverlap({ from: d.from, to: d.to }, ranges)) {
+        diagnostics.push(d)
+      } else {
+        // since the changed ranges overlap with the diagnostic
+        // we need to expand the context to include the entire diagnostic
+        // to ensure we lint correctly, and we need to ensure that the
+        // range is on a node-boundary
+        ranges.push(getNodePosition(state, d.from, d.to, 0, filter))
+      }
+    })
+
+  // sort the ranges and merge any overlapping regions
+  ranges = mergeRanges(ranges)
+
+  return { ranges, diagnostics }
+}
+
+// Used to hide the linter tool tip
+export const hideLinterToolTipEffect = StateEffect.define<boolean>()
+
+// Manually trigger linting of the stored change buffer.
+export const refreshLinterEffect = StateEffect.define<boolean>()
+
+/** This is defined here for all linters because it is not possible
+ *  to configure `hideOn` per-linter.
+ *
+ *  Can be used to control what kind of transactions cause lint hover
+ *  tooltips associated with the given document range to be hidden.
+ *  By default any transactions that changes the line around the range
+ *  will hide it. Returning null falls back to this behavior.
+ *
+ *  https://codemirror.net/docs/ref/#lint.linter^config.hideOn
+ */
+function hideOn (tr: Transaction): boolean | null {
+  for (const e of tr.effects) {
+    if (e.is(hideLinterToolTipEffect) && e.value) {
+      return true
+    }
+
+    if (e.is(setDiagnosticsEffect)) {
+      return false
+    }
+  }
+
+  return null
+}
+
+/** This is defined here for all linters because it is not possible
+ *  to configure `needsRefresh` per-linter.
+ *
+ *  Optional predicate that can be used to indicate when diagnostics
+ *  need to be recomputed. Linting is always re-done on document changes.
+ *
+ *  https://codemirror.net/docs/ref/#lint.linter^config.needsRefresh
+ */
+function needsRefresh (update: ViewUpdate): boolean {
+  for (const tr of update.transactions) {
+    for (const e of tr.effects) {
+      if (e.is(refreshLinterEffect)) {
+        if (e.value) {
+          return true
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+export const linterConfig =  linter(null, {
+  delay: 1000,
+  hideOn,
+  needsRefresh
+})

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -74,6 +74,7 @@ export interface EditorConfiguration {
   distractionFree: boolean
   lintMarkdown: boolean
   lintLanguageTool: boolean
+  languageToolCharsPerRequest: number
   showStatusbar: boolean
   showFormattingToolbar: boolean
   darkMode: boolean
@@ -140,6 +141,7 @@ export function getDefaultConfig (): EditorConfiguration {
     distractionFree: false,
     lintMarkdown: false,
     lintLanguageTool: false,
+    languageToolCharsPerRequest: 0,
     showStatusbar: false,
     showFormattingToolbar: true,
     darkMode: false,

--- a/source/common/vue/form/FormBuilder.vue
+++ b/source/common/vue/form/FormBuilder.vue
@@ -243,6 +243,7 @@ interface ListField extends BasicInfo {
   columnLabels: string[]
   striped?: boolean
   addable?: boolean
+  optional?: boolean | number[]
   editable?: boolean | number[]
   deletable?: boolean
   deleteLabel?: string

--- a/source/common/vue/form/FormField.vue
+++ b/source/common/vue/form/FormField.vue
@@ -131,6 +131,7 @@
     v-bind:editable="props.field.editable"
     v-bind:striped="props.field.striped"
     v-bind:addable="props.field.addable"
+    v-bind:optional="props.field.optional"
     v-bind:searchable="props.field.searchable"
     v-bind:search-label="props.field.searchLabel"
     v-bind:empty-message="props.field.emptyMessage"

--- a/source/common/vue/form/elements/ListControl.vue
+++ b/source/common/vue/form/elements/ListControl.vue
@@ -611,7 +611,7 @@ function handleAddition (): void {
     for (let i = 0; i < keys.length; i++) {
       const newVal = newValues[i]
 
-      if (isColumnOptional(i) && newVal === undefined) {
+      if (!isColumnOptional(i) && newVal === undefined) {
         console.error('Cannot add new record: Didn\'t receive the right amount of values to add.')
         return
       }

--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -509,6 +509,13 @@ const toolbarControls = computed<ToolbarControl[]>(() => {
       icon: 'export'
     },
     {
+      type: 'button',
+      id: 'markdownLint',
+      title: trans('Check document for errors'),
+      icon: 'pencil',
+      visible: getToolbarButtonDisplay('showMarkdownLintButton')
+    },
+    {
       type: 'spacer',
       id: 'spacer-two',
       size: '1x'

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -232,6 +232,9 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
   // everything all the time, but rather do one initial configuration, so
   // even if we incur a performance penalty, it won't be noticed that much.
   const { editor, display, zkn, darkMode, darkModeEditor } = configStore.config
+
+  const ltCharsPerRequest = editor.lint.languageTool.provider === 'custom' ? editor.lint.languageTool.charsPerRequest : editor.lint.languageTool.apiKey ? 60_000 : 20_000
+
   return {
     indentUnit: editor.indentUnit,
     indentWithTabs: editor.indentWithTabs,
@@ -278,6 +281,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     lintMarkdown: editor.lint.markdown,
     // The editor only needs to know if it should use languageTool
     lintLanguageTool: editor.lint.languageTool.active,
+    languageToolCharsPerRequest: ltCharsPerRequest,
     distractionFree: props.distractionFree.valueOf(),
     showStatusbar: editor.showStatusbar,
     showFormattingToolbar: editor.showFormattingToolbar,

--- a/source/win-preferences/App.vue
+++ b/source/win-preferences/App.vue
@@ -88,6 +88,7 @@ import { getImportExportFields } from './schema/import-export'
 import { getSnippetsFields } from './schema/snippets'
 import { useConfigStore } from 'source/pinia'
 import { PreferencesGroups } from './schema/_preferences-groups'
+import type { DictionaryRecord } from 'source/app/service-providers/dictionary'
 
 export type PreferencesFieldset = Fieldset & { group: PreferencesGroups }
 
@@ -99,7 +100,7 @@ const hasVibrancy = computed(() => configStore.config.window.vibrancy && process
 const currentGroup = ref(0)
 const query = ref('')
 // Will be populated afterwards, contains the user dict
-const userDictionaryContents = ref<string[]>([])
+const userDictionaryContents = ref<DictionaryRecord[]>([])
 // Will be populated afterwards, contains all dictionaries
 const availableDictionaries = ref<Array<{ selected: boolean, value: string, key: string }>>([])
 // Will be populated afterwards, contains the available languages
@@ -317,7 +318,7 @@ function handleInput (prop: string, val: unknown): void {
     // The user dictionary is not handled by the config
     ipcRenderer.invoke('dictionary-provider', {
       command: 'set-user-dictionary',
-      payload: val
+      payload: JSON.parse(JSON.stringify(val))
     })
       .catch(err => console.error(err))
   } else if (prop === 'availableDictionaries') {

--- a/source/win-preferences/schema/appearance.ts
+++ b/source/win-preferences/schema/appearance.ts
@@ -157,6 +157,11 @@ export function getAppearanceFields (config: ConfigOptions): PreferencesFieldset
           label: trans('Display "Next file" button'),
           model: 'displayToolbarButtons.showNextFileButton'
         },
+        {
+          type: 'checkbox',
+          label: trans('Display "Lint document" button'),
+          model: 'displayToolbarButtons.showMarkdownLintButton'
+        },
         { type: 'separator' },
         {
           type: 'form-text',

--- a/source/win-preferences/schema/spellchecking.ts
+++ b/source/win-preferences/schema/spellchecking.ts
@@ -191,6 +191,27 @@ export function getSpellcheckingFields (config: ConfigOptions): PreferencesField
           model: 'editor.lint.languageTool.customServer',
           disabled: config.editor.lint.languageTool.provider !== 'custom'
         },
+        {
+          type: 'number',
+          label: trans('Custom server characters per request'),
+          placeholder: '75_000',
+          model: 'editor.lint.languageTool.charsPerRequest',
+          disabled: config.editor.lint.languageTool.provider !== 'custom'
+        },
+        {
+          type: 'number',
+          label: trans('Custom server characters per minute'),
+          placeholder: '300_000',
+          model: 'editor.lint.languageTool.charsPerMinute',
+          disabled: config.editor.lint.languageTool.provider !== 'custom'
+        },
+        {
+          type: 'number',
+          label: trans('Custom server requests per minute'),
+          placeholder: '80',
+          model: 'editor.lint.languageTool.requestsPerMinute',
+          disabled: config.editor.lint.languageTool.provider !== 'custom'
+        },
         { type: 'separator' },
         {
           type: 'form-text',

--- a/source/win-preferences/schema/spellchecking.ts
+++ b/source/win-preferences/schema/spellchecking.ts
@@ -67,13 +67,17 @@ export function getSpellcheckingFields (config: ConfigOptions): PreferencesField
       fields: [
         {
           type: 'list',
-          valueType: 'simpleArray',
+          valueType: 'record',
+          keyNames: [ 'word', 'affix' ],
+          columnLabels: [ trans('Word'), trans('Affixes') ],
           model: 'userDictionaryContents',
-          columnLabels: [trans('Dictionary entry')],
           deletable: true,
+          addable: true,
+          optional: [1],
+          editable: false,
           searchable: true,
           searchLabel: trans('Search for entries …'),
-          striped: true
+          striped: true,
         }
       ]
     },


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors the hunspell and languagetool linters to provide chunked, incremental linting. It improves performance, allows LT processing of large documents, and enhances local dictionary functionality.

This PR is pretty much ready for review, but I am starting it as a draft until I can finish a more complete write up. Since it is so large, I am opening it before hand in case anyone wants to get a head start. It is also missing tests, which would be especially pertinent for the `utils`.

Please review this commit by commit. It should be more manageable that way.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->

### WIP

I'll cover changes below based on the commit message to keep this organized:

#### [add linter utilities](https://github.com/Zettlr/Zettlr/pull/6195/commits/d87aa74382fda9779268be7712ff50599295bd2a)

These utilities are used across the LanguageTool and hunspell linters to consolidate a lot of chunking/grouping logic.

The main engine is the `changesFieldEffectFactory` and the `prepareDiagnostics` function.

`changesFieldEffectFactory` returns a `StateEffect` and a `Statefield` to control and store the change history of the document. They allow manually setting or resetting the changed ranges via the `StateEffect`. This is used to reset the changes after the completion of each linter, as well as to set the changes to encompass the entire document when the `Lint document` toolbar button is clicked, among other helpers.

The factory allows us to keep unique change histories for each linter, which is helpful for LanguageTool, which may not completely process a changeset during a lint run.

Otherwise, several helpers are included to help with expanding ranges to node boundaries and merging overlapping ranges.

The lint configuration was centralized in this file, as well, and it is reused for all linters. I learned through a bug report with the codemirror maintainer that the lint config is not unique per-linter, and it is essentially merged into one. This means that whatever triggers one linter triggers the others.

#### [refactor dictionary provider](https://github.com/Zettlr/Zettlr/pull/6195/commits/7da2ba4b8dc09e8ecea7fcbe479488de59b8cdeb)

This change brings about a huge functional improvement to the hunspell linter. And it also seems to boost performance in my testing, especially for large user dictionaries.

To start with the chore items, several of the functions were updated to use the `async` counterparts for `Nodehun` operations, such as `suggest`, `spell`, `add`, etc... 

Under the hood, the user dictionary is now loaded as an overlay hunspell dictionary. This means that for every dictionary the user has enabled, the user dictionary is applied on top. This means that the user dic gets the full functionality of a hunspell dictionary, with spelling suggestions, flags, etc. without having to maintain a distinct `affix` file. It also improves performance because the user dictionary is no longer naively checked as a simple list iteration and string comparison. Since all of the loaded dictionaries are already checked, this removes an iteration over the user word list and incorporates the user dic spellchecking into the regular dictionary process.

The user interface for the user dictionary was also improved. Now, users can manually add words to the dictionary, and optionally, they can include hunspell flags. This required changes to the `ListControl` component to allow for optional column entries.

#### [refactor spellcheck linter](https://github.com/Zettlr/Zettlr/pull/6195/commits/3ce11404e151a2e9e87543e40a4af4bd477f3f35)

The hunspell linter refactored so that it only runs on a range over the recent document changes. This dramatically improves performance in long documents. Since hunspell handles checks word by word, context-aware processing is unnecessary, so we get as little context as possible. In this instance, we try to get the boundary of the closest text node. 

Actions were added to the hunspell lint tooltip to either add a word to the user dictionary. Suggestions are also returned.

#### [refactor languagetool](https://github.com/Zettlr/Zettlr/pull/6195/commits/39d0233411f1c03433f88b99f41bb7f70eb8b232)

The LanguageTool linter was refactored in largely the same way as the hunspell linter. The linter in this case grabs a larger context window than hunspell, since LanguageTool provides context-aware lints. This is currently not configurable, but I am definitely interested in making it so.

The linter now chunks the context and implements rate limiting. This is to address limits imposed on the public and premium API service, but it also improves user experience. Since the lint context is chunked, lints are returned after every chunk is processed. So for long documents, you will start seeing lints appear much sooner. 

On a technical level, if a new lint request comes in while LT is still running, the old diagnostics will be returned, and the running process will be signalled to cancel for the fact that after every chunk, it checks whether the document has changed since it started. This is to prevent drift in positions from the returned diagnostics.

Ratelimiting is enforced through a token bucket limiter. I don't have much experience with ratelimiting techniques, and I based this implementation largely off of some stackoverflow comments and cursory research. It works in my tests, though!

 The chunk length, per-char request limit, and per-minute request limit are all configurable for self-hosted servers, and they are hardcoded for the public api based on its documented limits.

#### [persist diagnostic information](https://github.com/Zettlr/Zettlr/pull/6195/commits/6e5614e3f59605d0a961b9a36e41c0bc0819d3af)

Diagnostic information is now stored in the editore `persistentState`. This means that focusing and unfocusing the editor preserves lint information and stored changed ranges. 

#### [increase lint-panel max height](https://github.com/Zettlr/Zettlr/pull/6195/commits/9c47f8899090caf908d7d963074fc7a70a82d336)

The lint panel is too small for my use. This increases the height by about twice the current height. Still out of the way, but much more readable.

#### [ignore word](https://github.com/Zettlr/Zettlr/pull/6195/commits/c72f01b4fdd3ea88e6983e4be17bb4111dd07305)

An `Ignore` function was added to the dictionary provider. It has the same functionality as `add`, except the word is only added to the runtime dictionary and not persisted to the user dictionary. 

An action was added to hunspell lint diagnostics that allows a user to ignore a mispelled word. Ignored words are reset when the regular dictionaries are reloaded (unselecting and reselecting, or restarting the app).

#### [add force-lint button to toolbar](https://github.com/Zettlr/Zettlr/pull/6195/commits/2377f2fe5d59a6161046e681913378b0335b542c)

This adds a toolbar button which, when clicked, will re-run all of the enabled linters over the entire document.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
as an aside, I have been using this myself for about a month in this state, and have found it to work quite well!

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->

macOS 26