### PR TITLE
Fix: Allow triple-click selection in table cells by clamping to cell boundaries

### DIFF
--- a/source/common/modules/markdown-editor/table-editor/subview.ts
+++ b/source/common/modules/markdown-editor/table-editor/subview.ts
@@ -17,7 +17,7 @@
  */
 
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language'
-import { EditorState, MapMode, Prec, StateField, type ChangeSpec, type Range } from '@codemirror/state'
+import { EditorState, MapMode, Prec, StateField, EditorSelection, type ChangeSpec, type Range } from '@codemirror/state'
 import { EditorView, drawSelection, type DecorationSet, Decoration, ViewPlugin, type ViewUpdate } from '@codemirror/view'
 import markdownParser from '../parser/markdown-parser'
 import { tableEditorKeymap } from '../keymaps/table-editor'
@@ -66,21 +66,33 @@ const ensureBoundariesFilter = EditorState.transactionFilter.of((tr) => {
   // proper boundaries (they include any whitespace that was in the cell
   // before the view got instantiated, but exclude any whitespace added to the
   // cell after the fact.)
+  const mappedFrom = tr.changes.mapPos(cellFrom, -1, MapMode.TrackBefore)
+  const mappedTo =  tr.changes.mapPos(cellTo, 1, MapMode.TrackAfter)
+
+  const wasDeleted = mappedFrom === null || mappedTo === null
+
+  if (wasDeleted) {
+    return [] // Disallow this transaction
+  }
+
+  let newSelection = tr.selection
   if (tr.selection !== undefined) {
     const { from, to } = tr.selection.main
 
-    const mappedFrom = tr.changes.mapPos(cellFrom, -1, MapMode.TrackBefore)
-    const mappedTo =  tr.changes.mapPos(cellTo, 1, MapMode.TrackAfter)
-
-    const wasDeleted = mappedFrom === null || mappedTo === null
-
-    if (wasDeleted || from < mappedFrom || to > mappedTo) {
-      console.log(`Disallowing transaction: Selection: ${from} - ${to} | Cell: ${cellFrom} - ${cellTo} | Mapped: ${mappedFrom} - ${mappedTo}`)
-      return [] // Disallow this transaction
+    if (from < mappedFrom || to > mappedTo) {
+      const clampedRanges = tr.selection.ranges.map(range => {
+        const clampedAnchor = Math.max(mappedFrom, Math.min(mappedTo, range.anchor))
+        const clampedHead = Math.max(mappedFrom, Math.min(mappedTo, range.head))
+        return EditorSelection.range(clampedAnchor, clampedHead)
+      })
+      newSelection = EditorSelection.create(clampedRanges, tr.selection.mainIndex)
     }
   }
 
   if (!tr.docChanged) {
+    if (newSelection !== tr.selection) {
+      return { ...tr, selection: newSelection }
+    }
     return tr
   }
 
@@ -97,7 +109,7 @@ const ensureBoundariesFilter = EditorState.transactionFilter.of((tr) => {
     }
   })
 
-  return { ...tr, changes: safeChanges }
+  return { ...tr, changes: safeChanges, selection: newSelection }
 })
 
 interface hiddenSpanState {

--- a/source/common/modules/markdown-editor/table-editor/subview.ts
+++ b/source/common/modules/markdown-editor/table-editor/subview.ts
@@ -77,9 +77,13 @@ const ensureBoundariesFilter = EditorState.transactionFilter.of((tr) => {
 
   let newSelection = tr.selection
   if (tr.selection !== undefined) {
-    const { from, to } = tr.selection.main
+    // Check if ANY range (not just the main selection) exceeds the cell
+    // boundaries. If so, clamp all ranges to the cell's bounds.
+    const anyOutOfBounds = tr.selection.ranges.some(
+      range => range.from < mappedFrom || range.to > mappedTo
+    )
 
-    if (from < mappedFrom || to > mappedTo) {
+    if (anyOutOfBounds) {
       const clampedRanges = tr.selection.ranges.map(range => {
         const clampedAnchor = Math.max(mappedFrom, Math.min(mappedTo, range.anchor))
         const clampedHead = Math.max(mappedFrom, Math.min(mappedTo, range.head))


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
This PR fixes triple-click text selection inside table cells. Previously, a triple-click would attempt to select the entire line (which exceeds the cell's subview boundaries), causing the transaction to be outright disallowed — leaving the user unable to select all text in a cell with a triple-click.

The fix changes the boundary enforcement logic in `ensureBoundariesFilter `(in `subview.ts`) from disallowing out-of-bounds selection transactions to clamping them to the cell's boundaries instead. This allows triple-click select-all to work correctly within the cell.

## Changes
**`source/common/modules/markdown-editor/table-editor/subview.ts`**

- Replaced the blanket "disallow" behavior for out-of-bounds selections with clamping:
  if any selection range exceeds the cell boundaries, all ranges are clamped to the cell
  rather than the transaction being rejected.
- The existing `wasDeleted` guard is preserved — transactions that would delete the cell
  itself are still disallowed.

No breaking changes to public APIs or UX beyond the intended fix.

## Additional information
This fix was discussed in issue #6100. 

A "check-then-clamp" strategy was chosen over "always-clamp" after benchmarking. The guard avoids allocating new EditorSelection objects on every transaction during normal editing (the common case), where selections are already within bounds.
## AI Disclosure Statement

No AI was used in the development of this PR.

<!-- Tell us on which platforms you tested your changes. -->
Tested on: Windows 11
