### PR TITLE
chore: reuse `posInNode` function

### DIFF
--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -68,7 +68,7 @@ export const handleReplacement: Command = (target: EditorView): boolean => {
     let pos = range.from - 1
 
     // Ignore those cursors that are inside protected nodes
-    if (posInNode(range.from, tree, PROTECTED_NODES, -1)) {
+    if (posInNode(pos, tree, PROTECTED_NODES, -1)) {
       continue
     }
 
@@ -85,7 +85,7 @@ export const handleReplacement: Command = (target: EditorView): boolean => {
 
     for (const { key, value } of replacements) {
       if (slice.endsWith(key)) {
-        const startOfReplacement = range.from - key.length
+        const startOfReplacement = pos - key.length
         if (posInNode(startOfReplacement, tree, PROTECTED_NODES, -1)) {
           break // `range.from` is not in a protected area, but start is.
         }

--- a/source/common/modules/markdown-editor/commands/autocorrect.ts
+++ b/source/common/modules/markdown-editor/commands/autocorrect.ts
@@ -15,49 +15,24 @@
 
 // The autocorrect plugin is basically just a keymap that listens to spaces and enters
 import { syntaxTree } from '@codemirror/language'
-import { EditorSelection, type ChangeSpec, type EditorState } from '@codemirror/state'
+import { EditorSelection, type ChangeSpec } from '@codemirror/state'
 import { type Command, type EditorView } from '@codemirror/view'
 import { configField } from '../util/configuration'
 import { insertNewlineAndIndent, isolateHistory } from '@codemirror/commands'
 import { insertNewlineContinueMarkup } from '@codemirror/lang-markdown'
+import { posInNode } from '../util/node-in-selection'
 
 // These characters can be directly followed by a starting magic quote
 const startChars = ' ([{-–—\n\r\t\v\f/\\'
 
-/**
- * Given the editor state and a position, this function returns whether the
- * position sits within a node that is protected from autocorrect. In those
- * cases, no autocorrection will be applied, regardless of whether there is a
- * suitable candidate.
- *
- * @param   {EditorState}  state  The state
- * @param   {number}       pos    The position to check
- *
- * @return  {boolean}             True if the position touches a protected node.
- */
-function posInProtectedNode (state: EditorState, pos: number): boolean {
-  const PROTECTED_NODES = [
-    'InlineCode', // `code`
-    'Comment', 'CommentBlock', // <!-- comment -->
-    'FencedCode', 'CodeText', // Code block
-    'HorizontalRule', // --- and ***
-    'YAMLFrontmatter',
-    'HTMLTag', 'HTMLBlock' // HTML elements
-  ]
-
-  let node = syntaxTree(state).resolveInner(pos, -1)
-
-  while (node.parent !== null) {
-    if (PROTECTED_NODES.includes(node.type.name)) {
-      return true
-    }
-
-    node = node.parent
-  }
-
-  // Neither the node itself, nor any of its parents, are protected.
-  return false
-}
+const PROTECTED_NODES = [
+  'InlineCode', // `code`
+  'Comment', 'CommentBlock', // <!-- comment -->
+  'FencedCode', 'CodeText', // Code block
+  'HorizontalRule', // --- and ***
+  'YAMLFrontmatter',
+  'HTMLTag', 'HTMLBlock' // HTML elements
+]
 
 // If Autocorrect is active, handles the potential text replacement
 export const handleReplacement: Command = (target: EditorView): boolean => {
@@ -81,6 +56,7 @@ export const handleReplacement: Command = (target: EditorView): boolean => {
   const maxKeyLength = replacements[0].key.length
   const changes: ChangeSpec[] = []
 
+  const tree = syntaxTree(target.state)
   for (const range of target.state.selection.ranges) {
     // Ignore selections (only cursors)
     if (!range.empty) {
@@ -92,7 +68,7 @@ export const handleReplacement: Command = (target: EditorView): boolean => {
     let pos = range.from - 1
 
     // Ignore those cursors that are inside protected nodes
-    if (posInProtectedNode(target.state, pos)) {
+    if (posInNode(range.from, tree, PROTECTED_NODES, -1)) {
       continue
     }
 
@@ -109,8 +85,8 @@ export const handleReplacement: Command = (target: EditorView): boolean => {
 
     for (const { key, value } of replacements) {
       if (slice.endsWith(key)) {
-        const startOfReplacement = pos - key.length
-        if (posInProtectedNode(target.state, startOfReplacement)) {
+        const startOfReplacement = range.from - key.length
+        if (posInNode(startOfReplacement, tree, PROTECTED_NODES, -1)) {
           break // `range.from` is not in a protected area, but start is.
         }
 
@@ -246,12 +222,14 @@ export function handleQuote (quote: string): Command {
     const secondary = autocorrect.magicQuotes.secondary.split('…')
     const quotes = (quote === '"') ? primary : secondary
 
+    const tree = syntaxTree(view.state)
+
     const transaction = view.state.changeByRange((range) => {
       // NOTE we're running through the hassle of definitely inserting quotes as
       // otherwise the quote character would be swallowed, even in "protected"
       // areas of the document.
-      const isFromProtected = posInProtectedNode(view.state, range.from)
-      const isToProtected = posInProtectedNode(view.state, range.to)
+      const isFromProtected = posInNode(range.from, tree, PROTECTED_NODES, -1)
+      const isToProtected = posInNode(range.to, tree, PROTECTED_NODES, -1)
 
       if (range.empty) {
         // Check the character before and insert an appropriate quote

--- a/source/common/modules/markdown-editor/plugins/default-context-menu.ts
+++ b/source/common/modules/markdown-editor/plugins/default-context-menu.ts
@@ -18,52 +18,7 @@ import { syntaxTree } from '@codemirror/language'
 import { EditorView } from '@codemirror/view'
 import { defaultMenu } from '../context-menu/default-menu'
 import { linkImageMenu } from '../context-menu/link-image-menu'
-import type { SyntaxNode } from '@lezer/common'
-import { NODES } from '../parser/citation-parser'
-import { citationMenu } from '../context-menu/citation-menu'
-
-/**
- * Takes an EditorView and a position within it, and returns either a SyntaxNode
- * of type URL, Link, or Image, or null. This information can be used to
- * determine whether there is any form of Link or image at the given position.
- *
- * @param   {EditorView}  view  The editor view
- * @param   {number}      pos   The position to check
-*
- * @return  {SyntaxNode|null}   Either a Link, Image, or URL syntax node, or null.
- */
-function getLinkOrImageNodeFromPos (view: EditorView, pos: number): SyntaxNode|null {
-  const node = syntaxTree(view.state).resolveInner(pos)
-
-  if ([ 'URL', 'Link', 'Image' ].includes(node.type.name)) {
-    return node
-  }
-
-  let nodeAt: SyntaxNode|null = node
-  while (nodeAt !== null && ![ 'Link', 'Image', 'LinkReference' ].includes(nodeAt.type.name)) {
-    nodeAt = nodeAt.parent
-  }
-
-  return nodeAt
-}
-
-/**
- * If available, returns a Citation node at the current position.
- *
- * @param   {EditorView}  view  The editor view
- * @param   {number}      pos   The position
- *
- * @return  {SyntaxNode}        Either the citation node, or null
- */
-function getCitationNodeFromPos (view: EditorView, pos: number): SyntaxNode|null {
-  let node: SyntaxNode|null = syntaxTree(view.state).resolveInner(pos)
-
-  while (node !== null && node.name !== NODES.CITATION) {
-    node = node.parent
-  }
-
-  return node
-}
+import { posInNode } from '../util/node-in-selection'
 
 export const defaultContextMenu = EditorView.domEventHandlers({
   contextmenu (event, view) {
@@ -75,8 +30,9 @@ export const defaultContextMenu = EditorView.domEventHandlers({
       return false // No context menu to show
     }
 
-    const maybeLinkNode = getLinkOrImageNodeFromPos(view, pos)
+    const tree = syntaxTree(view.state)
 
+    const maybeLinkNode = posInNode(pos, tree, [ 'URL', 'Link', 'Image', 'LinkReference' ])
     if (maybeLinkNode !== null) {
       // We can show a Link/Image context menu!
       linkImageMenu(view, maybeLinkNode, coords)
@@ -98,7 +54,7 @@ export const defaultContextMenu = EditorView.domEventHandlers({
       view.dispatch({ selection: wordAt })
     }
 
-    const node = syntaxTree(view.state).resolveInner(pos)
+    const node = tree.resolveInner(pos)
     defaultMenu(view, node, coords).catch(err => console.error(err))
     return true
   }

--- a/source/common/modules/markdown-editor/plugins/default-context-menu.ts
+++ b/source/common/modules/markdown-editor/plugins/default-context-menu.ts
@@ -19,6 +19,8 @@ import { EditorView } from '@codemirror/view'
 import { defaultMenu } from '../context-menu/default-menu'
 import { linkImageMenu } from '../context-menu/link-image-menu'
 import { posInNode } from '../util/node-in-selection'
+import { NODES } from '../parser/citation-parser'
+import { citationMenu } from '../context-menu/citation-menu'
 
 export const defaultContextMenu = EditorView.domEventHandlers({
   contextmenu (event, view) {
@@ -39,7 +41,7 @@ export const defaultContextMenu = EditorView.domEventHandlers({
       return true
     }
 
-    const citationNode = getCitationNodeFromPos(view, pos)
+    const citationNode = posInNode(pos, tree, [NODES.CITATION])
 
     if (citationNode !== null) {
       // We can show a citation menu

--- a/source/common/modules/markdown-editor/tooltips/hyperlinks.ts
+++ b/source/common/modules/markdown-editor/tooltips/hyperlinks.ts
@@ -21,6 +21,7 @@ import { trans } from '@common/i18n-renderer'
 import { pathDirname } from '@common/util/renderer-path-polyfill'
 import _ from 'underscore'
 import { findReferenceForLinkLabel } from '../util/links'
+import { posInNode } from '../util/node-in-selection'
 
 const ipcRenderer = window.ipc
 
@@ -33,51 +34,42 @@ function unescape (text: string): string {
  * Displays a tooltip for URLs and Links across a document
  */
 export function urlTooltip (view: EditorView, pos: number, side: 1 | -1): Tooltip|null {
-  let nodeAt = syntaxTree(view.state).cursorAt(pos, side).node
+  const tree = syntaxTree(view.state)
+  let node = posInNode(pos, tree, [ 'URL', 'Link', 'LinkReference' ], side)
 
-  // If the node here is a URL, it's quick, but if not, it must be a Link node
-  // that contains a URL as a child
-  if (nodeAt.type.name !== 'URL') {
-    // First, navigate to one of the two possible parent nodes.
-    while (nodeAt.parent !== null && ![ 'Link', 'LinkReference' ].includes(nodeAt.type.name)) {
-      nodeAt = nodeAt.parent
-    }
-
-    // Then, we can either have a "Link", which can either have an URL or a
-    // LinkLabel. If it has a LinkLabel, we must search the document for the
-    // corresponding counterpart.
-
-    if (nodeAt.type.name === 'Link') {
-      const urlNode = nodeAt.getChild('URL')
-      const labelNode = nodeAt.getChild('LinkLabel')
-      if (urlNode !== null) {
-        nodeAt = urlNode
-      } else if (labelNode !== null) {
-        const labelString = view.state.sliceDoc(labelNode.from, labelNode.to)
-        const ref = findReferenceForLinkLabel(view.state, labelString)
-      
-        if (ref !== null) {
-          const url = ref.getChild('URL')
-          if (url !== null) {
-            nodeAt = url
-          }
-        }
-      }
-    } else if (nodeAt.type.name === 'LinkReference') {
-      const url = nodeAt.getChild('URL')
-      if (url !== null) {
-        nodeAt = url
-      }
-    }
+  if (node === null) {
+    return null
   }
 
-  if (nodeAt.type.name !== 'URL') {
-    return null
+  // We either have a "Link", which can either have an URL, a  "LinkReference",
+  // or a "URL". If it has a "LinkReference", we must search the document for the
+  // corresponding counterpart.
+  if (node.name === 'Link') {
+    const urlNode = node.getChild('URL')
+    const labelNode = node.getChild('LinkLabel')
+    if (urlNode !== null) {
+      node = urlNode
+    } else if (labelNode !== null) {
+      const labelString = view.state.sliceDoc(labelNode.from, labelNode.to)
+      const ref = findReferenceForLinkLabel(view.state, labelString)
+
+      if (ref !== null) {
+        const url = ref.getChild('URL')
+        if (url !== null) {
+          node = url
+        }
+      }
+    }
+  } else if (node.name === 'LinkReference') {
+    const url = node.getChild('URL')
+    if (url !== null) {
+      node = url
+    }
   }
 
   // We got an URL.
   const absPath = view.state.field(configField).metadata.path
-  const url = view.state.sliceDoc(nodeAt.from, nodeAt.to)
+  const url = view.state.sliceDoc(node.from, node.to)
   const base = pathDirname(absPath)
   const validURI = makeValidUri(url, base)
 

--- a/source/common/modules/markdown-editor/util/node-in-selection.ts
+++ b/source/common/modules/markdown-editor/util/node-in-selection.ts
@@ -51,7 +51,7 @@ export function nodeInSelection (
  * @param   {-1|0|1}            side              How nodes shoud be entered.
  *                                                Passed to `SyntaxTree.resolveInner`
  *
- * @return  {boolean}                             `true` if the position touches a node.
+ * @return  {SyntaxNode|null}                     The inner-most node that the position touches.
  */
 export function posInNode (
   pos: number,


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
This PR reuses the `posInNode` function to centralize and deduplicate a lot of logic. It may have marginal performance improvements since calls to `syntaxTree` have been significantly reduced

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

The changes touch URL tooltip rendering, link and citation context menus, and autocorrect replacement logic, if you are looking to test the effects.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).
None


<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->
macOS 26