### PR TITLE
feat: add text transforms and additional shortcuts to link/image shortcut menu

### DIFF
--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -18,10 +18,9 @@ import { trans } from '@common/i18n-renderer'
 import showPopupMenu, { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
 import { type SyntaxNode } from '@lezer/common'
 import { forEachDiagnostic, type Diagnostic, forceLinting, setDiagnostics } from '@codemirror/lint'
-import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList } from '../commands/markdown'
-import { cut, copyAsPlain, copyAsHTML, paste, pasteAsPlain } from '../util/copy-paste-cut'
-import { getTransformSubmenu } from './transform-items'
 import { extractLTSpellcheckSuggestionsFrom, isLanguageToolMisspelling } from '../linters/language-tool'
+import { getFormatMenuItems } from './format-items'
+import { getInsertSubmenu } from './insert-items'
 
 const ipcRenderer = window.ipc
 const suggestionCache = new Map<string, string[]>()
@@ -185,99 +184,8 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
   )
 
   const tpl: AnyMenuItem[] = [
-    {
-      label: trans('Bold'),
-      accelerator: 'CmdOrCtrl+B',
-      type: 'normal',
-      action () { applyBold(view) }
-    },
-    {
-      label: trans('Italic'),
-      accelerator: 'CmdOrCtrl+I',
-      type: 'normal',
-      action () { applyItalic(view) }
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: trans('Insert link'),
-      accelerator: 'CmdOrCtrl+K',
-      type: 'normal',
-      action () { insertLink(view) }
-    },
-    {
-      label: trans('Insert unordered list'),
-      type: 'normal',
-      action () { applyBulletList(view) }
-    },
-    {
-      label: trans('Insert numbered list'),
-      type: 'normal',
-      action () { applyOrderedList(view) }
-    },
-    {
-      label: trans('Insert task list'),
-      accelerator: 'CmdOrCtrl+T',
-      type: 'normal',
-      action () { applyTaskList(view) }
-    },
-    {
-      label: trans('Insert blockquote'),
-      type: 'normal',
-      action () { applyBlockquote(view) }
-    },
-    {
-      label: trans('Insert table'),
-      type: 'normal',
-      action () { view.dispatch(view.state.replaceSelection('| | |\n|-|-|\n| | |\n')) }
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: trans('Cut'),
-      accelerator: 'CmdOrCtrl+X',
-      type: 'normal',
-      action () { cut(view) }
-    },
-    {
-      label: trans('Copy'),
-      accelerator: 'CmdOrCtrl+C',
-      type: 'normal',
-      action () { copyAsPlain(view) }
-    },
-    {
-      label: trans('Copy as HTML'),
-      accelerator: 'CmdOrCtrl+Alt+C',
-      type: 'normal',
-      action () { copyAsHTML(view) }
-    },
-    {
-      label: trans('Paste'),
-      accelerator: 'CmdOrCtrl+V',
-      type: 'normal',
-      action () { paste(view) }
-    },
-    {
-      label: trans('Paste without style'),
-      accelerator: 'CmdOrCtrl+Shift+V',
-      type: 'normal',
-      action () { pasteAsPlain(view) }
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: trans('Select all'),
-      accelerator: 'CmdOrCtrl+A',
-      type: 'normal',
-      action () { view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } }) }
-    },
-    {
-      type: 'separator'
-    },
-    getTransformSubmenu(view)
+    ...getFormatMenuItems(view),
+    getInsertSubmenu(view),
   ]
 
   // If we found a diagnostic earlier and a word, add the suggestion items

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -183,10 +183,7 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
     { type: 'separator' }
   )
 
