### PR TITLE
feat: visual cue + manual Revert for externally changed files

### DIFF
--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -138,6 +138,7 @@ export type DocumentManagerIPCAPI = IPCAPI<{
   'set-pinned': LeafLoc & { path: string, pinned: boolean }
   'retrieve-tab-config': { windowId: string }
   'save-file': { path: string }
+  'revert-file': { path: string }
   'open-file': LeafLoc & { path: string, newTab: boolean }
   'close-file': LeafLoc & { path: string }
   'close-file-everywhere': { path: string }
@@ -295,6 +296,9 @@ export default class DocumentManager extends ProviderContract {
         }
         case 'save-file': {
           return await this.saveFile(payload.path)
+        }
+        case 'revert-file': {
+          return await this.revertFile(payload.path)
         }
         case 'open-file': {
           const { windowId, leafId, path, newTab } = payload
@@ -1295,6 +1299,33 @@ current contents from the editor somewhere else, and restart the application.`
     leaf.tabMan.setPinnedStatus(filePath, shouldBePinned)
     this.broadcastEvent(DP_EVENTS.CHANGE_FILE_STATUS, { windowId, leafId, filePath, status: 'pinned' })
     this.syncToConfig()
+  }
+
+  /**
+   * Force-reloads the given file from disk, discarding any in-memory buffer.
+   * Intended for the user-initiated "Revert" command, which is needed when
+   * the watcher missed an external change (or when the modtime guard in
+   * handleRemoteChange short-circuited).
+   *
+   * @param {string} filePath The file in question
+   */
+  public async revertFile (filePath: string): Promise<boolean> {
+    const doc = this.documents.find(d => d.filePath === filePath)
+    if (doc === undefined) {
+      return false
+    }
+
+    // Refresh the descriptor so the next getDocument() call sees the
+    // current on-disk modtime/content rather than the stale cached one.
+    try {
+      const metadata = await this._app.fsal.getFilesystemMetadata(filePath)
+      doc.descriptor.modtime = metadata.modtime
+    } catch (err: any) {
+      this._app.log.warning(`[DocumentManager] Could not refresh descriptor for ${filePath} during revert: ${err.message as string}`)
+    }
+
+    await this.notifyRemoteChange(filePath)
+    return true
   }
 
   /**

--- a/source/app/service-providers/menu/menu.darwin.ts
+++ b/source/app/service-providers/menu/menu.darwin.ts
@@ -211,6 +211,14 @@ export default function getMenu (
           }
         },
         {
+          id: 'menu.revert_file',
+          label: trans('Revert (reload from disk)'),
+          accelerator: 'Cmd+Alt+R',
+          click: function (_menuItem, focusedWindow) {
+            (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'revert-file')
+          }
+        },
+        {
           type: 'separator'
         },
         {

--- a/source/app/service-providers/menu/menu.win32.ts
+++ b/source/app/service-providers/menu/menu.win32.ts
@@ -178,6 +178,14 @@ export default function getMenu (
           }
         },
         {
+          id: 'menu.revert_file',
+          label: trans('Revert (reload from disk)'),
+          accelerator: 'Ctrl+Alt+R',
+          click: function (_menuItem, focusedWindow) {
+            (focusedWindow as BrowserWindow|undefined)?.webContents.send('shortcut', 'revert-file')
+          }
+        },
+        {
           type: 'separator'
         },
         {

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -13,6 +13,17 @@
     <div v-bind:id="`cm-text-${props.leafId}`">
       <!-- This element will be replaced with Codemirror's wrapper element on mount -->
     </div>
+    <Transition name="remote-reload-cue">
+      <div
+        v-if="showRemoteReloadCue"
+        class="remote-reload-cue"
+        role="status"
+        v-bind:aria-label="trans('Reloaded from disk')"
+      >
+        <clr-icon shape="sync"></clr-icon>
+        {{ trans('Reloaded from disk') }}
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -36,6 +47,7 @@
 import MarkdownEditor, { type EditorViewPersistentState } from '@common/modules/markdown-editor'
 
 import { ref, computed, onMounted, onBeforeUnmount, watch, toRef, onUpdated } from 'vue'
+import { trans } from '@common/i18n-renderer'
 import { type EditorCommands } from './App.vue'
 import { hasMarkdownExt } from '@common/util/file-extention-checks'
 import { DP_EVENTS, type OpenDocument } from '@dts/common/documents'
@@ -119,6 +131,15 @@ ipcRenderer.on('shortcut', (event, command) => {
         }
       })
       .catch(e => console.error(e))
+  } else if (command === 'revert-file') {
+    // Force-reload the active file from disk, discarding the in-memory buffer.
+    // The visible reload cue is driven by the FILE_REMOTELY_CHANGED broadcast
+    // that revertFile -> notifyRemoteChange emits.
+    ipcRenderer.invoke('documents-provider', {
+      command: 'revert-file',
+      payload: { path: props.file.path }
+    } as DocumentManagerIPCAPI)
+      .catch(e => console.error(e))
   } else if (command === 'search') {
     currentEditor.toggleSearchPanel()
   } else if (command === 'toggle-typewriter-mode') {
@@ -137,6 +158,16 @@ ipcRenderer.on('documents-update', (e, payload: { event: DP_EVENTS, context: Doc
     // that the document provider has already reloaded the document and we only
     // need to tell the main editor to reload it as well.
     currentEditor?.reload().catch(e => console.error(e))
+    // Surface a brief visual cue so the user notices the buffer was swapped
+    // out from under them (e.g., after an external tool edited the file).
+    showRemoteReloadCue.value = true
+    if (remoteReloadCueTimeout !== null) {
+      clearTimeout(remoteReloadCueTimeout)
+    }
+    remoteReloadCueTimeout = setTimeout(() => {
+      showRemoteReloadCue.value = false
+      remoteReloadCueTimeout = null
+    }, 2500)
   } else if (event === DP_EVENTS.FILE_SAVED && context.filePath === props.file.path) {
     // The file has been saved to disk. This means we should probably update the
     // descriptor to know of, e.g., library changes.
@@ -180,6 +211,10 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  if (remoteReloadCueTimeout !== null) {
+    clearTimeout(remoteReloadCueTimeout)
+    remoteReloadCueTimeout = null
+  }
   if (currentEditor !== null) {
     props.persistentStateMap.set(props.file.path, currentEditor.persistentState)
     // Clear out the table of contents before unmounting the component.
@@ -213,6 +248,8 @@ onUpdated(() => {
 
 // DATA SETUP
 const mainEditorWrapper = ref<HTMLDivElement|null>(null)
+const showRemoteReloadCue = ref<boolean>(false)
+let remoteReloadCueTimeout: ReturnType<typeof setTimeout>|null = null
 
 // COMPUTED PROPERTIES
 const useH1 = computed<boolean>(() => configStore.config.fileNameDisplay.includes('heading'))
@@ -697,6 +734,40 @@ function maybeHighlightSearchResults (): void {
   background-color: #ffffff;
   transition: 0.2s background-color ease;
   position: relative;
+
+  .remote-reload-cue {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    pointer-events: none;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background-color: rgba(40, 40, 40, 0.92);
+    color: #ffffff;
+    font-size: 13px;
+    line-height: 1.2;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+
+    clr-icon { color: #ffffff; }
+  }
+
+  // Fade in / fade out the remote-reload cue. The cue itself is only
+  // mounted for ~2.5s after an external reload (see ipc handler above).
+  .remote-reload-cue-enter-active,
+  .remote-reload-cue-leave-active {
+    transition: opacity 250ms ease, transform 250ms ease;
+  }
+
+  .remote-reload-cue-enter-from,
+  .remote-reload-cue-leave-to {
+    opacity: 0;
+    transform: translate(-50%, -6px);
+  }
 
   .cm-editor {
     .cm-scroller { padding: 50px 50px; }

--- a/source/win-preferences/schema/general.ts
+++ b/source/win-preferences/schema/general.ts
@@ -94,8 +94,13 @@ export function getGeneralFields (appLangOptions: Record<string, string>): Prefe
       fields: [
         {
           type: 'checkbox',
-          label: trans('Always load remote changes to the current file'),
+          label: trans('Automatically reload files changed externally'),
           model: 'alwaysReloadFiles'
+        },
+        {
+          type: 'form-text',
+          display: 'info',
+          contents: trans('When enabled, Zettlr silently reloads the editor buffer if the file changes on disk and you have no unsaved changes. A brief notification appears so you know the buffer was refreshed. If you have unsaved changes, Zettlr will always ask before discarding them.')
         },
         {
           type: 'checkbox',


### PR DESCRIPTION
Closes #6354.

## Summary

- **Visual cue on auto-reload** — when `DocumentManager` broadcasts `FILE_REMOTELY_CHANGED` and the editor swaps its buffer, `MainEditor.vue` now shows a brief pill ("Reloaded from disk") at the top of the affected pane. Fades in/out over ~2.5s, animated via a `<Transition>`. Pre-existing silent-reload behaviour for clean buffers is preserved; only the visibility of it changes.
- **`Revert (reload from disk)` command** — new entry on the File menu (under Save) with accelerator `Cmd+Alt+R` / `Ctrl+Alt+R`. Forces a fresh read from disk for the active file, useful when the chokidar watcher missed a change or `handleRemoteChange`'s `modtime <= ourModtime` short-circuit fired on a sub-second external write. Wired via a new `revert-file` route on `documents-provider` and a `DocumentManager.revertFile()` method that refreshes the descriptor's modtime and then reuses the existing `notifyRemoteChange()` path. No bypass of the unsaved-changes check is introduced via the watcher path — but a deliberate user "Revert" is treated as intent and discards the buffer (mirrors the user already confirming "Load changes from disk" in the dialog).
- **Clearer Preferences copy** — relabels `alwaysReloadFiles` to "Automatically reload files changed externally" and adds an info line explaining when auto-reload kicks in (clean buffer) vs. when the prompt appears (dirty buffer).

## Why

Increasingly common scenario: an LLM/agent edits the open file on disk. Today the buffer may silently update (good) or may silently fail to update if the watcher missed the event or the modtime guard tripped (bad), and there's no manual recovery short of closing/reopening the tab (see #37). This PR surfaces what already happens and adds a recovery path for what doesn't.

## Implementation notes

- No new dependencies.
- `DocumentManager.revertFile()` is additive; the existing `handleRemoteChange` flow (prompt + `alwaysReloadFiles`) is untouched.
- The `<Transition>` and CSS for the cue are scoped to `.main-editor-wrapper` in `MainEditor.vue`; the existing `clr-icon` custom element is used (matches sidebar/file-manager conventions).
- The cue uses `trans()`; the English source string ("Reloaded from disk", "Revert (reload from disk)", and the new Preferences copy) falls back to the msgid if not yet translated, so this PR doesn't touch `.po` files.

## Disclosure

The implementation was produced with assistance from Claude (Anthropic). I reviewed every change; happy to iterate on scope, naming, accelerator choice, or visual treatment.

## Test plan

- [x] `yarn lint:types` (vue-tsc --noEmit) — passes, no new errors.
- [x] `yarn lint:code` — 0 errors. (169 pre-existing warnings, none introduced.)
- [x] `yarn test` — 375 passing.
- [ ] Maintainer smoke test: open a Markdown file, edit it externally with another editor or `sed -i`, confirm the cue appears and the buffer updates.
- [ ] Maintainer smoke test: with unsaved changes in the buffer, edit externally — confirm the existing dialog still appears (no regression).
- [ ] Maintainer smoke test: trigger `File → Revert (reload from disk)` and confirm the active file reloads + the cue appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)