### PR TITLE
fix: exclude link/image title from word & character counts (#6093)

### DIFF
--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -152,10 +152,10 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
 
     case 'Image':
     case 'Link': {
+      // Only the visible link text (alt) is document text. The title — the
+      // quoted tooltip after the URL — is metadata and must not be counted
+      // (nor spellchecked), otherwise it inflates word/char statistics. See #6093.
       textNodes.push(ast.alt)
-      if (ast.title !== undefined) {
-        textNodes.push(ast.title)
-      }
       break
     }
 

--- a/test/counter.spec.ts
+++ b/test/counter.spec.ts
@@ -93,6 +93,14 @@ const countWordsTesters = [
     locale: 'ja',
     expectedWords: 6,
     expectedChars: 22
+  },
+  {
+    // Regression for #6093: a link's title (the quoted tooltip) must not be
+    // counted toward word/char stats — only the visible link text.
+    input: '[Wikipedia test](https://en.wikipedia.org/wiki/Function_(mathematics) "Math article")',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 14
   }
 ]
 


### PR DESCRIPTION
## What

A link's (or image's) **title** — the quoted tooltip after the URL — is incorrectly counted toward the document's **word and character statistics**.

`extractTextnodes` pushes both the visible text (`alt`) **and** the `title` as text nodes. Since the counter (and the spellchecker) consume those text nodes, the title inflates the stats even though it isn't visible document text.

### Reproduction (from #6093)

```
[Wikipedia test](https://en.wikipedia.org/wiki/Function_(mathematics) "Math article")
```

- Expected: **2 words / 14 chars** ("Wikipedia test")
- Actual: **4 words / 26 chars** ("Wikipedia test" + "Math article")

## Fix

In `extractTextnodes`, push only the visible text (`alt`) for `Link`/`Image` nodes; drop the `title`. The title is metadata, so it should neither be counted nor spellchecked.

## Test

Adds a regression case to `test/counter.spec.ts`. Fails on the previous code, passes with this change. Full unit suite: **377 passing**.

---

Addresses #6093 (the link-title case). Per @benniekiss's review, the **image-within-a-link** case (an image's URL counted inside link text) is a separate remaining problem — happy to follow up on that in a dedicated PR, so leaving the issue open rather than auto-closing.
