### PR TITLE
fix(ci): pin Windows build job to windows-2022 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,8 @@ jobs:
     env:
       npm_config_arch: x64
     needs: [preflight, verify_version]
-    runs-on: windows-latest
+    # Pin to windows-2022 until @electron/rebuild used by Forge supports VS 2026 on windows-latest.
+    runs-on: windows-2022
     steps:
       - name: Checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v6


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
Avoid VS 2026 on windows-latest until @electron/node-gyp used by Forge can detect Visual Studio 18.x during native module rebuilds.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).

<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->
