### PR TITLE
fix: search results display

### DIFF
--- a/source/win-main/GlobalSearch.vue
+++ b/source/win-main/GlobalSearch.vue
@@ -161,7 +161,7 @@ import ButtonControl from '@common/vue/form/elements/ButtonControl.vue'
 import ProgressControl from '@common/vue/form/elements/ProgressControl.vue'
 import AutocompleteText from '@common/vue/form/elements/AutocompleteText.vue'
 import { trans } from '@common/i18n-renderer'
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import showPopupMenu, { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
 import { useConfigStore, useWindowStateStore, useWorkspaceStore } from 'source/pinia'
 import { pathBasename, pathDirname, relativePath } from 'source/common/util/renderer-path-polyfill'
@@ -351,19 +351,23 @@ const filteredSearchResults = computed<SearchResultWrapper[]>(() => {
 // Changing the query should reset the no-results message
 watch(query, () => { hadNoResult.value = false })
 
+const stopListeningForSearchResults = ipcRenderer.on('search-provider', (event, message) => {
+  if (message.type === 'search-end') {
+    searchIsRunning.value = false
+    hadNoResult.value = filteredSearchResults.value.length === 0
+    searchProgress.value = 0
+  } else if (message.type === 'search-result') {
+    processSearchResult(message.progress as number, message.file as string, message.result as SearchResult|undefined)
+      .catch(err => console.error(err))
+  }
+})
+
 onMounted(() => {
   queryInputElement.value?.focus()
+})
 
-  ipcRenderer.on('search-provider', (event, message) => {
-    if (message.type === 'search-end') {
-      searchIsRunning.value = false
-      hadNoResult.value = filteredSearchResults.value.length === 0
-      searchProgress.value = 0
-    } else if (message.type === 'search-result') {
-      processSearchResult(message.progress as number, message.file as string, message.result as SearchResult|undefined)
-        .catch(err => console.error(err))
-    }
-  })
+onBeforeUnmount(() => {
+  stopListeningForSearchResults()
 })
 
 /**


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  0. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  1. I documented the code extensively.
  2. This PR targets the develop branch, *not* the master branch.
  3. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  4. `yarn lint` and `yarn test` run successfully.
  5. I followed the code-style of the repository.
  6. I agree that my code will be published under the GNU GPL v3 license.
  7. All new files have the correct license/description header (see existing
     files).
  8. Before opening this PR, I ran `git pull` one last time to prevent any merge
     issues.
  9. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, feel free to open
  your PR nevertheless and mention them. We are happy to help you fulfill them
  and do not want to stop you from contributing to the codebase.
 -->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
Fix for duplicate global-search results messing up the result rendering.
Fixes #6432 

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->
clean up search ipc listener on unmount.

## Additional information
<!-- If there is anything else that might be of interest, please provide it here -->
the search results were continuously getting more and more events because previous ipc listeners weren't unmounted

## AI Disclosure Statement
Describe how AI has been used in this PR (GPT-models/coding agents).
GPT-5.6 was used to peruse vue docs

<!-- Tell us on which platforms you tested your changes. -->
Tested on: MacOS 26.5.1 arm64 and linux opensuse tumbleweed