### PR TITLE
Fix startup crash when restored files were deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ verify any of your exports.
 - Fix indenting and tab insertion behavior (#6196).
 - Fix Zettlr not correctly parsing Pandoc extensions (#6212).
 - Improved error handling when opening PDF attachments.
-- Prevent startup crashes when session restoration references files that were moved or deleted while Zettlr was closed (#6223).
+- Prevent startup crashes when session restoration references files that were
+  moved or deleted while Zettlr was closed (#6223).
 
 ## Under the Hood
 

--- a/source/app/service-providers/fsal/index.ts
+++ b/source/app/service-providers/fsal/index.ts
@@ -287,7 +287,7 @@ export default class FSAL extends ProviderContract {
         // Zettlr was not running. Skip those stale entries so startup can
         // continue and the remaining files/workspaces still load.
         const message = err instanceof Error ? err.message : String(err)
-        this._logger.warning(`[FSAL] Skipping stale path during reindex: ${absPath} (${message})`)
+        this._logger.error(`[FSAL] Skipping stale path during reindex: ${absPath} (${message})`)
       }
     }
 
@@ -310,14 +310,24 @@ export default class FSAL extends ProviderContract {
     const allDescriptors: AnyDescriptor[] = []
 
     for (const file of openFiles) {
-      allDescriptors.push(await this.getDescriptorFor(file))
+      try {
+        allDescriptors.push(await this.getDescriptorFor(file))
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        this._logger.error(`[FSAL] Skipping stale path while collecting descriptors: ${file} (${message})`)
+      }
     }
 
     for (const workspace of openWorkspaces) {
       const allPaths = await this.readDirectoryRecursively(workspace)
       for (const child of allPaths) {
-        const descriptor = await this.getDescriptorFor(child)
-        allDescriptors.push(descriptor)
+        try {
+          const descriptor = await this.getDescriptorFor(child)
+          allDescriptors.push(descriptor)
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err)
+          this._logger.error(`[FSAL] Skipping stale path while collecting descriptors: ${child} (${message})`)
+        }
       }
     }
 


### PR DESCRIPTION
## Description
Prevent session restore from aborting startup when `openFiles` includes a file path that no longer exists.

## Changes
- Wrap `getDescriptorFor(absPath)` in `FSAL.reindexFiles` with error handling.
- Skip stale file paths (moved/deleted while app was closed) and continue indexing remaining files/workspaces.
- Add an upcoming changelog entry for #6223.

## Additional information
This keeps the fix narrowly scoped to startup reindexing: missing paths are logged and ignored instead of throwing and terminating boot.

Tested on: Linux (WSL2) — ran `yarn lint:code source/app/service-providers/fsal/index.ts` successfully.

Fixes #6223