-  const tpl: AnyMenuItem[] = [
-    ...getFormatMenuItems(view),
-    getInsertSubmenu(view),
-  ]
+  const tpl: AnyMenuItem[] = getFormatMenuItems(view)
 
   // If we found a diagnostic earlier and a word, add the suggestion items
   if (diagnostic !== undefined && misspelledWord !== undefined) {

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -20,7 +20,6 @@ import { type SyntaxNode } from '@lezer/common'
 import { forEachDiagnostic, type Diagnostic, forceLinting, setDiagnostics } from '@codemirror/lint'
 import { extractLTSpellcheckSuggestionsFrom, isLanguageToolMisspelling } from '../linters/language-tool'
 import { getFormatMenuItems } from './format-items'
-import { getInsertSubmenu } from './insert-items'
 
 const ipcRenderer = window.ipc
 const suggestionCache = new Map<string, string[]>()

--- a/source/common/modules/markdown-editor/context-menu/format-items.ts
+++ b/source/common/modules/markdown-editor/context-menu/format-items.ts
@@ -18,6 +18,7 @@ import { applyBold, applyItalic } from '../commands/markdown'
 import { copyAsHTML, copyAsPlain, cut, paste, pasteAsPlain } from '../util/copy-paste-cut'
 import { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
 import { getTransformSubmenu } from './transform-items'
+import { getInsertSubmenu } from './insert-items'
 
 export function getFormatMenuItems (view: EditorView): AnyMenuItem[] {
   return [
@@ -78,6 +79,7 @@ export function getFormatMenuItems (view: EditorView): AnyMenuItem[] {
     {
       type: 'separator'
     },
-    getTransformSubmenu(view)
+    getInsertSubmenu(view),
+    getTransformSubmenu(view),
   ]
 }

--- a/source/common/modules/markdown-editor/context-menu/format-items.ts
+++ b/source/common/modules/markdown-editor/context-menu/format-items.ts
@@ -1,0 +1,83 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        getFormatSubmenu
+ * CVM-Role:        Utility function
+ * Maintainer:      benniekiss
+ * License:         GNU GPL v3
+ *
+ * Description:     This function returns menu items for formatting commands
+ *
+ * END HEADER
+ */
+
+import { type EditorView } from '@codemirror/view'
+import { trans } from '@common/i18n-renderer'
+import { applyBold, applyItalic } from '../commands/markdown'
+import { copyAsHTML, copyAsPlain, cut, paste, pasteAsPlain } from '../util/copy-paste-cut'
+import { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
+import { getTransformSubmenu } from './transform-items'
+
+export function getFormatMenuItems (view: EditorView): AnyMenuItem[] {
+  return [
+    {
+      type: 'separator'
+    },
+    {
+      label: trans('Bold'),
+      accelerator: 'CmdOrCtrl+B',
+      type: 'normal',
+      action () { applyBold(view) }
+    },
+    {
+      label: trans('Italic'),
+      accelerator: 'CmdOrCtrl+I',
+      type: 'normal',
+      action () { applyItalic(view) }
+    },
+    {
+      label: trans('Cut'),
+      accelerator: 'CmdOrCtrl+X',
+      type: 'normal',
+      action () { cut(view) }
+    },
+    {
+      label: trans('Copy'),
+      accelerator: 'CmdOrCtrl+C',
+      type: 'normal',
+      action () { copyAsPlain(view) }
+    },
+    {
+      label: trans('Copy as HTML'),
+      accelerator: 'CmdOrCtrl+Alt+C',
+      type: 'normal',
+      action () { copyAsHTML(view) }
+    },
+    {
+      label: trans('Paste'),
+      accelerator: 'CmdOrCtrl+V',
+      type: 'normal',
+      action () { paste(view) }
+    },
+    {
+      label: trans('Paste without style'),
+      accelerator: 'CmdOrCtrl+Shift+V',
+      type: 'normal',
+      action () { pasteAsPlain(view) }
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: trans('Select all'),
+      accelerator: 'CmdOrCtrl+A',
+      type: 'normal',
+      action () { view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } }) }
+    },
+    {
+      type: 'separator'
+    },
+    getTransformSubmenu(view)
+  ]
+}

--- a/source/common/modules/markdown-editor/context-menu/insert-items.ts
+++ b/source/common/modules/markdown-editor/context-menu/insert-items.ts
@@ -1,0 +1,60 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        getInsertSubmenu
+ * CVM-Role:        Utility function
+ * Maintainer:      benniekiss
+ * License:         GNU GPL v3
+ *
+ * Description:     This function returns a shim submenu with all insert commands
+ *
+ * END HEADER
+ */
+
+import { type EditorView } from '@codemirror/view'
+import { type SubmenuItem } from '../../window-register/application-menu-helper'
+import { trans } from 'source/common/i18n-renderer'
+import { insertLink, applyBlockquote, applyOrderedList, applyBulletList, applyTaskList } from '../commands/markdown'
+
+export function getInsertSubmenu (view: EditorView): SubmenuItem {
+  return {
+    label: trans('Insert'),
+    id: 'submenuInsert',
+    type: 'submenu',
+    submenu: [
+      {
+        label: trans('Insert link'),
+        accelerator: 'CmdOrCtrl+K',
+        type: 'normal',
+        action () { insertLink(view) }
+      },
+      {
+        label: trans('Insert unordered list'),
+        type: 'normal',
+        action () { applyBulletList(view) }
+      },
+      {
+        label: trans('Insert numbered list'),
+        type: 'normal',
+        action () { applyOrderedList(view) }
+      },
+      {
+        label: trans('Insert task list'),
+        accelerator: 'CmdOrCtrl+T',
+        type: 'normal',
+        action () { applyTaskList(view) }
+      },
+      {
+        label: trans('Insert blockquote'),
+        type: 'normal',
+        action () { applyBlockquote(view) }
+      },
+      {
+        label: trans('Insert table'),
+        type: 'normal',
+        action () { view.dispatch(view.state.replaceSelection('| | |\n|-|-|\n| | |\n')) }
+      },
+    ]
+  }
+}

--- a/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
@@ -25,6 +25,8 @@ import { configField } from '../util/configuration'
 import type { WindowControlsIPCAPI } from 'source/app/service-providers/windows'
 import { findReferenceForLinkLabel, removeMarkdownLink } from '../util/links'
 import { getTransformSubmenu } from './transform-items'
+import { applyBold, applyItalic } from '../commands/markdown'
+import { copyAsHTML, copyAsPlain, cut, paste, pasteAsPlain } from '../util/copy-paste-cut'
 
 const ipcRenderer = window.ipc
 
@@ -83,8 +85,70 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
   const basePath = pathDirname(view.state.field(configField).metadata.path)
   const url = getURLForNode(node, view.state)
 
+  const defaultTpl: AnyMenuItem[] = [
+    {
+      type: 'separator'
+    },
+    {
+      label: trans('Bold'),
+      accelerator: 'CmdOrCtrl+B',
+      type: 'normal',
+      action () { applyBold(view) }
+    },
+    {
+      label: trans('Italic'),
+      accelerator: 'CmdOrCtrl+I',
+      type: 'normal',
+      action () { applyItalic(view) }
+    },
+    {
+      label: trans('Cut'),
+      accelerator: 'CmdOrCtrl+X',
+      type: 'normal',
+      action () { cut(view) }
+    },
+    {
+      label: trans('Copy'),
+      accelerator: 'CmdOrCtrl+C',
+      type: 'normal',
+      action () { copyAsPlain(view) }
+    },
+    {
+      label: trans('Copy as HTML'),
+      accelerator: 'CmdOrCtrl+Alt+C',
+      type: 'normal',
+      action () { copyAsHTML(view) }
+    },
+    {
+      label: trans('Paste'),
+      accelerator: 'CmdOrCtrl+V',
+      type: 'normal',
+      action () { paste(view) }
+    },
+    {
+      label: trans('Paste without style'),
+      accelerator: 'CmdOrCtrl+Shift+V',
+      type: 'normal',
+      action () { pasteAsPlain(view) }
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: trans('Select all'),
+      accelerator: 'CmdOrCtrl+A',
+      type: 'normal',
+      action () { view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } }) }
+    },
+    {
+      type: 'separator'
+    },
+    getTransformSubmenu(view)
+  ]
+
   if (url === undefined) {
     console.error('Could not show Link/Image context menu: No URL found!')
+    showPopupMenu(coords, defaultTpl)
     return
   }
 
