### PR TITLE
feat: Add text direction toggle to editor configuration

### DIFF
--- a/source/app/service-providers/config/config-validation.ts
+++ b/source/app/service-providers/config/config-validation.ts
@@ -35,6 +35,7 @@ const RULES = {
   'editor.boldFormatting': 'required|string|in:__,**|default:**',
   'editor.italicFormatting': 'required|string|in:_,*|default:_',
   'editor.readabilityAlgorithm': 'required|string|in:dale-chall,gunning-fog,coleman-liau,automated-readability|default:dale-chall',
+  'editor.textDirection': 'required|string|in:ltr,rtl,auto|default:auto',
   cslLibrary: 'optional|string|default:',
   'display.imageWidth': 'required|number|min:1|max:100|default:100',
   'display.imageHeight': 'required|number|min:1|max:100|default:100',

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -150,6 +150,7 @@ export interface ConfigOptions {
     boldFormatting: '**'|'__'
     italicFormatting: '_'|'*'
     highlightFormatting: 'span'|'=='
+    textDirection: 'ltr'|'rtl'|'auto'
     readabilityAlgorithm: 'dale-chall'|'gunning-fog'|'coleman-liau'|'automated-readability'
     lint: {
       markdown: boolean
@@ -366,6 +367,7 @@ export function getConfigTemplate (): ConfigOptions {
       boldFormatting: '**', // Can be ** or __
       italicFormatting: '_', // Can be * or _
       highlightFormatting: '==', // Can be 'span' or ==
+      textDirection: 'auto', // Can be ltr, rtl, or auto
       readabilityAlgorithm: 'dale-chall', // The algorithm to use with readability mode.
       showStatusbar: true,
       showFormattingToolbar: true,

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -65,6 +65,7 @@ export interface EditorConfiguration {
   boldFormatting: '**'|'__'
   italicFormatting: '*'|'_'
   highlightFormatting: 'span'|'=='
+  textDirection: 'ltr'|'rtl'|'auto'
   citeStyle: 'in-text'|'in-text-suffix'|'regular'
   inputMode: 'default'|'vim'|'emacs'
   muteLines: boolean
@@ -130,6 +131,7 @@ export function getDefaultConfig (): EditorConfiguration {
     boldFormatting: '**',
     italicFormatting: '_',
     highlightFormatting: '==',
+    textDirection: 'auto',
     citeStyle: 'regular',
     muteLines: true,
     readabilityAlgorithm: 'dale-chall',

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -1,10 +1,11 @@
 <template>
-  <div
+    <div
     ref="mainEditorWrapper"
     class="main-editor-wrapper"
     role="region"
     v-bind:aria-label="`Markdown Editor: Currently editing file ${pathBasename(props.file.path)}`"
     v-bind:style="{ 'font-size': `${fontSize}px` }"
+    v-bind:dir="textDirection"
     v-bind:class="{
       'code-file': !isMarkdown,
       fullscreen: distractionFree
@@ -219,6 +220,9 @@ const mainEditorWrapper = ref<HTMLDivElement|null>(null)
 const useH1 = computed<boolean>(() => configStore.config.fileNameDisplay.includes('heading'))
 const useTitle = computed<boolean>(() => configStore.config.fileNameDisplay.includes('title'))
 const fontSize = computed<number>(() => configStore.config.editor.fontSize)
+const textDirection = computed<string>(() => {
+  return configStore.config.editor.textDirection
+})
 const globalSearchResults = computed(() => windowStateStore.searchResults)
 const snippets = computed(() => windowStateStore.snippets)
 const tags = computed(() => tagStore.tags)
@@ -253,6 +257,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     boldFormatting: editor.boldFormatting,
     italicFormatting: editor.italicFormatting,
     highlightFormatting: editor.highlightFormatting,
+    textDirection: editor.textDirection,
     muteLines: configStore.config.muteLines,
     citeStyle: editor.citeStyle,
     readabilityAlgorithm: editor.readabilityAlgorithm,

--- a/source/win-preferences/schema/editor.ts
+++ b/source/win-preferences/schema/editor.ts
@@ -37,11 +37,21 @@ export function getEditorFields (config: ConfigOptions): PreferencesFieldset[] {
     },
     {
       title: trans('Writing direction'),
-      infoString: trans('We are currently planning on re-introducing bidirectional writing support, which will then be configurable here.'),
+      infoString: trans('Controls the text direction of the editor. Choose "Auto" to let Zettlr automatically detect the writing direction based on the first character.'),
       group: PreferencesGroups.Editor,
       help: undefined, // TODO
       fields: [
-        // TODO: Add field for LTR/RTL
+        {
+          type: 'select',
+          model: 'editor.textDirection',
+          inline: true,
+          label: trans('Writing direction:'),
+          options: {
+            auto: trans('Auto detect'),
+            ltr: trans('Left-to-Right (LTR)'),
+            rtl: trans('Right-to-Left (RTL)')
+          }
+        }
       ]
     },
     {


### PR DESCRIPTION
## Description
This PR implements the text direction (writing direction) preference in the editor settings, replacing the placeholder that was previously in place, fixing #4596 . Users can now choose between Left-to-Right, Right-to-Left, or Auto-detect text direction, which is applied as the HTML `dir` attribute on the editor wrapper element.

## Changes
- Added `textDirection: 'ltr' | 'rtl' | 'auto'` to the `editor` config section in `ConfigOptions` (type + default)
- Added `textDirection` to the `EditorConfiguration` interface and its default config
- Replaced the "Writing direction" placeholder fieldset in the preferences schema with a working select field offering three options: Auto detect, LTR, RTL
- Mapped `editor.textDirection` through `MainEditor.vue` onto the editor wrapper div as a `dir` attribute
- Added validation rule for `editor.textDirection`
- No breaking changes — existing configs will receive the default `auto` via `safeAssign`

## Additional information
The `dir="auto"` value is natively supported by all browsers and automatically detects text direction based on the first strong directional character in the content, making this a zero-config sensible default.

## AI Disclosure Statement
This PR was implemented with assistance from Kilo code.
