### PR TITLE
fix: Fix s/S (substitute) in vim-mode

### DIFF
--- a/source/common/modules/markdown-editor/plugins/vim-mode.ts
+++ b/source/common/modules/markdown-editor/plugins/vim-mode.ts
@@ -104,6 +104,13 @@ Vim.map('j', 'gj') // Account for line wraps when moving down
 // @ts-expect-error The types are not properly updated
 Vim.map('k', 'gk') // Account for line wraps when moving up
 
+// Map s and S, which "should" work out of the box with CM-vim.
+// See https://github.com/Zettlr/Zettlr/issues/6431-4892471526
+// @ts-expect-error The types are not properly updated
+Vim.map('s', 'cl') // Add missing substitute-character command
+// @ts-expect-error The types are not properly updated
+Vim.map('S', 'cc') // Add missing substitute-line command
+
 // Unmap bindings to restore default editor behavior
 // @ts-expect-error The types are not properly updated
 Vim.unmap('<C-f>') // Allow invoking Ctrl+F search from all modes


### PR DESCRIPTION
## Description

This addresses #6431 by re-mapping the s and S keys to the substitute command, acting as a workaround for what is suspected to be an issue in CM core.

## Changes

No breaking UI or API changes.

## Additional information

No tests added.

## AI Disclosure Statement

No AI was used in the authoring of this PR. 

Tested on: macOS Tahoe 26.5.1.