@@ -124,7 +188,8 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
           removeMarkdownLink(node, view)
         }
       }
-    }
+    },
+    ...defaultTpl
   ]
 
   const validAbsoluteURI = makeValidUri(url, basePath)
@@ -155,10 +220,7 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
         } as WindowControlsIPCAPI)
       }
     },
-    {
-      type: 'separator'
-    },
-    getTransformSubmenu(view)
+    ...defaultTpl
   ]
 
   showPopupMenu(coords, isLink ? linkTpl : imgTpl)

--- a/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
@@ -24,6 +24,7 @@ import { pathDirname } from 'source/common/util/renderer-path-polyfill'
 import { configField } from '../util/configuration'
 import type { WindowControlsIPCAPI } from 'source/app/service-providers/windows'
 import { findReferenceForLinkLabel, removeMarkdownLink } from '../util/links'
+import { getTransformSubmenu } from './transform-items'
 
 const ipcRenderer = window.ipc
 
@@ -153,7 +154,11 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
           payload: { itemPath: validAbsoluteURI }
         } as WindowControlsIPCAPI)
       }
-    }
+    },
+    {
+      type: 'separator'
+    },
+    getTransformSubmenu(view)
   ]
 
   showPopupMenu(coords, isLink ? linkTpl : imgTpl)

