### PR TITLE
feat: apply list formatting > toggle list formatting

### DIFF
--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -247,6 +247,8 @@ export interface ConfigOptions {
     showMarkdownLinkButton: boolean
     showMarkdownImageButton: boolean
     showMarkdownMakeTaskListButton: boolean
+    showMarkdownMakeOrderedListButton: boolean
+    showMarkdownMakeBulletListButton: boolean
     showInsertTableButton: boolean
     showInsertFootnoteButton: boolean
     showDocumentInfoText: boolean
@@ -513,6 +515,8 @@ export function getConfigTemplate (): ConfigOptions {
       showMarkdownLinkButton: true,
       showMarkdownImageButton: true,
       showMarkdownMakeTaskListButton: true,
+      showMarkdownMakeOrderedListButton: true,
+      showMarkdownMakeBulletListButton: true,
       showInsertTableButton: true,
       showInsertFootnoteButton: true,
       showDocumentInfoText: true,

--- a/source/common/modules/markdown-editor/commands/markdown.ts
+++ b/source/common/modules/markdown-editor/commands/markdown.ts
@@ -132,6 +132,24 @@ function insertPandocDiv (target: EditorView, attributes: string): void {
 }
 
 /**
+ * Helper function that removes only heading and blockquote markup from a line,
+ * leaving list markers intact.
+ *
+ * @param   {string}  line  The line text
+ *
+ * @return  {string}        The line text without heading/blockquote markup
+ */
+function removeHeadingAndBlockquoteMarkup (line: string): string {
+  let match
+  if ((match = /^#{1,6}\s+/.exec(line)) !== null) {
+    return line.substring(match[0].length)
+  } else if ((match = /^(\s{,3})>\s/.exec(line)) !== null) {
+    return match[1] + line.substring(match[0].length)
+  }
+  return line
+}
+
+/**
  * Helper function that removes block level markup from the provided line
  *
  * @param   {string}  line  The line text
@@ -140,9 +158,18 @@ function insertPandocDiv (target: EditorView, attributes: string): void {
  */
 function removeBlockMarkup (line: string): string {
   let match
-  if ((match = /^#{1,6}\s+/.exec(line)) !== null) {
-    return line.substring(match[0].length)
-  } else if ((match = /^(\s{,3})>\s/.exec(line)) !== null) {
+  const withoutHeading = removeHeadingAndBlockquoteMarkup(line)
+  if (withoutHeading !== line) {
+    return withoutHeading
+  } else if ((match = /^(\s*)- \[.\] /.exec(line)) !== null) {
+    return match[1] + line.substring(match[0].length)
+  } else if ((match = /^(\s*)\* /.exec(line)) !== null) {
+    return match[1] + line.substring(match[0].length)
+  } else if ((match = /^(\s*)- /.exec(line)) !== null) {
+    return match[1] + line.substring(match[0].length)
+  } else if ((match = /^(\s*)\+ /.exec(line)) !== null) {
+    return match[1] + line.substring(match[0].length)
+  } else if ((match = /^(\s*)\d+\. /.exec(line)) !== null) {
     return match[1] + line.substring(match[0].length)
   }
   return line
@@ -167,12 +194,15 @@ function applyBlockMarkup (target: EditorView, formatting: string): void {
     for (let i = startLine; i <= endLine; i++) {
       // TODO: Test if this does what it should do
       const line = target.state.doc.line(i)
-      const withoutBlocks = removeBlockMarkup(line.text)
+      const withoutBlocks = removeHeadingAndBlockquoteMarkup(line.text)
       offsetCharacters += line.text.length - withoutBlocks.length + formatting.length + 1
       changes.push({ from: line.from, to: line.to, insert: formatting + ' ' + withoutBlocks })
     }
 
-    return { changes, range: EditorSelection.range(range.from, range.to + offsetCharacters) }
+    const newDocLength = target.state.doc.length + changes.reduce((acc, c: any) => acc + (c.insert?.length ?? 0) - (c.to - c.from), 0)
+    const newTo = Math.min(Math.max(0, range.to + offsetCharacters), newDocLength)
+    const newFrom = Math.min(range.from, newTo)
+    return { changes, range: EditorSelection.range(newFrom, newTo) }
   })
 
   target.dispatch(transaction)
@@ -238,8 +268,28 @@ function applyInlineMarkup (target: EditorView, start: string, end: string): voi
 }
 
 /**
+ * Returns true if the given line text already matches the specified list type.
+ *
+ * @param   {string}            text  The line text
+ * @param   {'ul'|'ol'|'task'}  type  The list type to check for
+ */
+function lineMatchesType (text: string, type: 'ul'|'ol'|'task'): boolean {
+  // Strip leading blockquote markers before checking list type
+  const stripped = text.replace(/^([ ]{0,3}>[ \t])+/, '')
+  if (type === 'task') {
+    return /^\s*- \[.\] /.test(stripped)
+  } else if (type === 'ul') {
+    return /^\s*[*\-+] /.test(stripped) && !/^\s*- \[.\] /.test(stripped)
+  } else {
+    return /^\s*\d+\. /.test(stripped)
+  }
+}
+
+/**
  * Helper function that turns the selection ranges into the provided type of
- * list type.
+ * list type. If the lines are already formatted as the given list type, the
+ * formatting is removed. If they are formatted as a different list type, the
+ * formatting is replaced.
  *
  * @param   {EditorView}        target  The target view
  * @param   {'ul'|'ol'|'task'}  type    The list type
@@ -248,22 +298,56 @@ function applyList (target: EditorView, type: 'ul'|'ol'|'task'): void {
   const transaction = target.state.changeByRange(range => {
     const startLine = target.state.doc.lineAt(range.from).number
     const endLine = target.state.doc.lineAt(range.to).number
-
     const changes: ChangeSpec[] = []
-
     let offsetCharacters = 0
 
+    const nonBlankLines = Array.from({ length: endLine - startLine + 1 }, (_, i) => {
+      return target.state.doc.line(startLine + i)
+    }).filter(line => line.text.trim() !== '')
+
+    const allMatch = nonBlankLines.length > 0 && nonBlankLines.every(line => lineMatchesType(line.text, type))
+
+    const olCounters = new Map<string, number>()
     for (let i = startLine; i <= endLine; i++) {
       const line = target.state.doc.line(i)
-      const withoutBlocks = removeBlockMarkup(line.text)
-      const formatting = (type === 'ol') ? `${i - startLine + 1}.` : (type === 'ul') ? '*' : '- [ ]'
-      offsetCharacters += line.text.length - withoutBlocks.length + formatting.length + 1
-      changes.push({ from: line.from, to: line.to, insert: formatting + ' ' + withoutBlocks })
+
+      if (nonBlankLines.length > 0 && line.text.trim() === '') {
+        continue
+      }
+
+      const blockquotePrefix = /^([ ]{0,3}>[ \t])+/.exec(line.text)?.[0] ?? ''
+      const afterBlockquote = line.text.substring(blockquotePrefix.length)
+      const indent = /^(\s*)/.exec(afterBlockquote)![1]
+      const withoutBlocks = removeBlockMarkup(afterBlockquote)
+      const withoutIndent = withoutBlocks.substring(indent.length)
+
+      if (allMatch) {
+        offsetCharacters += (blockquotePrefix + withoutBlocks).length - line.text.length
+        changes.push({ from: line.from, to: line.to, insert: blockquotePrefix + withoutBlocks })
+      } else {
+        let formatting: string
+        if (type === 'ol') {
+          const count = olCounters.get(indent) ?? 0
+          olCounters.set(indent, count + 1)
+          for (const key of olCounters.keys()) {
+            if (key.length > indent.length) {
+              olCounters.delete(key)
+            }
+          }
+          formatting = `${count + 1}.`
+        } else {
+          formatting = type === 'ul' ? '*' : '- [ ]'
+        }
+        const insert = blockquotePrefix + indent + formatting + ' ' + withoutIndent
+        offsetCharacters += insert.length - line.text.length
+        changes.push({ from: line.from, to: line.to, insert: insert })
+      }
     }
 
-    return { changes, range: EditorSelection.cursor(range.to + offsetCharacters) }
+    const newDocLength = target.state.doc.length + changes.reduce((acc, c: any) => acc + (c.insert?.length ?? 0) - (c.to - c.from), 0)
+    const cursorPos = Math.min(Math.max(0, range.to + offsetCharacters), newDocLength)
+    return { changes, range: EditorSelection.cursor(cursorPos) }
   })
-
   target.dispatch(transaction)
 }
 

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -207,17 +207,19 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
       action () { insertLink(view) }
     },
     {
-      label: trans('Insert unordered list'),
+      label: trans('Toggle unordered list'),
+      accelerator: 'CmdOrCtrl+Shift+B',
       type: 'normal',
       action () { applyBulletList(view) }
     },
     {
-      label: trans('Insert numbered list'),
+      label: trans('Toggle numbered list'),
+      accelerator: 'CmdOrCtrl+Shift+O',
       type: 'normal',
       action () { applyOrderedList(view) }
     },
     {
-      label: trans('Insert task list'),
+      label: trans('Toggle task list'),
       accelerator: 'CmdOrCtrl+T',
       type: 'normal',
       action () { applyTaskList(view) }

--- a/source/common/modules/markdown-editor/index.ts
+++ b/source/common/modules/markdown-editor/index.ts
@@ -73,6 +73,8 @@ import {
 import {
   applyComment,
   applyTaskList,
+  applyOrderedList,
+  applyBulletList,
   insertImage,
   insertLink,
   applyPandocDivOrSpan
@@ -604,6 +606,12 @@ export default class MarkdownEditor extends EventEmitter {
         break
       case 'markdownMakeTaskList':
         applyTaskList(this._instance)
+        break
+      case 'markdownMakeOrderedList':
+        applyOrderedList(this._instance)
+        break
+      case 'markdownMakeBulletList':
+        applyBulletList(this._instance)
         break
       default:
         console.warn('Unimplemented command:', cmd)

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -61,7 +61,7 @@ import {
   maybeIndentList, maybeUnindentList, customMoveLineUp, customMoveLineDown
 } from '../commands/lists'
 import {
-  insertLink, insertImage, applyBold, applyItalic, applyComment, applyTaskList,
+  insertLink, insertImage, applyBold, applyItalic, applyComment, applyTaskList, applyOrderedList, applyBulletList,
   applyHighlight,
   insertTabOrSpace
 } from '../commands/markdown'
@@ -131,6 +131,8 @@ export function defaultKeymap (): Extension {
     { key: 'Alt-ArrowUp', run: customMoveLineUp, shift: copyLineUp },
     { key: 'Alt-ArrowDown', run: customMoveLineDown, shift: copyLineDown },
     { key: 'Mod-t', run: applyTaskList },
+    { key: 'Mod-Shift-b', run: applyBulletList },
+    { key: 'Mod-Shift-o', run: applyOrderedList },
     { key: 'Mod-Shift-v', run: view => { pasteAsPlain(view); return true } },
     { key: 'Mod-Alt-c', run: view => { copyAsHTML(view); return true } },
     { key: '"', run: handleQuote('"') },

--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -544,9 +544,23 @@ const toolbarControls = computed<ToolbarControl[]>(() => {
     {
       type: 'button',
       id: 'markdownMakeTaskList',
-      title: trans('Insert task list'),
+      title: trans('Toggle task list'),
       icon: 'checkbox-list',
       visible: getToolbarButtonDisplay('showMarkdownMakeTaskListButton')
+    },
+    {
+      type: 'button',
+      id: 'markdownMakeOrderedList',
+      title: trans('Toggle numbered list'),
+      icon: 'number-list',
+      visible: getToolbarButtonDisplay('showMarkdownMakeOrderedListButton')
+    },
+    {
+      type: 'button',
+      id: 'markdownMakeBulletList',
+      title: trans('Toggle unordered list'),
+      icon: 'bullet-list',
+      visible: getToolbarButtonDisplay('showMarkdownMakeBulletListButton')
     },
     {
       type: 'button',

--- a/source/win-preferences/schema/appearance.ts
+++ b/source/win-preferences/schema/appearance.ts
@@ -170,8 +170,18 @@ export function getAppearanceFields (config: ConfigOptions): PreferencesFieldset
         },
         {
           type: 'checkbox',
-          label: trans('Display "Insert task list" button'),
+          label: trans('Display "Toggle task list" button'),
           model: 'displayToolbarButtons.showMarkdownMakeTaskListButton'
+        },
+        {
+          type: 'checkbox',
+          label: trans('Display "Toggle numbered list" button'),
+          model: 'displayToolbarButtons.showMarkdownMakeOrderedListButton'
+        },
+        {
+          type: 'checkbox',
+          label: trans('Display "Toggle unordered list" button'),
+          model: 'displayToolbarButtons.showMarkdownMakeBulletListButton'
         },
         {
           type: 'checkbox',


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

x  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
x  1. I documented the code extensively.
x  2. This PR targets the develop branch, *not* the master branch.
x  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
x  4. `yarn lint` and `yarn test` run successfully.
x  5. I followed the code-style of the repository.
x  6. I agree that my code will be published under the GNU GPL v3 license.
x  7. All new files have the correct license/description header (see existing
     files).
x  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
x  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->

I added functionality to edit lists (ul, ol, task lists) better in the markdown editor, such as being able to remove list formatting, change between formats, format nested lists, and format lists within blockquotes.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

"Insert [some type of] list" becomes "toggle [some type of] list." Choosing this option with a list selected will remove the list formatting.
Or, if you choose a different type of list (e.g., the text is formatted with a bulleted list, and you choose a numbered list), it will change it to a numbered list.
Some list and blockquote creation code has been separated so that they don't interfere with each other.
Toggling a list within a blockquote now works as expected.
When inserting lists, indented lines are respected, becoming nested lists
Added keyboard shortcuts for ordered (Ctrl+Shift+O) and unordered (Ctrl+Shift+B) lists. I'm not tied to these options; feel free to change them to something else.
Added toolbar buttons, as well as settings for displaying or not displaying these buttons.
When a selection contains blank and non-blank lines, inserting a list will only apply to the non-blank lines.
Fixed an error that popped up when the selection went to the end of the document (the selection went out of bounds).

No breaking changes as far as I know.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).

I used Claude Sonnet 4.6 to write the new functionality. I reviewed the code and understand what it does. I've tested it carefully.

<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->

Tested on Fedora 44 x86