### PR TITLE
[Enhancement] Improve autocorrect undo history handling

### DIFF
--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -51,7 +51,10 @@ import { type Extension } from '@codemirror/state'
 
 import { nextSnippet, abortSnippet } from '../autocomplete/snippets'
 import {
-  handleReplacement, handleBackspace, handleQuote
+  handleBackspace,
+  handleQuote,
+  handleAutocorrectEnter,
+  handleAutocorrectSpace
 } from '../commands/autocorrect'
 import { addNewFootnote, selectFootnoteBeforeDelete } from '../commands/footnotes'
 import {
@@ -106,7 +109,7 @@ export function defaultKeymap (): Extension {
     { key: 'Tab', run: maybeIndentList, shift: maybeUnindentList },
 
     // Overload Enter
-    { key: 'Enter', run: handleReplacement },
+    { key: 'Enter', run: handleAutocorrectEnter },
     { key: 'Enter', run: moveNextRow, shift: movePrevRow },
     // If no replacement can be handled, the default should be newlineAndIndent
     { key: 'Enter', run: insertNewlineContinueMarkup },
@@ -120,7 +123,7 @@ export function defaultKeymap (): Extension {
     { key: 'Backspace', run: handleBackspace },
 
     { key: 'Escape', run: abortSnippet },
-    { key: 'Space', run: handleReplacement },
+    { key: 'Space', run: handleAutocorrectSpace },
 
     { key: 'Alt-ArrowUp', run: customMoveLineUp, shift: copyLineUp },
     { key: 'Alt-ArrowDown', run: customMoveLineDown, shift: copyLineDown },


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below as well.

  First, the obligatory checklist. You must make sure to follow this list as
  much as possible to make merging your PR as easy as possible:

  1. I documented all behaviour within the code as far as I could.
  2. This PR targets the develop branch and *not* the master branch.
  3. I have tested my changes extensively and paid extra attention to potential
     cross-platform issues (e./g. Cmd/Ctrl/Super key bindings)
  4. I ran the `yarn lint` and `yarn test` commands successfully
  5. I have added an entry to the CHANGELOG.md
  6. I matched my code-style to the repository as far as possible
  7. I agree that my code will be published under the GNUP GPL v3 license
  8. In case I created new files, I added a header to them (see the existing
     files for examples)
  9. Before opening this PR, I ran `git pull` a last time to prevent any merge
     issues

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention those points where you are unsure. The more
  you can fulfill, the faster we can merge your PR, otherwise it will just take
  longer.
 -->

## Description
<!-- Below, please describe what the PR does in one or two short sentences. -->
This PR refactors autocorrect replacement handling to improve the UX of the undo history. It makes it so that, after an autocorrect replacement occurs, undoing the transaction first reverts the replacement without removing the inserted space/newline.

## Changes
<!-- What changes did you make? Please explicitly state any breaking API changes so that nobody is confused why other components suddenly stop working -->
The replacement handling was refactored into two commands, `handleAutocorrectSpace` and `handleAutocorrectEnter`, so that the respective `space` or `enter` text insertions can occur **before** the autocorrect replacement happens. This improves UX for undoing autocorrect replacements.

Because the replacement now occurs **after** the space or enter, when a user tries to undo the autocorrect replacement, they are able to do so without also removing the newly entered space or newline. 

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
Currently, when a user tries to undo the replacement, it undoes the entire initial text and insertion.

However, it's not as simple as adding the `isolateHistory` annotation. Then, they must undo the history twice, once to remove the space, and again to remove the replacement. This then throws the user into a precarious loop where, on the next space or newline, the replacement will be triggered *again* because the cursor is placed adjacent to the autocorrect text, and so the user is forced to do some gymnastics to prevent the autocorrect. 

This PR makes it so that a user has to undo the history once, and they can continue typing.

<!-- Please provide any testing system -->
Tested on: <!-- OS including version -->

macOS 26