### PR TITLE
fix: Update broken link in contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ You can pass additional [command-line switches](#command-line-switches) such as
 `--clear-cache` as well. They will be passed to the child process.
 
 Additionally, have a look at our
-[full development documentation](https://docs.zettlr.com/en/get-involved).
+[full development documentation](https://docs.zettlr.com/en/getting-started/get-involved/).
 
 #### `package`
 


### PR DESCRIPTION
## Description

The link was broken.

<img width="648" height="327" alt="image" src="https://github.com/user-attachments/assets/ba3e1099-1a8d-4e95-937a-3aac990e97cb" />


## Changes

I pointed the link at the updated English-language docs section.
