### PR TITLE
fix: count image alt, not URL, when an image is a link's text (#6093)

### DIFF
--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -571,6 +571,21 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         }
       }
 
+      // A link whose visible text is itself an image — e.g. a clickable banner,
+      // `[![alt](img.png)](url)` — stores the raw image Markdown, including the
+      // image URL, between its link marks. Counting that raw text inflates the
+      // word/character statistics, so when the link text is exactly an image,
+      // count that image's alt text instead. See #6093.
+      const innerImage = node.name === 'Link' ? node.getChild('Image') : null
+      const linkWrapsImage = innerImage !== null && marks.length >= 2 &&
+        markdown.substring(marks[0].to, marks[1].from).trim() === markdown.substring(innerImage.from, innerImage.to).trim()
+
+      const alt = linkWrapsImage
+        ? (parseNode(innerImage as SyntaxNode, markdown) as LinkOrImage).alt
+        : marks.length >= 2
+          ? genericTextNode(marks[0].to, marks[1].from, markdown.substring(marks[0].to, marks[1].from))
+          : genericTextNode(url.from, url.to, markdown.substring(url.from, url.to))
+
       const astNode: LinkOrImage = {
         type: node.name,
         name: node.name,
@@ -580,9 +595,7 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         whitespaceBefore: getWhitespaceBeforeNode(node, markdown),
         title: title === null ? undefined : genericTextNode(title.from, title.to, markdown.substring(title.from, title.to)),
         url: markdown.substring(url.from, url.to),
-        alt: marks.length >= 2
-          ? genericTextNode(marks[0].to, marks[1].from, markdown.substring(marks[0].to, marks[1].from))
-          : genericTextNode(url.from, url.to, markdown.substring(url.from, url.to))
+        alt
       }
 
       return astNode

--- a/test/counter.spec.ts
+++ b/test/counter.spec.ts
@@ -93,6 +93,15 @@ const countWordsTesters = [
     locale: 'ja',
     expectedWords: 6,
     expectedChars: 22
+  },
+  {
+    // A link whose visible text is an image (e.g. a clickable banner) must count
+    // only the image's alt text, not the raw image Markdown/URL between the link
+    // marks. Same count as the bare image `![alt text](…)`. See #6093.
+    input: '[![alt text](https://example.com/img.png)](https://example.com)',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 8
   }
 ]
 


### PR DESCRIPTION
## Follow-up to #6425

In #6425 @benniekiss noted that PR still left one case open:

> This doesn't actually completely close the linked issue, as there is still a problem with **images within links having the image URL included in word counts**

This PR fixes that case.

## Bug

When a link's visible text is an image — a clickable banner, `[![alt text](https://example.com/img.png)](https://example.com)` — the parser stored the **raw image Markdown** (including the image URL) in the link's `alt` range, because `alt` is taken as the raw substring between the link marks. The counter then counted that raw text:

| Markdown | Counted before | Correct |
|---|---|---|
| `![alt text](…/img.png)` (bare image) | 2 words / 8 chars | 2 / 8 |
| `[![alt text](…/img.png)](…)` (image as link text) | **5 words / 40 chars** | 2 / 8 |

## Fix

In `parseNode` (`markdown-ast`), when a `Link`'s text is exactly an `Image`, build the link's `alt` from the inner image's alt text instead of the raw substring. Guarded so it only triggers when the image fills the link text — plain links, bare images, links with titles, and links with text *surrounding* an image are all unchanged.

## Test

Adds a regression case to `test/counter.spec.ts` (`[![alt text](…)](…)` → 2 words / 8 chars). Full suite green: **377 passing** (375 → 377; the new case adds the word + char assertions).
