### PR TITLE
fix: Update tag regex to also match emojis with variation selectors

### DIFF
--- a/source/common/modules/markdown-editor/parser/zkn-tag-parser.ts
+++ b/source/common/modules/markdown-editor/parser/zkn-tag-parser.ts
@@ -19,7 +19,7 @@ const allowedCharsBefore = /^[ \t\n\(\{\[]$/
 
 // Tags start with one or two '#' followed by letters, numbers, emojis,
 // underscores, or hyphens
-const tagRE = /^##?[\p{L}\p{N}\p{Emoji_Presentation}_-]+#?/u
+const tagRE = /^##?[\p{L}\p{N}\p{Emoji}\uFE0F_-]+#?/u
 
 export const zknTagParser: InlineParser = {
   name: 'zkn-tags',


### PR DESCRIPTION
## Description
I noticed that even after the recent fix for emojis in tags (#6155), there were still some emojis that were not detected correctly when in tags, e.g. ☑️:

<img width="106" height="47" alt="Screenshot 2026-02-21 125542" src="https://github.com/user-attachments/assets/fd2801bb-9e56-432c-abf8-61cec1d685b0" />


After a quick research, it turns out that some symbols have a _dual_ representation: either a text-based, or a colorful (=emoji) one. This can be toggled with a special, invisible Unicode character, called _variation selector_. The selector has the encoding `U+FE0F`. The checkmark symbol, in it's plain text form, has encoding `U+2611`. When the variation selector is added, the total encoding becomes `\u2611\uFE0F`, which then gets decoded as the emoji checkmark (☑️). Note that it may also be possible that the plain encoding itself could be decoded/rendered as the emoji directly (_as it seems to be the case here on Github: when I copy the plain checkmark from [this page](https://www.compart.com/de/unicode/U+2611), it is rendered in the PR description as the emoji checkmark_).

## Changes

To fix the issue, we have to allow the variation selector in the regex. Also, `Emoji` is a superset of `Emoji_Presentation`, so I changed that as well, to cover more symbols.

With the fix, the example tag from above is correctly parsed:

<img width="99" height="48" alt="Screenshot 2026-02-21 131459" src="https://github.com/user-attachments/assets/48e67cec-aecd-446f-9acf-08f9d206da43" />


## Additional information

<!-- Please provide any testing system -->
Tested on: Windows 11, Ubuntu WSL
