### PR TITLE
feat: Reopen last closed tab(s)

### DIFF
--- a/source/app/app-service-container.ts
+++ b/source/app/app-service-container.ts
@@ -119,9 +119,8 @@ export class AppServiceContainer {
     this._targetProvider = new TargetProvider(this._logProvider, this._fsal)
     this._linkProvider = new LinkProvider(this._logProvider, this._configProvider, this._fsal)
     this._searchProvider = new SearchProvider(this._logProvider, this._fsal, this._configProvider)
-    
-    // The document provider accesses only the FSAL in its constructor
-    this._documentManager = new DocumentManager(this)
+
+    this._documentManager = new DocumentManager(this, this._recentDocsProvider)
     this._tagProvider = new TagProvider(this._logProvider, this._documentManager, this._configProvider, this._fsal)
     this._windowProvider = new WindowProvider(this._logProvider, this._configProvider, this._documentManager)
 
@@ -192,7 +191,7 @@ export class AppServiceContainer {
     await this._informativeBoot(this._tagProvider, 'TagProvider')
     await this._informativeBoot(this._trayProvider, 'TrayProvider')
     await this._informativeBoot(this._citeprocProvider, 'CiteprocProvider')
-    
+
     await this._informativeBoot(this._documentManager, 'DocumentManager')
     await this._informativeBoot(this._menuProvider, 'MenuProvider')
     await this._informativeBoot(this._updateProvider, 'UpdateProvider')

--- a/source/app/service-providers/commands/index.ts
+++ b/source/app/service-providers/commands/index.ts
@@ -41,6 +41,7 @@ import Print from './print'
 import RequestMove from './request-move'
 import RootClose from './root-close'
 import RootOpen from './root-open'
+import ReopenFile from './reopen-recently-closed-file'
 import SaveImageFromClipboard from './save-image-from-clipboard'
 import TutorialOpen from './tutorial-open'
 import UpdateProjectProperties from './update-project-properties'
@@ -81,6 +82,7 @@ export const commands = [
   OpenAuxWindow,
   Print,
   RenameTag,
+  ReopenFile,
   RequestMove,
   RootClose,
   RootOpen,

--- a/source/app/service-providers/commands/reopen-recently-closed-file.ts
+++ b/source/app/service-providers/commands/reopen-recently-closed-file.ts
@@ -1,0 +1,28 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        ReopenRecentlyClosedFile command
+ * CVM-Role:        <none>
+ * Maintainer:      Rich Douglas
+ * License:         GNU GPL v3
+ *
+ * Description:     Reopens the most recently closed file, if any.
+ *
+ * END HEADER
+ */
+
+import type { AppServiceContainer } from 'source/app/app-service-container'
+import ZettlrCommand from './zettlr-command'
+
+export default class ReopenRecentlyClosedFile extends ZettlrCommand {
+  constructor (app: AppServiceContainer) {
+    super(app, 'reopen-recently-closed-file')
+  }
+
+  run (_evt: string, _arg: string): Promise<boolean> {
+    const windowId = this._app.documents.windowKeys()[0]
+    const leafId = this._app.documents.leafIds(windowId)[0]
+    return this._app.documents.reopenRecentlyClosedFile(windowId, leafId)
+  }
+}

--- a/source/app/service-providers/documents/index.ts
+++ b/source/app/service-providers/documents/index.ts
@@ -37,6 +37,7 @@ import { trans } from '@common/i18n-main'
 import type FSALWatchdog from '@providers/fsal/fsal-watchdog'
 import { getDocumentTypeForExtension, hasImageExt, hasMdOrCodeExt, hasPDFExt } from 'source/common/util/file-extention-checks'
 import isDir from 'source/common/util/is-dir'
+import type RecentDocumentsProvider from '../recent-docs'
 
 type DocumentWindows = Record<string, DocumentTree>
 type DocumentWindowsJSON = Record<string, BranchNodeJSON|LeafNodeJSON>
@@ -141,6 +142,7 @@ export type DocumentManagerIPCAPI = IPCAPI<{
   'open-file': LeafLoc & { path: string, newTab: boolean }
   'close-file': LeafLoc & { path: string }
   'close-file-everywhere': { path: string }
+  'reopen-recently-closed-file': LeafLoc
   'get-open-workspace-files': { path: string }
   'sort-open-files': LeafLoc & { newOrder: string[] }
   'get-file-modification-status': unknown
@@ -225,7 +227,10 @@ export default class DocumentManager extends ProviderContract {
     leafId: string|undefined
   }
 
-  constructor (private readonly _app: AppServiceContainer) {
+  constructor (
+    private readonly _app: AppServiceContainer,
+    private readonly _recentDocs: RecentDocumentsProvider
+  ) {
     super()
 
     const containerPath = path.join(app.getPath('userData'), 'documents.yaml')
@@ -307,6 +312,10 @@ export default class DocumentManager extends ProviderContract {
         case 'close-file-everywhere': {
           const { path } = payload
           return this.closeFileEverywhere(path)
+        }
+        case 'reopen-recently-closed-file': {
+          const { windowId, leafId } = payload
+          return await this.reopenRecentlyClosedFile(windowId, leafId)
         }
         case 'get-open-workspace-files':
           const { path } = payload
@@ -1021,6 +1030,22 @@ current contents from the editor somewhere else, and restart the application.`
     }
 
     this.syncWatchedFilePaths()
+  }
+
+  /**
+   * Reopens the most recently closed file, if possible.
+   *
+   * If there are no such closed files then this is a no-op.
+   *
+   * @returns {boolean}            `true` iff the most recently closed file was reopened.
+   */
+  public async reopenRecentlyClosedFile (windowId: string, leafId: string): Promise<boolean> {
+    const filePath = this._recentDocs.getMostRecentlyClosedDocument(this.documents.map((doc) => doc.filePath))
+    if (filePath === undefined) {
+      return false
+    }
+
+    return this.openFile(windowId, leafId, filePath, true)
   }
 
   /**

--- a/source/app/service-providers/menu/menu.darwin.ts
+++ b/source/app/service-providers/menu/menu.darwin.ts
@@ -623,6 +623,14 @@ export default function getMenu (
           }
         },
         {
+          id: 'menu.tab_reopen',
+          label: trans('Reopen Tab'),
+          click: function () {
+            commands.run('reopen-recently-closed-file', {})
+              .catch(e => logger.error(String(e.message), e))
+          }
+        },
+        {
           id: 'menu.new_window',
           label: trans('New window'),
           accelerator: 'CmdOrCtrl+Shift+N',

--- a/source/app/service-providers/menu/menu.win32.ts
+++ b/source/app/service-providers/menu/menu.win32.ts
@@ -599,6 +599,14 @@ export default function getMenu (
           }
         },
         {
+          id: 'menu.tab_reopen',
+          label: trans('Reopen Tab'),
+          click: function () {
+            commands.run('reopen-recently-closed-file', {})
+              .catch(e => logger.error(String(e.message), e))
+          }
+        },
+        {
           id: 'menu.new_window',
           label: trans('New window'),
           accelerator: 'CmdOrCtrl+Shift+N',

--- a/source/app/service-providers/recent-docs/index.ts
+++ b/source/app/service-providers/recent-docs/index.ts
@@ -95,6 +95,41 @@ export default class RecentDocumentsProvider extends ProviderContract {
   }
 
   /**
+   * Get the most recently-closed document's filepath, if any.
+   *
+   * **Implementation note**
+   *
+   * This attempts to _derive_ the most recently-closed document by comparing
+   * the list of recent docs with the list of docs that are currently open in
+   * the app; if a doc is in the list of recent docs but _not_ in the list of
+   * currently open docs then it must have been recently closed and so that's
+   * the doc that is returned.
+   *
+   * This isn't perfect: if a user closes a document (tab) and then opens more
+   * than `n` docs &mdash; where `n` is the maximum number of recent docs that
+   * are remembered &mdash; then it's no longer possible to derive the most
+   * recently-closed document because the list of currently open docs and the
+   * most recent docs will be the same.
+   *
+   * This derivation-based approach holds for the usual case where a user closes
+   * a document (in error) and reopens it shortly thereafter.
+   *
+   * @param {string[]} currentlyOpenDocs the documents currently open in the app
+   *
+   * @returns the filepath to the most recently-closed document or `undefined`
+   */
+  getMostRecentlyClosedDocument (currentlyOpenDocs: string[]): string | undefined {
+    for (const recentDoc of this._recentDocs) {
+      const isCurrentlyOpen = currentlyOpenDocs.indexOf(recentDoc) >= 0
+      if (!isCurrentlyOpen) {
+        return recentDoc
+      }
+    }
+
+    return undefined
+  }
+
+  /**
   * Shuts down the provider
   * @return {Boolean} Always returns true
   */

--- a/source/win-main/DocumentTabs.vue
+++ b/source/win-main/DocumentTabs.vue
@@ -448,6 +448,14 @@ function handleTabbarContext (event: MouseEvent): void {
           windowId: props.windowId
         }
       } as DocumentManagerIPCAPI).catch(e => console.error(e))
+    } else if (clickedID === 'reopen-recently-closed-file') {
+      ipcRenderer.invoke('documents-provider', {
+        command: 'reopen-recently-closed-file',
+        payload: {
+          leafId: props.leafId,
+          windowId: props.windowId
+        }
+      } as DocumentManagerIPCAPI).catch(e => console.error(e))
     }
   })
 }

--- a/source/win-main/tabs-context.ts
+++ b/source/win-main/tabs-context.ts
@@ -20,6 +20,11 @@ export function displayTabbarContext (event: MouseEvent, callback: (clickedID: s
       label: 'Close leaf',
       id: 'close-leaf',
       type: 'normal'
+    },
+    {
+      label: 'Reopen tab',
+      id: 'reopen-recently-closed-file',
+      type: 'normal'
     }
   ]
 


### PR DESCRIPTION
Closes #5741

## Description
This adds a feature where the user can reopen the most recently closed tab (document), if any.

If the user has closed at least one tab (document) in this Zettlr session then invoking the _Reopen Tab_ action will reopen that document.

The most recently _closed_ tabs (documents) are maintained in a stack data structure so the user can close multiple documents and then repeatedly invoke the _Reopen Tab_ action to reopen each closed document.

If they have not closed any documents then the _Reopen Tab_ action silently does nothing. The UI elements exposing the _Reopen Tab_ action do not (currently) disable themselves if there are no recently closed documents.

The memory of "closed documents" is _per Zettlr session_; if a user closes a document and then closes all Zettlr windows/instances -- thus closing the session -- then when Zettlr is restarted there is not considered to be anything to reopen.

## Action Shots

Here's an action shot of the feature being used to reopen a recently-closed document from the application menu.


https://github.com/user-attachments/assets/e13c64fa-55da-43bf-868c-56e7e26831ed

Here's an action shot of the feature being used to reopen two recently-closed documents in succession from the application menu.


https://github.com/user-attachments/assets/6bfbb3c9-38e9-48a9-9eef-b56b7306d3e3



Here's an action shot of the feature being used to reopen a recently-closed document from the little menu activated by right-clicking on the tab bar.

https://github.com/user-attachments/assets/32d0ce70-eb16-43b6-9ca0-6b384da45b5b

## Changes
I'm aware that Hendrik is not personally keen on PRs that are self-annotated by the author; I have annotated this PR because the user who raised the ticket expressed an interest in grokking the implementation so a little self-annotation to guide them through the implementation feels okay in this instance.

I trust that Hendrik will forgive me this one time 🙇‍♂️ 

## Additional information

There is no keyboard shortcut / accelerator to invoke the _Reopen Tab_ action; this is a deliberate omission.

The most common accelerator for this action across apps is <kbd>CTRL+SHIFT+T</kbd>. This accelerator is already used by Zettlr's _Filter files_ action.

On the ticket Hendrik wrote this:

> Feel free to open a PR but as for now not yet bound to a shortcut, then we at least have that functionality and can do some reshuffling of the shortcuts in line with a custom shortcut implementation.

## AI Disclosure Statement

No AI was used.

Tested on: Windows 11 (x86)
