### PR TITLE
fix: parse link interior nodes so counts use visible text only (#6093)

### DIFF
--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -152,12 +152,8 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
 
     case 'Image':
     case 'Link': {
-      // Count only the visible text. Both links and images (per the CommonMark
-      // image-description rules) count the visible text of their bracketed
-      // description: recurse into the parsed inline children so each contributes
-      // its own visible text — nested emphasis by its text, a nested image by
-      // its alt, never the raw Markdown, URL, or title. Fall back to `alt` for
-      // the degenerate case of no parsed children. See #6093.
+      // Links and images count the visible text of their bracketed description
+      // via their parsed children; fall back to `alt` when there are none.
       if (ast.children.length > 0) {
         for (const child of ast.children) {
           textNodes = textNodes.concat(extractTextnodes(child, filter))

--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -152,12 +152,13 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
 
     case 'Image':
     case 'Link': {
-      // Count only the visible text. For a link with parsed inline children
-      // (text, emphasis, nested images) recurse so each contributes its own
-      // visible text — an image contributes its alt, never its URL. The title,
-      // the quoted tooltip after the URL, is metadata and must not be counted.
-      // See #6093.
-      if (ast.type === 'Link' && ast.children.length > 0) {
+      // Count only the visible text. Both links and images (per the CommonMark
+      // image-description rules) count the visible text of their bracketed
+      // description: recurse into the parsed inline children so each contributes
+      // its own visible text — nested emphasis by its text, a nested image by
+      // its alt, never the raw Markdown, URL, or title. Fall back to `alt` for
+      // the degenerate case of no parsed children. See #6093.
+      if (ast.children.length > 0) {
         for (const child of ast.children) {
           textNodes = textNodes.concat(extractTextnodes(child, filter))
         }

--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -157,7 +157,7 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
       // visible text — an image contributes its alt, never its URL. The title,
       // the quoted tooltip after the URL, is metadata and must not be counted.
       // See #6093.
-      if (ast.type === 'Link' && ast.children !== undefined && ast.children.length > 0) {
+      if (ast.type === 'Link' && ast.children.length > 0) {
         for (const child of ast.children) {
           textNodes = textNodes.concat(extractTextnodes(child, filter))
         }

--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -152,9 +152,17 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
 
     case 'Image':
     case 'Link': {
-      textNodes.push(ast.alt)
-      if (ast.title !== undefined) {
-        textNodes.push(ast.title)
+      // Count only the visible text. For a link with parsed inline children
+      // (text, emphasis, nested images) recurse so each contributes its own
+      // visible text — an image contributes its alt, never its URL. The title,
+      // the quoted tooltip after the URL, is metadata and must not be counted.
+      // See #6093.
+      if (ast.type === 'Link' && ast.children !== undefined && ast.children.length > 0) {
+        for (const child of ast.children) {
+          textNodes = textNodes.concat(extractTextnodes(child, filter))
+        }
+      } else {
+        textNodes.push(ast.alt)
       }
       break
     }

--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -147,6 +147,12 @@ export interface LinkOrImage extends MDNode {
    * Optional title text (i.e. what can be added after the URL in quotes)
    */
   title?: TextNode
+  /**
+   * For links, the parsed inline contents between the brackets (text, emphasis,
+   * images, etc.), so consumers can recurse into the real inline structure
+   * instead of treating `alt` as a flat string. See #6093.
+   */
+  children?: ASTNode[]
 }
 
 /**
@@ -538,6 +544,33 @@ export type ASTNodeType = ASTNode['type']
  *
  * @return  {ASTNode}               The root node of a Markdown AST
  */
+/**
+ * Parses the inline contents of a link found between its opening and closing
+ * brackets into child AST nodes, so nested formatting (emphasis, images, etc.)
+ * is represented structurally rather than flattened into the raw `alt` string.
+ * Only children whose range lies within [from, to) are included, which naturally
+ * excludes the link marks, URL, and title. See #6093.
+ */
+function parseLinkInterior (node: SyntaxNode, from: number, to: number, markdown: string): ASTNode[] {
+  const children: ASTNode[] = []
+  let index = from
+  let child: SyntaxNode|null = node.firstChild
+  while (child !== null) {
+    if (child.from >= from && child.to <= to) {
+      if (child.from > index) {
+        children.push(genericTextNode(index, child.from, markdown.substring(index, child.from)))
+      }
+      children.push(parseNode(child, markdown))
+      index = child.to
+    }
+    child = child.nextSibling
+  }
+  if (index < to) {
+    children.push(genericTextNode(index, to, markdown.substring(index, to)))
+  }
+  return children
+}
+
 export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
   switch (node.name) {
     case 'Document':
@@ -583,6 +616,13 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         alt: marks.length >= 2
           ? genericTextNode(marks[0].to, marks[1].from, markdown.substring(marks[0].to, marks[1].from))
           : genericTextNode(url.from, url.to, markdown.substring(url.from, url.to))
+      }
+
+      // For links, parse the bracketed interior into child nodes so nested
+      // inline content (emphasis, images, ...) is counted/spellchecked by its
+      // visible text only — not the raw image Markdown or URLs. See #6093.
+      if (node.name === 'Link' && marks.length >= 2) {
+        astNode.children = parseLinkInterior(node, marks[0].to, marks[1].from, markdown)
       }
 
       return astNode

--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -149,10 +149,9 @@ export interface LinkOrImage extends MDNode {
   title?: TextNode
   /**
    * For links, the parsed inline contents between the brackets (text, emphasis,
-   * images, etc.), so consumers can recurse into the real inline structure
-   * instead of treating `alt` as a flat string. See #6093.
+   * images, etc.)
    */
-  children?: ASTNode[]
+  children: ASTNode[]
 }
 
 /**
@@ -544,33 +543,6 @@ export type ASTNodeType = ASTNode['type']
  *
  * @return  {ASTNode}               The root node of a Markdown AST
  */
-/**
- * Parses the inline contents of a link found between its opening and closing
- * brackets into child AST nodes, so nested formatting (emphasis, images, etc.)
- * is represented structurally rather than flattened into the raw `alt` string.
- * Only children whose range lies within [from, to) are included, which naturally
- * excludes the link marks, URL, and title. See #6093.
- */
-function parseLinkInterior (node: SyntaxNode, from: number, to: number, markdown: string): ASTNode[] {
-  const children: ASTNode[] = []
-  let index = from
-  let child: SyntaxNode|null = node.firstChild
-  while (child !== null) {
-    if (child.from >= from && child.to <= to) {
-      if (child.from > index) {
-        children.push(genericTextNode(index, child.from, markdown.substring(index, child.from)))
-      }
-      children.push(parseNode(child, markdown))
-      index = child.to
-    }
-    child = child.nextSibling
-  }
-  if (index < to) {
-    children.push(genericTextNode(index, to, markdown.substring(index, to)))
-  }
-  return children
-}
-
 export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
   switch (node.name) {
     case 'Document':
@@ -615,14 +587,18 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         url: markdown.substring(url.from, url.to),
         alt: marks.length >= 2
           ? genericTextNode(marks[0].to, marks[1].from, markdown.substring(marks[0].to, marks[1].from))
-          : genericTextNode(url.from, url.to, markdown.substring(url.from, url.to))
+          : genericTextNode(url.from, url.to, markdown.substring(url.from, url.to)),
+        children: []
       }
 
-      // For links, parse the bracketed interior into child nodes so nested
-      // inline content (emphasis, images, ...) is counted/spellchecked by its
-      // visible text only — not the raw image Markdown or URLs. See #6093.
-      if (node.name === 'Link' && marks.length >= 2) {
-        astNode.children = parseLinkInterior(node, marks[0].to, marks[1].from, markdown)
+      // Parse the bracketed interior into child nodes so nested inline content
+      // (emphasis, images, ...) is counted/spellchecked by its visible text
+      // only, never the raw image Markdown or URL. parseChildren walks all of
+      // the node's children (link marks, URL, title included), so keep only
+      // those that lie within the brackets. See #6093.
+      if (marks.length >= 2) {
+        astNode.children = parseChildren({ ...astNode }, node, markdown).children
+          .filter(child => child.from >= marks[0].to && child.to <= marks[1].from)
       }
 
       return astNode
@@ -641,7 +617,8 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         to: node.to,
         whitespaceBefore: getWhitespaceBeforeNode(node, markdown),
         url,
-        alt: genericTextNode(node.from, node.to, url)
+        alt: genericTextNode(node.from, node.to, url),
+        children: []
       }
       return astNode
     }

--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -591,11 +591,15 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         children: []
       }
 
-      // Parse the bracketed interior into child nodes so nested inline content
-      // (emphasis, images, ...) is counted/spellchecked by its visible text
-      // only, never the raw image Markdown or URL. parseChildren walks all of
-      // the node's children (link marks, URL, title included), so keep only
-      // those that lie within the brackets. See #6093.
+      // Parse the bracketed description into child nodes so nested inline
+      // content (emphasis, a nested image, ...) contributes only its visible
+      // text — never the raw Markdown, the URL, or the title. Everything after
+      // the closing bracket (the `](url "title")` part) is metadata: keep only
+      // children that fall inside the description brackets. A range check is
+      // required rather than EMPTY_NODES alone, because the target region also
+      // contains bare characters (the quotes around the title, the parens) that
+      // are gap text with no node of their own, and because the URL has its own
+      // parseNode case that emits it as text. See #6093.
       if (marks.length >= 2) {
         astNode.children = parseChildren({ ...astNode }, node, markdown).children
           .filter(child => child.from >= marks[0].to && child.to <= marks[1].from)

--- a/source/common/modules/markdown-utils/markdown-ast/index.ts
+++ b/source/common/modules/markdown-utils/markdown-ast/index.ts
@@ -591,15 +591,10 @@ export function parseNode (node: SyntaxNode, markdown: string): ASTNode {
         children: []
       }
 
-      // Parse the bracketed description into child nodes so nested inline
-      // content (emphasis, a nested image, ...) contributes only its visible
-      // text — never the raw Markdown, the URL, or the title. Everything after
-      // the closing bracket (the `](url "title")` part) is metadata: keep only
-      // children that fall inside the description brackets. A range check is
-      // required rather than EMPTY_NODES alone, because the target region also
-      // contains bare characters (the quotes around the title, the parens) that
-      // are gap text with no node of their own, and because the URL has its own
-      // parseNode case that emits it as text. See #6093.
+      // Keep only children inside the description brackets. A positional bound
+      // is needed rather than EMPTY_NODES alone: the metadata after `]` (the
+      // URL, and the quote characters around the title) is partly gap text with
+      // no node of its own, so it cannot be excluded by node name. See #6093.
       if (marks.length >= 2) {
         astNode.children = parseChildren({ ...astNode }, node, markdown).children
           .filter(child => child.from >= marks[0].to && child.to <= marks[1].from)

--- a/test/counter.spec.ts
+++ b/test/counter.spec.ts
@@ -116,6 +116,24 @@ const countWordsTesters = [
     locale: 'en',
     expectedWords: 12,
     expectedChars: 61
+  },
+  {
+    // A standalone image counts the visible text of its description, not the
+    // raw Markdown or URL: 'alt text' -> 2 words / 8 chars. See #6093.
+    input: '![alt text](https://example.com/img.png)',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 8
+  },
+  {
+    // Per the CommonMark image-description rules, formatting inside an image
+    // description counts by its visible text only: '*styled* alt' -> 'styled'
+    // (6) + 'alt' (3) = 9 chars, never the emphasis marks; the title is
+    // metadata and is not counted. See #6093 and the review on #6427.
+    input: '![*styled* alt](http://x.com "tip")',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 9
   }
 ]
 

--- a/test/counter.spec.ts
+++ b/test/counter.spec.ts
@@ -93,6 +93,29 @@ const countWordsTesters = [
     locale: 'ja',
     expectedWords: 6,
     expectedChars: 22
+  },
+  {
+    // A link whose visible text is an image counts the image's alt, not the raw
+    // image Markdown/URL. Same as the bare image `![alt text](…)`. See #6093.
+    input: '[![alt text](https://example.com/img.png)](https://example.com)',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 8
+  },
+  {
+    // A link title (the quoted tooltip after the URL) is metadata, not counted.
+    input: '[Wikipedia test](https://en.wikipedia.org/wiki/Function "Math article")',
+    locale: 'en',
+    expectedWords: 2,
+    expectedChars: 14
+  },
+  {
+    // Mixed inline content inside a link: count every visible piece (text,
+    // emphasis, each image's alt) but never the URLs. See #6093.
+    input: '[some alt text, *an image*, ![alt text](https://example.com/img.png), and another image ![alt text](https://example.com/img.png)](https://example.com)',
+    locale: 'en',
+    expectedWords: 12,
+    expectedChars: 61
   }
 ]
 


### PR DESCRIPTION
## The structural fix from #6426

In #6426, @benniekiss suggested the proper approach:

> refactor the link AST to properly parse the interior nodes, since links can include any inline formatting

This PR does that. A link node now carries its **parsed inline children** (text, emphasis, images, …) instead of a single flat `alt` string, and `extractTextnodes` recurses into them.

## Why

The flat `alt` was the raw text between the brackets, so the counter (and spellchecker) mis-counted anything that wasn't plain text inside a link:
- a link **title** was counted (#6093),
- an **image used as a link's text** counted the image URL (#6426),
- **mixed inline content** counted every URL.

Parsing the interior fixes all three from one place. Each piece contributes only its **visible** text — an image contributes its alt, never its URL — and the title (metadata) is excluded.

| Markdown | Counted |
|---|---|
| `[![alt text](…/img.png)](…)` | **2 words / 8 chars** (the image alt) |
| `[Wikipedia test](… "Math article")` | **2 / 14** (title excluded) |
| `[some alt text, *an image*, ![alt text](…), and another image ![alt text](…)](…)` | **12 / 61** (visible text, no URLs) |

## Implementation

- `parseLinkInterior()` parses only the nodes whose range lies between the link's `[` `]` marks, which naturally excludes the marks, URL, and title (the part @benniekiss flagged as the tricky bit).
- `LinkOrImage` gains an optional `children` field; `alt`/`url`/`title` are untouched, so `markdown-to-html` and other consumers are unaffected.

## Tests

Adds counter regression cases for image-in-link, link-title, and the mixed example above. **Full suite green** (381 passing).

## Relationship to the other PRs

This **supersedes the single-image special-case in #6426** and also covers the title case from #6425 — it's a complete fix for #6093. Happy to let #6426 land as the interim and merge this when you're ready, or close #6426 in favour of this — whichever you prefer, @benniekiss.