--- a/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
@@ -24,9 +24,7 @@ import { pathDirname } from 'source/common/util/renderer-path-polyfill'
 import { configField } from '../util/configuration'
 import type { WindowControlsIPCAPI } from 'source/app/service-providers/windows'
 import { findReferenceForLinkLabel, removeMarkdownLink } from '../util/links'
-import { getTransformSubmenu } from './transform-items'
-import { applyBold, applyItalic } from '../commands/markdown'
-import { copyAsHTML, copyAsPlain, cut, paste, pasteAsPlain } from '../util/copy-paste-cut'
+import { getFormatMenuItems } from './format-items'
 
 const ipcRenderer = window.ipc
 
@@ -85,66 +83,7 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
   const basePath = pathDirname(view.state.field(configField).metadata.path)
   const url = getURLForNode(node, view.state)
 
-  const defaultTpl: AnyMenuItem[] = [
-    {
-      type: 'separator'
-    },
-    {
-      label: trans('Bold'),
-      accelerator: 'CmdOrCtrl+B',
-      type: 'normal',
-      action () { applyBold(view) }
-    },
-    {
-      label: trans('Italic'),
-      accelerator: 'CmdOrCtrl+I',
-      type: 'normal',
-      action () { applyItalic(view) }
-    },
-    {
-      label: trans('Cut'),
-      accelerator: 'CmdOrCtrl+X',
-      type: 'normal',
-      action () { cut(view) }
-    },
-    {
-      label: trans('Copy'),
-      accelerator: 'CmdOrCtrl+C',
-      type: 'normal',
-      action () { copyAsPlain(view) }
-    },
-    {
-      label: trans('Copy as HTML'),
-      accelerator: 'CmdOrCtrl+Alt+C',
-      type: 'normal',
-      action () { copyAsHTML(view) }
-    },
-    {
-      label: trans('Paste'),
-      accelerator: 'CmdOrCtrl+V',
-      type: 'normal',
-      action () { paste(view) }
-    },
-    {
-      label: trans('Paste without style'),
-      accelerator: 'CmdOrCtrl+Shift+V',
-      type: 'normal',
-      action () { pasteAsPlain(view) }
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: trans('Select all'),
-      accelerator: 'CmdOrCtrl+A',
-      type: 'normal',
-      action () { view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } }) }
-    },
-    {
-      type: 'separator'
-    },
-    getTransformSubmenu(view)
-  ]
+  const defaultTpl: AnyMenuItem[] = getFormatMenuItems(view)
 
   if (url === undefined) {
     console.error('Could not show Link/Image context menu: No URL found!')


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
This PR adds several additional context menu items to for links and images.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

Context menu items were added for bold,italic, cut, copy, and paste, as well as the text transforms context menu.

Link and image title text can contain markdown formatting, so having these items available for links and images makes sense to me. I also use link formatting for some internal things, so I'm pasting regular text within brackets, and I really enjoy having these transforms available.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).

N/A

<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->
