### PR TITLE
Update Japanese translations and version number

### DIFF
--- a/static/lang/ja-JP.po
+++ b/static/lang/ja-JP.po
@@ -6,17 +6,45 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Zettlr 4.2.1\n"
+"Project-Id-Version: Zettlr 4.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Zettlr/Zettlr/issues\n"
 "POT-Creation-Date: 2026-03-28 03:19+0000\n"
-"PO-Revision-Date: 2026-03-18 23:52+0900\n"
+"PO-Revision-Date: 2026-06-15 14:08+0900\n"
 "Last-Translator: coolvitto\n"
 "Language-Team: \n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
+
+#: Additional translations in v4.6.0
+msgid "Font size"
+msgstr "フォントサイズ"
+
+#: Additional translations in v4.6.0
+msgid "Font size in pixels:"
+msgstr "フォントサイズ (ピクセル) :"
+
+#: Additional translations in v4.6.0
+msgid "Indentation"
+msgstr "インデント"
+
+#: Additional translations in v4.6.0
+msgid "Adjust your editor indentation settings"
+msgstr "エディタのインデント設定を調整してください"
+
+#: Additional translations in v4.6.0
+msgid "Snippet Autocompletion"
+msgstr "スニペットの自動補完"
+
+#: Additional translations in v4.6.0
+msgid "Control the snippet autocompletion functionality"
+msgstr "スニペットの自動補完機能を設定してください"
+
+#: Additional translations in v4.6.0
+msgid "Autocomplete trigger character:"
+msgstr "自動補完のトリガー文字 :"
 
 #: source/common/modules/markdown-utils/plain-link-highlighter.ts:25
 msgid "Cmd/Ctrl-click to follow this link"


### PR DESCRIPTION
## Description
Add translations.

## Changes
Translations of translation items added in v4.6.0.


#: Additional translations in v4.6.0
msgid "Font size"
msgstr "フォントサイズ"

#: Additional translations in v4.6.0
msgid "Font size in pixels:"
msgstr "フォントサイズ (ピクセル) :"

#: Additional translations in v4.6.0
msgid "Indentation"
msgstr "インデント"

#: Additional translations in v4.6.0
msgid "Adjust your editor indentation settings"
msgstr "エディタのインデント設定を調整してください"

#: Additional translations in v4.6.0
msgid "Snippet Autocompletion"
msgstr "スニペットの自動補完"

#: Additional translations in v4.6.0
msgid "Control the snippet autocompletion functionality" msgstr "スニペットの自動補完機能を設定してください"

#: Additional translations in v4.6.0
msgid "Autocomplete trigger character:"
msgstr "自動補完のトリガー文字 :"