### PR TITLE
fix(search): Prevent log for unsupported files

### DIFF
--- a/source/app/service-providers/search/index.ts
+++ b/source/app/service-providers/search/index.ts
@@ -137,8 +137,6 @@ export class SearchProvider implements ProviderContract {
       return
     }
 
-    this._logger.verbose(`[Search Provider] Searching file ${path.basename(nextFile)}...`)
-
     this.searchFileBoolean(nextFile, this.currentQuery)
       .then(rawResult => {
         // Save some resources both in the IPC and the renderer by not
@@ -171,6 +169,8 @@ export class SearchProvider implements ProviderContract {
     if (descriptor.type === 'other') {
       return []
     }
+
+    this._logger.verbose(`[Search Provider] Searching file ${path.basename(absPath)}...`)
 
     const fileContent = await this._fsal.loadAnySupportedFile(absPath)
     return searchFileBoolean(descriptor, fileContent, query)


### PR DESCRIPTION
## Description
While testing the new search provider, I have noticed that verbose logs are also printed for images (e.g. png). After looking at the code, it turns out that those files are _not_ actually searched, but only a log message is printed (for any file). Unfortunately, this pollutes the logs, if there are many images.

## Changes
Move the log call to the `searchFileBoolean` method of the `SearchProvider` class, so that it only gets called if the file to be searched is of a valid descriptor type.

## Additional information
If the current behavior, that is, to log _any_ file, is indeed intended, then please forget my PR :)

## AI Disclosure Statement
Only used for code completion.

