### PR TITLE
Feature/open tabs at end

### DIFF
--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -233,6 +233,7 @@ export interface ConfigOptions {
     deleteOnFail: boolean
     leaveAppRunning: boolean
     avoidNewTabs: boolean
+    openTabsAtEnd: boolean
     iframeWhitelist: string[]
     checkForUpdates: boolean
     zoomBehavior: 'gui'|'editor'
@@ -498,6 +499,7 @@ export function getConfigTemplate (): ConfigOptions {
       deleteOnFail: false, // Whether to delete files if trashing them fails
       leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
       avoidNewTabs: false, // Whether to avoid opening new tabs for documents if possible
+      openTabsAtEnd: false, // Whether to always open new tabs at the end of the tab bar
       iframeWhitelist: [ 'www.youtube.com', 'player.vimeo.com' ], // Contains a list of whitelisted iFrame prerendering domains
       checkForUpdates: true,
       zoomBehavior: 'gui' // Used to determine what gets zoomed: The GUI or the editor

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -18,6 +18,7 @@ import { v4 as uuid4 } from 'uuid'
 import getLanguageFile from '@common/util/get-language-file'
 
 export type MarkdownTheme = 'berlin'|'frankfurt'|'bielefeld'|'karl-marx-stadt'|'bordeaux'
+export type TabOpeningBehavior = 'next_to_current'|'replace_current'|'end_of_bar'
 
 // This is a handy interface to add groups of file types to the settings in
 // order to allow users to display them in filemanager and/or sidebar, and open
@@ -232,8 +233,7 @@ export interface ConfigOptions {
   system: {
     deleteOnFail: boolean
     leaveAppRunning: boolean
-    avoidNewTabs: boolean
-    openTabsAtEnd: boolean
+    tabOpeningBehavior: TabOpeningBehavior
     iframeWhitelist: string[]
     checkForUpdates: boolean
     zoomBehavior: 'gui'|'editor'
@@ -498,8 +498,7 @@ export function getConfigTemplate (): ConfigOptions {
     system: {
       deleteOnFail: false, // Whether to delete files if trashing them fails
       leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
-      avoidNewTabs: false, // Whether to avoid opening new tabs for documents if possible
-      openTabsAtEnd: false, // Whether to always open new tabs at the end of the tab bar
+      tabOpeningBehavior: 'next_to_current',
       iframeWhitelist: [ 'www.youtube.com', 'player.vimeo.com' ], // Contains a list of whitelisted iFrame prerendering domains
       checkForUpdates: true,
       zoomBehavior: 'gui' // Used to determine what gets zoomed: The GUI or the editor

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -498,7 +498,7 @@ export function getConfigTemplate (): ConfigOptions {
     system: {
       deleteOnFail: false, // Whether to delete files if trashing them fails
       leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
-      tabOpeningBehavior: 'next_to_current',
+      tabOpeningBehavior: 'next-to-current',
       iframeWhitelist: [ 'www.youtube.com', 'player.vimeo.com' ], // Contains a list of whitelisted iFrame prerendering domains
       checkForUpdates: true,
       zoomBehavior: 'gui' // Used to determine what gets zoomed: The GUI or the editor

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -18,7 +18,7 @@ import { v4 as uuid4 } from 'uuid'
 import getLanguageFile from '@common/util/get-language-file'
 
 export type MarkdownTheme = 'berlin'|'frankfurt'|'bielefeld'|'karl-marx-stadt'|'bordeaux'
-export type TabOpeningBehavior = 'next_to_current'|'replace_current'|'end_of_bar'
+export type TabOpeningBehavior = 'next-to-current'|'replace-current'|'end'
 
 // This is a handy interface to add groups of file types to the settings in
 // order to allow users to display them in filemanager and/or sidebar, and open

--- a/source/app/service-providers/config/index.ts
+++ b/source/app/service-providers/config/index.ts
@@ -286,6 +286,22 @@ export default class ConfigProvider extends ProviderContract {
         }
       }
     } // END: openPaths migration
+
+    // Migrate old tab opening booleans to the unified enum setting.
+    if ('system' in readConfig && typeof readConfig.system === 'object') {
+      const { avoidNewTabs, openTabsAtEnd } = readConfig.system
+      if (!('tabOpeningBehavior' in readConfig.system)) {
+        if (avoidNewTabs === true) {
+          readConfig.system.tabOpeningBehavior = 'replace_current'
+        } else if (openTabsAtEnd === true) {
+          readConfig.system.tabOpeningBehavior = 'end_of_bar'
+        } else {
+          readConfig.system.tabOpeningBehavior = 'next_to_current'
+        }
+      }
+      delete readConfig.system.avoidNewTabs
+      delete readConfig.system.openTabsAtEnd
+    }
   }
 
   /**

--- a/source/app/service-providers/documents/document-tree/tab-manager.ts
+++ b/source/app/service-providers/documents/document-tree/tab-manager.ts
@@ -131,7 +131,7 @@ export class TabManager {
    *
    * @return  {Promise<boolean>}        True upon successful opening
    */
-  public openFile (filePath: string, modifyHistory?: boolean): boolean {
+  public openFile (filePath: string, modifyHistory?: boolean, openAtEnd?: boolean): boolean {
     if (this.activeFile?.path === filePath) {
       return false
     }
@@ -158,7 +158,7 @@ export class TabManager {
 
     const file: OpenDocument = { path: filePath, pinned: false }
 
-    if (this._activeFile !== null) {
+    if (this._activeFile !== null && openAtEnd !== true) {
       // ... behind our active file
       const idx = this._openFiles.indexOf(this._activeFile)
       this._openFiles.splice(idx + 1, 0, file)

--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -893,7 +893,8 @@ current contents from the editor somewhere else, and restart the application.`
     // (previously) active file *before* opening the new one. See bug #5065 for
     // context.
     const activeFile = leaf.tabMan.activeFile
-    const ret = leaf.tabMan.openFile(filePath)
+    const { openTabsAtEnd } = this._app.config.get().system
+    const ret = leaf.tabMan.openFile(filePath, undefined, openTabsAtEnd)
     if (ret) {
       this.broadcastEvent(DP_EVENTS.OPEN_FILE, { windowId, leafId, filePath })
     }

--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -893,16 +893,17 @@ current contents from the editor somewhere else, and restart the application.`
     // (previously) active file *before* opening the new one. See bug #5065 for
     // context.
     const activeFile = leaf.tabMan.activeFile
-    const { openTabsAtEnd } = this._app.config.get().system
-    const ret = leaf.tabMan.openFile(filePath, undefined, openTabsAtEnd)
+    const { tabOpeningBehavior } = this._app.config.get().system
+    const openAtEnd = tabOpeningBehavior === 'end_of_bar'
+    const replaceCurrentTab = tabOpeningBehavior === 'replace_current'
+    const ret = leaf.tabMan.openFile(filePath, undefined, openAtEnd)
     if (ret) {
       this.broadcastEvent(DP_EVENTS.OPEN_FILE, { windowId, leafId, filePath })
     }
 
-    // Close the (formerly active) file if we should avoid new tabs and have not
-    // gotten a specific request to open it in a *new* tab
-    const { avoidNewTabs } = this._app.config.get().system
-    if (activeFile !== null && avoidNewTabs && newTab !== true && !this.isModified(activeFile.path)) {
+    // In replace mode we close the previously active tab unless explicitly
+    // requested to keep it by opening the target in a new tab.
+    if (activeFile !== null && replaceCurrentTab && newTab !== true && !this.isModified(activeFile.path)) {
       leaf.tabMan.closeFile(activeFile)
       this.syncWatchedFilePaths()
       this.broadcastEvent(DP_EVENTS.CLOSE_FILE, { windowId, leafId, filePath: activeFile.path })

--- a/source/common/modules/markdown-editor/tooltips/file-preview.ts
+++ b/source/common/modules/markdown-editor/tooltips/file-preview.ts
@@ -145,10 +145,9 @@ function getPreviewElement (metadata: FindFileAndReturnMetadataResult, linkConte
   openButton.addEventListener('click', openFunc)
   actions.appendChild(openButton)
 
-  // Only if preference "Avoid New Tabs" is set,
-  // offer an additional button on preview tooltip
-  // to open the file in a new tab
-  if (window.config.get('system.avoidNewTabs') === true) {
+  // In "replace current tab" mode, offer an extra button to force opening
+  // in a dedicated new tab.
+  if (window.config.get('system.tabOpeningBehavior') === 'replace_current') {
     const openFuncNewTab = function (): void {
       ipcRenderer.invoke('application', {
         command: 'force-open',

--- a/source/win-preferences/schema/general.ts
+++ b/source/win-preferences/schema/general.ts
@@ -98,14 +98,18 @@ export function getGeneralFields (appLangOptions: Record<string, string>): Prefe
           model: 'alwaysReloadFiles'
         },
         {
-          type: 'checkbox',
-          label: trans('Avoid opening files in new tabs if possible'),
-          model: 'system.avoidNewTabs'
+          type: 'form-text',
+          display: 'sub-heading',
+          contents: trans('Opening Files Behavior')
         },
         {
-          type: 'checkbox',
-          label: trans('Always open new tabs at the end of the tab bar'),
-          model: 'system.openTabsAtEnd'
+          type: 'radio',
+          model: 'system.tabOpeningBehavior',
+          options: {
+            next_to_current: trans('Open next to the current tab'),
+            replace_current: trans('Replace the current tab if possible'),
+            end_of_bar: trans('Open at the end of the tab bar')
+          }
         }
       ]
     },

--- a/source/win-preferences/schema/general.ts
+++ b/source/win-preferences/schema/general.ts
@@ -4,7 +4,7 @@
  *
  * Contains:        General Preferences Schema
  * CVM-Role:        Model
- * Maintainer:      Hendrik Erz
+ * Maintainer:      Zilu Wang
  * License:         GNU GPL v3
  *
  * Description:     Exports the general tab schema.

--- a/source/win-preferences/schema/general.ts
+++ b/source/win-preferences/schema/general.ts
@@ -100,15 +100,15 @@ export function getGeneralFields (appLangOptions: Record<string, string>): Prefe
         {
           type: 'form-text',
           display: 'sub-heading',
-          contents: trans('Opening Files Behavior')
+          contents: trans('Opening files behavior')
         },
         {
           type: 'radio',
           model: 'system.tabOpeningBehavior',
           options: {
-            next_to_current: trans('Open next to the current tab'),
-            replace_current: trans('Replace the current tab if possible'),
-            end_of_bar: trans('Open at the end of the tab bar')
+            next_to_current: trans('Open next to the current file'),
+            replace_current: trans('Replace the current tab'),
+            end_of_bar: trans('Open at the end')
           }
         }
       ]

--- a/source/win-preferences/schema/general.ts
+++ b/source/win-preferences/schema/general.ts
@@ -101,6 +101,11 @@ export function getGeneralFields (appLangOptions: Record<string, string>): Prefe
           type: 'checkbox',
           label: trans('Avoid opening files in new tabs if possible'),
           model: 'system.avoidNewTabs'
+        },
+        {
+          type: 'checkbox',
+          label: trans('Always open new tabs at the end of the tab bar'),
+          model: 'system.openTabsAtEnd'
         }
       ]
     },


### PR DESCRIPTION
## Description

Add a new "Open tabs at end" option for tab opening behavior. This allows users to choose whether new tabs open next to the current tab (default), replace the current tab, or always open at the end of the tab bar.

## Changes

1. Added a new enum value end_of_bar to the tab opening behavior setting.
2. Updated config migration logic to unify legacy booleans (avoidNewTabs, openTabsAtEnd) into the new tabOpeningBehavior enum.
3. Modified tab opening logic in the tab manager and document service to support opening new tabs at the end of the tab bar.
4. Updated Preferences UI to expose the new option under "Opening files behavior".
5. Updated config template types to include the new enum value.

No breaking changes.

## Additional information

1. The migration logic ensures backward compatibility with existing user configs.
2. The feature is accessible via General → Behavior → Opening files behavior.

Tested on: macOS 26.3.1 (a) (M4 Pro)
