### PR TITLE
chore(css): misc toolbar styling improvements

### DIFF
--- a/source/common/vue/window/WindowToolbar.vue
+++ b/source/common/vue/window/WindowToolbar.vue
@@ -140,11 +140,15 @@ const hasRTLTrafficLights = ref<boolean>(false)
 
 const scrollArea = ref<HTMLDivElement|null>(null)
 const canScroll = ref(false)
+// To account for really small differences between `scrollWidth` and `clientWidth`
+// (sometimes only fractions of a pixel), add a small additional tolerance to
+// `clientWidth` to prevent erroneously displaying of the scroll buttons.
+const clientWidthTolerance = 5
 
 function checkOverflow () {
   if (scrollArea.value) {
     const sa = scrollArea.value
-    canScroll.value = sa.scrollWidth > sa.clientWidth
+    canScroll.value = sa.scrollWidth > (sa.clientWidth + clientWidthTolerance)
   }
 }
 

--- a/source/common/vue/window/toolbar-controls/TextControl.vue
+++ b/source/common/vue/window/toolbar-controls/TextControl.vue
@@ -74,6 +74,6 @@ body .toolbar-text {
   font-size: 11px;
   text-wrap: nowrap;
   padding: 0 10px;
-  width: 150px; // constrain the text width to accommodate content changes.
+  width: fit-content; // constrain the text width to accommodate content changes.
 }
 </style>

--- a/source/win-log-viewer/App.vue
+++ b/source/win-log-viewer/App.vue
@@ -52,7 +52,7 @@ const toolbarControls: ToolbarControl[] = [
   },
   {
     type: 'spacer',
-    size: '3x'
+    size: '5x'
   },
   {
     type: 'toggle',

--- a/source/win-log-viewer/App.vue
+++ b/source/win-log-viewer/App.vue
@@ -52,7 +52,7 @@ const toolbarControls: ToolbarControl[] = [
   },
   {
     type: 'spacer',
-    size: '5x'
+    size: '3x'
   },
   {
     type: 'toggle',
@@ -213,25 +213,39 @@ function handleToggle (event: { id?: string, state?: string|boolean }): void {
 
 <style lang="less">
 // This is bad style, but let's add the toolbar button classes here
-body div#toolbar button {
-  &.verbose-control-active {
-    background-color: #d8d8d8;
-    color: rgb(131, 131, 131);
-  }
+body div#toolbar {
+  // Make space for the traffic lights, either on the left side or the right.
+  button {
+    &.verbose-control-active {
+      background-color: #d8d8d8;
+      color: rgb(131, 131, 131);
+    }
 
-  &.warning-control-active {
-    background-color: rgb(236, 238, 97);
-    color: rgb(139, 139, 24);
-  }
+    &.warning-control-active {
+      background-color: rgb(236, 238, 97);
+      color: rgb(139, 139, 24);
+    }
 
-  &.info-control-active {
-    background-color: rgb(165, 204, 255);
-    color: rgb(61, 136, 233);
-  }
+    &.info-control-active {
+      background-color: rgb(165, 204, 255);
+      color: rgb(61, 136, 233);
+    }
 
-  &.error-control-active {
-    background-color: rgb(255, 130, 130);
-    color: rgb(139, 27, 27);
+    &.error-control-active {
+      background-color: rgb(255, 130, 130);
+      color: rgb(139, 27, 27);
+    }
+  }
+}
+
+body.darwin div#toolbar {
+  // Remove traffic light padding on macOS since
+  // the toolbar is displayed with a titlebar
+  &:not(.has-rtl-traffic-lights) {
+    padding-left: 10px;
+  }
+  &.has-rtl-traffic-lights {
+    padding-right: 10px;
   }
 }
 

--- a/source/win-main/App.vue
+++ b/source/win-main/App.vue
@@ -574,6 +574,10 @@ const toolbarControls = computed<ToolbarControl[]>(() => {
       visible: getToolbarButtonDisplay('showDocumentInfoText')
     },
     {
+      type: 'spacer',
+      size: '1x'
+    },
+    {
       type: 'ring',
       id: 'pomodoro',
       title: trans('Pomodoro timer'),


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
This PR cleans up the log window toolbar on macos and increases the draggable space between the insert footnote and word count widgets.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->
The log window toolbar on macos no longer permanently shows the scroll overflow buttons, and the toolbar was resized to fill the space. A small tolerance had to be added to `checkOverflow`, since the `clientWidth` would occassionaly be reported as fractions of a pixel (which is what was causing the buttons to show in the log viewer).

The `TextControl` component was changed to use `width: fit-content` instead of the fixed-width of `width: 150px`. This increases the draggable area on the toolbar, as outlined in the pic below. An small spacer was added between the pomodoro popover and word count popover to account for the potentially smaller width.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->

Yellow is the current draggable area:

<img width="314" height="74" alt="Screenshot 2026-06-27 at 15 54 03" src="https://github.com/user-attachments/assets/6e556600-aac4-499d-b4d7-1eeeda3c5e26" />

<img width="763" height="128" alt="Screenshot 2026-06-27 at 16 05 53" src="https://github.com/user-attachments/assets/dd92c13c-53d7-4ffa-b679-d0df2f93ed37" />


## AI Disclosure Statement

Describe how AI has been used in this PR (GPT-models/coding agents).

N/A

<!-- Tell us on which platforms you tested your changes. -->
Tested on: <!-- e.g., macOS Tahoe 26.4.1 (M2); Windows 11 (x86); Ubuntu 26.04 (ARM) -->
