### PR TITLE
feat: snippet fixes and improvements

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -102,6 +102,17 @@ function applySnippet (view: EditorView, completion: Completion, from: number, t
 }
 
 /**
+ * Helper function to calculate the cursor association
+ * based on whether any ranges are directly before `pos`
+ */
+function getAssociation (selections: EditorSelection[], pos: number|undefined): -1|1 {
+  const isAdjacent = selections
+    .some(sel => sel.ranges.some(r => r.to === pos))
+
+  return isAdjacent ? -1 : 1
+}
+
+/**
  * Used internally to add ranges for the snippets to the state
  */
 const snippetTabsEffect = StateEffect.define<EditorSelection[]>()
@@ -121,13 +132,15 @@ export const snippetsUpdate = StateEffect.define<Array<{ name: string, content: 
 interface SnippetStateField {
   availableSnippets: Completion[]
   activeSelections: EditorSelection[]
+  association: number
 }
 
 export const snippetsUpdateField = StateField.define<SnippetStateField>({
   create (_state) {
     return {
       availableSnippets: [],
-      activeSelections: []
+      activeSelections: [],
+      association: 1,
     }
   },
   update (val, transaction) {
@@ -144,6 +157,12 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
         return { ...val }
       } else if (effect.is(snippetTabsEffect)) {
         val.activeSelections = effect.value
+
+        // Calculate the association when the effects come in
+        // because we need access to the current tab stop
+        // range, which is the `transaction.selection` value.
+        val.association = getAssociation(val.activeSelections, transaction.selection?.main.from)
+
         return { ...val }
       } else if (effect.is(shiftNextTabEffect)) {
         // NOTE: We cannot shift the range in the nextTab() command, as this
@@ -153,6 +172,8 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
         // starts typing, which re-evaluates the length of the activeRanges
         // array.)
         val.activeSelections.shift()
+        val.association = getAssociation(val.activeSelections, transaction.selection?.main.from)
+
         return { ...val }
       }
     }
@@ -164,10 +185,23 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
     // This monstrosity ensures that our ranges stay in sync while the user types
     val.activeSelections = val.activeSelections
       .filter(selection => {
-        return selection.ranges.some(r => transaction.changes.mapPos(r.from, 1, r.empty ? MapMode.TrackAfter : MapMode.TrackDel) !== null)
+        return selection.ranges
+          .some(r => transaction.changes.mapPos(r.from, 1, r.empty ? MapMode.TrackAfter : MapMode.TrackDel) !== null)
       })
       .map(selection => {
-        return selection.map(transaction.changes, 1)
+        // Unforturnately, `selection.map` only applies the provided `assoc`
+        // value to empty ranges, so we have to reimplement the logic here
+        // for the association to apply correctly.
+        return EditorSelection.create(selection.ranges.map(range => {
+          const from = transaction.changes.mapPos(range.from, 1)
+          // The reason to change the association for the `range.to` position is
+          // so that the selection range of the tabstop expands when text is added
+          // to the end of the range. We do not need to do this for empty tabstops,
+          // as they should remain empty.
+          const to = transaction.changes.mapPos(range.to, range.empty ? 1 : val.association)
+
+          return EditorSelection.range(from, to)
+        }))
       })
 
     return { ...val }

--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -24,11 +24,12 @@ import {
   StateField,
   EditorSelection,
   Facet,
+  MapMode,
   type SelectionRange,
   type EditorState,
-  MapMode,
+  type Range,
 } from '@codemirror/state'
-import { Decoration, EditorView, WidgetType } from '@codemirror/view'
+import { type Command, Decoration, EditorView, WidgetType } from '@codemirror/view'
 import { type AutocompletePlugin } from '.'
 import { DateTime } from 'luxon'
 import { v4 as uuid } from 'uuid'
@@ -213,7 +214,7 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
         return Decoration.none
       }
 
-      const decorations: any[] = []
+      const decorations: Range<Decoration>[] = []
       let position = 0
       for (const selection of fieldValue.activeSelections) {
         position++
@@ -501,16 +502,35 @@ export function nextSnippet (target: EditorView): boolean {
   return true
 }
 
-export function abortSnippet (target: EditorView): boolean {
+export const abortSnippet: Command = (target: EditorView): boolean => {
   // Removes all tabstops, if there are any
   const field = target.state.field(snippetsUpdateField, false)
   if (field === undefined) {
     return false
   }
 
-  const ranges = field.activeSelections.length
-  if (ranges > 0) {
+  if (field.activeSelections.length > 0) {
     target.dispatch({ effects: snippetTabsEffect.of([]) })
+    return true
+  }
+
+  return false
+}
+
+// Like `abortSnippet` above, but this also removes the placeholder content
+// of any pending tabstop.
+export const abortSnippetRemoveContent: Command = (target: EditorView): boolean => {
+  const field = target.state.field(snippetsUpdateField, false)
+  if (field === undefined) {
+    return false
+  }
+
+  if (field.activeSelections.length > 0) {
+    target.dispatch({
+      // Cuts all of the pending placeholder insertions
+      changes: field.activeSelections.flatMap(sel => sel.ranges.map(r => ({ from: r.from, to: r.to }))),
+      effects: snippetTabsEffect.of([])
+    })
     return true
   }
 

--- a/source/common/modules/markdown-editor/keymaps/default.ts
+++ b/source/common/modules/markdown-editor/keymaps/default.ts
@@ -49,7 +49,7 @@ import {
 } from '@codemirror/lang-markdown'
 import { type Extension } from '@codemirror/state'
 
-import { nextSnippet, abortSnippet } from '../autocomplete/snippets'
+import { nextSnippet, abortSnippet, abortSnippetRemoveContent } from '../autocomplete/snippets'
 import {
   handleBackspace,
   handleQuote,
@@ -125,7 +125,7 @@ export function defaultKeymap (): Extension {
     { key: 'Backspace', run: deleteBracketPair },
     { key: 'Backspace', run: handleBackspace },
 
-    { key: 'Escape', run: abortSnippet },
+    { key: 'Escape', run: abortSnippet, shift: abortSnippetRemoveContent },
     { key: 'Escape', run: closeSearchPanel },
     { key: 'Space', run: handleAutocorrectSpace },
 

--- a/source/common/modules/markdown-utils/snippets-syntax-extension.ts
+++ b/source/common/modules/markdown-utils/snippets-syntax-extension.ts
@@ -73,6 +73,15 @@ const tabstopDecorator = new MatchDecorator({
       return
     }
 
+    // Note: `from` is a document-relative position corresponding to the
+    // beginning of the matched text, while `start` and `end` are relative
+    // to whatever text was provided to the regex engine. In this case,
+    // codemirror matches per-line, so `start` and `end` are line-relative.
+    // i.e., a `start` of 0 corresponds to `view.state.doc.lineAt(from).from`.
+    //
+    // Furthermore, `from` cannot be used to get document-relative  positions
+    // for `start` and `end`, as `from` could refer to a position anywhere in the
+    // line. It would only work as an offset if `from` was at the start of a line.
     const line = view.state.doc.lineAt(from)
     const [ start, end ] = match.indices.groups.num
 
@@ -89,6 +98,15 @@ const variableDecorator = new MatchDecorator({
       return
     }
 
+    // Note: `from` is a document-relative position corresponding to the
+    // beginning of the matched text, while `start` and `end` are relative
+    // to whatever text was provided to the regex engine. In this case,
+    // codemirror matches per-line, so `start` and `end` are line-relative.
+    // i.e., a `start` of 0 corresponds to `view.state.doc.lineAt(from).from`.
+    //
+    // Furthermore, `from` cannot be used to get document-relative  positions
+    // for `start` and `end`, as `from` could refer to a position anywhere in the
+    // line. It would only work as an offset if `from` was at the start of a line.
     const line = view.state.doc.lineAt(from)
     const [ start, end ] = match.indices.groups.var
 
@@ -142,8 +160,14 @@ function getNestedRanges (state: EditorState, pos: number, text: string): Snippe
   return ranges
 }
 
-// Generates a `DecorationSet` for snippet placeholders with default values,
-// handling arbitrarily nested placeholders.
+/**
+ * Generates a `DecorationSet` for snippet placeholders with default values,
+ * handling arbitrarily nested placeholders.
+ *
+ * @param   {EditorView}    view  The editor view
+ *
+ * @returns {DecorationSet}       The generated decorations.
+ */
 function renderPlaceholders (view: EditorView): DecorationSet {
   const decos: Range<Decoration>[] = []
 
@@ -151,7 +175,7 @@ function renderPlaceholders (view: EditorView): DecorationSet {
     const text = view.state.sliceDoc(range.from, range.to)
     const nested = getNestedRanges(view.state, range.from, text)
 
-    for (const { id, from: start, to: end } of nested) {
+    for (const { id, from, to } of nested) {
       let idDeco = tabstopDeco
       let defaultDeco = placeholderDeco
 
@@ -170,12 +194,12 @@ function renderPlaceholders (view: EditorView): DecorationSet {
       decos.push(snippetMarkDeco.range(id.to, id.to + 1))
 
       // Only add a text decoration if not empty to avoid crashing the plugin
-      if (start !== end) {
-        decos.push(defaultDeco.range(start, end))
+      if (from !== to) {
+        decos.push(defaultDeco.range(from, to))
       }
 
       // The closing mark, `}`
-      decos.push(snippetMarkDeco.range(end, end + 1))
+      decos.push(snippetMarkDeco.range(to, to + 1))
     }
   }
 

--- a/source/common/modules/markdown-utils/snippets-syntax-extension.ts
+++ b/source/common/modules/markdown-utils/snippets-syntax-extension.ts
@@ -15,8 +15,25 @@
  */
 
 import { autocompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete'
-import { Decoration, EditorView, MatchDecorator, ViewPlugin, type ViewUpdate } from '@codemirror/view'
+import { matchBrackets } from '@codemirror/language'
+import { RangeSet, type EditorState, type Range } from '@codemirror/state'
+import { Decoration, type DecorationSet, EditorView, MatchDecorator, ViewPlugin, type ViewUpdate } from '@codemirror/view'
 
+// Helper interface for nested snippet ranges
+interface SnippetRange {
+  id: {
+    type: 'var'|'num', // Whether the placeholder is a variable or numbered tabstop
+    from: number,
+    to: number
+  },
+  from: number,
+  to: number
+}
+
+// The `s` flag is important for multi-line snippets
+const placeholderRe = /(?<placeholder>\$\{(?:(?<var>[A-Z_]+)|(?<num>\d+)):).+\}/ds
+
+const snippetMarkDeco = Decoration.mark({ class: 'cm-tm-snippet-mark' })
 const tabstopDeco = Decoration.mark({ class: 'cm-tm-tabstop' })
 const placeholderDeco = Decoration.mark({ class: 'cm-tm-placeholder' })
 const varDeco = Decoration.mark({ class: 'cm-tm-variable' })
@@ -48,38 +65,122 @@ const SUPPORTED_VARIABLES = [
   'EXTENSION'
 ]
 
-/**
- * This is the match decorator that can highlight snippet variables.
- *
- * @return  {MatchDecorator}  The snippets match decorator
- */
-const snippetsDecorator = new MatchDecorator({
-  // tabstops|tabstops with default|variables|variable with default
-  regexp: /(?<tabstop>\$\d+)|(?<tabstopDefault>\$\{\d+:.+?\})|\$(?<var>[A-Z_]+)|\$\{(?<varDefault>[A-Z_]+):.+?\}/g,
-  // tabstop and tabstopDefault -> valid tabstop
-  // var and varDefault --> check the corresponding group if variable is correct
-  decoration: m => {
-    if (m.groups?.tabstop !== undefined) {
-      return tabstopDeco
-    } else if (m.groups?.tabstopDefault !== undefined) {
-      return placeholderDeco
-    } else if (m.groups?.var !== undefined) {
-      if (SUPPORTED_VARIABLES.includes(m.groups.var)) {
-        return varDeco
-      } else {
-        return invalidVarDeco
-      }
-    } else if (m.groups?.varDefault !== undefined) {
-      if (SUPPORTED_VARIABLES.includes(m.groups.varDefault)) {
-        return varPlaceholderDeco
-      } else {
-        return invalidVarDeco
-      }
-    } else {
-      return invalidVarDeco // Default: invalid
+// Handles tabstops without default values: `$1`
+const tabstopDecorator = new MatchDecorator({
+  regexp: /\$(?<num>\d+)/dg,
+  decorate: (add, from, _, match, view) => {
+    if (match.indices?.groups?.num === undefined) {
+      return
     }
+
+    const line = view.state.doc.lineAt(from)
+    const [ start, end ] = match.indices.groups.num
+
+    add(from, from + 1, snippetMarkDeco)
+    add(line.from + start, line.from + end, tabstopDeco)
   }
 })
+
+// Handles variables without default values: `$CURRENT_YEAR`
+const variableDecorator = new MatchDecorator({
+  regexp: /\$(?<var>[A-Z_]+)/dg,
+  decorate: (add, from, _, match, view) => {
+    if (match.indices?.groups?.var === undefined) {
+      return
+    }
+
+    const line = view.state.doc.lineAt(from)
+    const [ start, end ] = match.indices.groups.var
+
+    add(from, from + 1, snippetMarkDeco)
+    add(line.from + start, line.from + end, SUPPORTED_VARIABLES.includes(match.groups!.var) ? varDeco : invalidVarDeco)
+  }
+})
+
+/**
+ * Parse nested snippet placeholder ranges from a string
+ *
+ * @param {EditorState}   state   The editor state
+ * @param {number}        pos     The document-relative start position of `text`
+ * @param {string}        text    The text to parse
+ *
+ * @returns {SnippetRange[]}      A list of parsed snippet placeholder ranges
+ */
+function getNestedRanges (state: EditorState, pos: number, text: string): SnippetRange[] {
+  const ranges: SnippetRange[] = []
+
+  const match = placeholderRe.exec(text)
+  if (!match?.indices?.groups?.placeholder) {
+    return ranges
+  }
+
+  const [ start, end ] = match.indices.groups.placeholder
+
+  // We can limit the search distance to the length of the match
+  // since it encompasses the maximum number of brackets
+  const brackets = matchBrackets(state, pos + start + 1, 1, { maxScanDistance: match[0].length })
+
+  // No matching bracket was found
+  if (!brackets || !brackets.matched || !brackets.end) {
+    return ranges
+  }
+
+  ranges.push({
+    id: {
+      type: match?.groups?.num !== undefined ? 'num' : 'var',
+      from: pos + start + 2,
+      to: pos + end - 1,
+    },
+    from: pos + end,
+    to: brackets.end.from
+  })
+
+  // Recurse on the interior text of the match. This is everything after the
+  // colon and before the final brace.
+  ranges.push(...getNestedRanges(state, pos + end, text.slice(end)))
+
+  return ranges
+}
+
+// Generates a `DecorationSet` for snippet placeholders with default values,
+// handling arbitrarily nested placeholders.
+function renderPlaceholders (view: EditorView): DecorationSet {
+  const decos: Range<Decoration>[] = []
+
+  for (const range of view.visibleRanges) {
+    const text = view.state.sliceDoc(range.from, range.to)
+    const nested = getNestedRanges(view.state, range.from, text)
+
+    for (const { id, from: start, to: end } of nested) {
+      let idDeco = tabstopDeco
+      let defaultDeco = placeholderDeco
+
+      if (id.type === 'var') {
+        idDeco = SUPPORTED_VARIABLES.includes(view.state.sliceDoc(id.from, id.to)) ? varDeco : invalidVarDeco
+        defaultDeco = varPlaceholderDeco
+      }
+
+      // The opening mark, `${`
+      decos.push(snippetMarkDeco.range(id.from - 2, id.from))
+
+      // Placeholder id, either the variable or number
+      decos.push(idDeco.range(id.from, id.to))
+
+      // The colon, `:`
+      decos.push(snippetMarkDeco.range(id.to, id.to + 1))
+
+      // Only add a text decoration if not empty to avoid crashing the plugin
+      if (start !== end) {
+        decos.push(defaultDeco.range(start, end))
+      }
+
+      // The closing mark, `}`
+      decos.push(snippetMarkDeco.range(end, end + 1))
+    }
+  }
+
+  return Decoration.set(decos, true)
+}
 
 /**
  * This plugin uses the snippets match decorator to highlight snippet variables.
@@ -89,11 +190,18 @@ const snippetsDecorator = new MatchDecorator({
  * @return  {ViewPlugin}        The finished view plugin
  */
 const snippetsHighlight = ViewPlugin.define(view => ({
-  decorations: snippetsDecorator.createDeco(view),
+  tabstops: tabstopDecorator.createDeco(view),
+  variables: variableDecorator.createDeco(view),
+  placeholders: renderPlaceholders(view),
   update (u: ViewUpdate) {
-    this.decorations = snippetsDecorator.updateDeco(u, this.decorations)
+    this.tabstops = tabstopDecorator.updateDeco(u, this.tabstops)
+    this.variables = variableDecorator.updateDeco(u, this.variables)
+
+    if (u.docChanged || u.viewportChanged) {
+      this.placeholders = renderPlaceholders(view)
+    }
   }
-}), { decorations: v => v.decorations })
+}), { decorations: v => RangeSet.join([ v.tabstops, v.variables, v.placeholders ]) })
 
 /**
  * This function attempts to return a set of possible autocompletion results.
@@ -122,11 +230,16 @@ function snippetsAutocomplete (context: CompletionContext): CompletionResult|nul
  */
 const snippetsTheme = EditorView.theme({
   // We're using this solarized theme here: https://ethanschoonover.com/solarized/
-  '.cm-tm-tabstop': { color: '#2aa198' }, // cyan
-  '.cm-tm-placeholder': { color: '#2aa198' }, // cyan
-  '.cm-tm-variable': { color: '#b58900' }, // yellow
-  '.cm-tm-variable-placeholder': { color: '#6c71c4' }, // violet
-  '.cm-tm-false-variable': { color: '#dc322f' } // red
+  //
+  // The selectors here are a little verbose so that the syntax highlighting from
+  // the markdown parser is overridden. `cm-content-span` and `cm-pandoc-attribute`
+  // nodes particularly conflict with the snippet styling.
+  '.cm-tm-snippet-mark, .cm-tm-snippet-mark > *': { color: '#859900 !important' },
+  '.cm-tm-tabstop, .cm-tm-tabstop > *': { color: '#2aa198 !important' }, // cyan
+  '.cm-tm-placeholder, .cm-tm-placeholder > *': { color: '#2aa198 !important' }, // cyan
+  '.cm-tm-variable, .cm-tm-variable > *': { color: '#b58900 !important' }, // yellow
+  '.cm-tm-variable-placeholder, .cm-tm-variable-placeholder > *': { color: '#6c71c4 !important' }, // violet
+  '.cm-tm-false-variable, .cm-tm-false-variable > *': { color: '#dc322f !important' } // red
 })
 
 /**


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
This PR fixes syntax highlighting for the snippet editor, adds an `abortSnippetRemoveContent` to cancel and remove a pending snippet, and improves the cursor association for snippet placeholders.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->
Syntax highlighting was restored and improved for the snippet editor. Nested snippets should be highlighted correctly.

An `abortSnippetRemoveContent` command was added, bound to `Shift + Esc`, which removes all pending tabstops and associated default content for in-progress snippets.

Cursor association for tabstops with default content was improved. For such tabstops, text inserted *before* the tabstop remains separate and unassociated, i.e., the tabstop will not expand to encompass text inserted before it. Text inserted directly *after* a tabstop with default text will be associated with the tabstop, i.e., the tabstop will grow to encompass the inserted text. Text placed before or after a tabstop without default content(`$1`, `${2}`, etc), remains unassociated to keep the placeholder empty.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).
None

<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->
macOS 26