### PR TITLE
feat: Look Up feature in contextual menu on macOS

### DIFF
--- a/source/app/service-providers/windows/index.ts
+++ b/source/app/service-providers/windows/index.ts
@@ -78,6 +78,7 @@ export type WindowControlsIPCAPI = IPCAPI<{
   'copy': unknown
   'paste': unknown
   'selectAll': unknown
+  'show-definition-for-selection': undefined
   'inspect-element': { x: number, y: number }
   'drag-start': { filePath: string }
   'show-item-in-folder': { itemPath: string }
@@ -191,6 +192,12 @@ export default class WindowProvider extends ProviderContract {
           break
         case 'selectAll':
           event.sender.selectAll()
+          break
+        // This command is only available on macOS
+        case 'show-definition-for-selection':
+          if (process.platform === 'darwin') {
+            event.sender.showDefinitionForSelection()
+          }
           break
         case 'inspect-element':
           event.sender.inspectElement(Math.round(payload.x), Math.round(payload.y))

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -283,7 +283,7 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
 
   const lookupItem = getMacOSLookupItem(view)
   if (lookupItem !== undefined) {
-    tpl.unshift(lookupItem, { type: 'separator' })
+    tpl.push({ type: 'separator' }, lookupItem)
   }
 
   // If we found a diagnostic earlier and a word, add the suggestion items

--- a/source/common/modules/markdown-editor/context-menu/default-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/default-menu.ts
@@ -22,6 +22,7 @@ import { applyBold, applyItalic, insertLink, applyBlockquote, applyOrderedList, 
 import { cut, copyAsPlain, copyAsHTML, paste, pasteAsPlain } from '../util/copy-paste-cut'
 import { getTransformSubmenu } from './transform-items'
 import { extractLTSpellcheckSuggestionsFrom, isLanguageToolMisspelling } from '../linters/language-tool'
+import { getMacOSLookupItem } from './macos-lookup-item'
 
 const ipcRenderer = window.ipc
 const suggestionCache = new Map<string, string[]>()
@@ -279,6 +280,11 @@ export async function defaultMenu (view: EditorView, node: SyntaxNode, coords: {
     },
     getTransformSubmenu(view)
   ]
+
+  const lookupItem = getMacOSLookupItem(view)
+  if (lookupItem !== undefined) {
+    tpl.unshift(lookupItem, { type: 'separator' })
+  }
 
   // If we found a diagnostic earlier and a word, add the suggestion items
   if (diagnostic !== undefined && misspelledWord !== undefined) {

--- a/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
@@ -160,7 +160,7 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
   const template = isLink ? linkTpl : imgTpl
   const lookupItem = getMacOSLookupItem(view)
   if (lookupItem !== undefined) {
-    template.unshift(lookupItem, { type: 'separator' })
+    template.push({ type: 'separator' }, lookupItem)
   }
 
   showPopupMenu(coords, template)

--- a/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
+++ b/source/common/modules/markdown-editor/context-menu/link-image-menu.ts
@@ -24,6 +24,7 @@ import { pathDirname } from 'source/common/util/renderer-path-polyfill'
 import { configField } from '../util/configuration'
 import type { WindowControlsIPCAPI } from 'source/app/service-providers/windows'
 import { findReferenceForLinkLabel, removeMarkdownLink } from '../util/links'
+import { getMacOSLookupItem } from './macos-lookup-item'
 
 const ipcRenderer = window.ipc
 
@@ -156,5 +157,11 @@ export function linkImageMenu (view: EditorView, node: SyntaxNode, coords: { x: 
     }
   ]
 
-  showPopupMenu(coords, isLink ? linkTpl : imgTpl)
+  const template = isLink ? linkTpl : imgTpl
+  const lookupItem = getMacOSLookupItem(view)
+  if (lookupItem !== undefined) {
+    template.unshift(lookupItem, { type: 'separator' })
+  }
+
+  showPopupMenu(coords, template)
 }

--- a/source/common/modules/markdown-editor/context-menu/macos-lookup-item.ts
+++ b/source/common/modules/markdown-editor/context-menu/macos-lookup-item.ts
@@ -1,0 +1,45 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        macOS lookup menu item
+ * CVM-Role:        Utility function
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     Creates a context menu item for looking up the current
+ *                  editor selection in the macOS dictionary.
+ *
+ * END HEADER
+ */
+
+import { type EditorView } from '@codemirror/view'
+import { trans } from '@common/i18n-renderer'
+import { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
+import { type WindowControlsIPCAPI } from '@providers/windows'
+
+const ipcRenderer = window.ipc
+
+export function getMacOSLookupItem (view: EditorView): AnyMenuItem|undefined {
+  // Only macOS provides a native dictionary popover for the current selection
+  if (process.platform !== 'darwin') {
+    return undefined
+  }
+
+  const selection = view.state.selection.main
+  if (selection.empty) {
+    return undefined
+  }
+
+  const selectedText = view.state.sliceDoc(selection.from, selection.to)
+  return {
+    label: trans('Look Up “%s”', selectedText),
+    type: 'normal',
+    action () {
+      ipcRenderer.send('window-controls', {
+        command: 'show-definition-for-selection',
+        payload: undefined
+      } as WindowControlsIPCAPI)
+    }
+  }
+}

--- a/source/common/modules/markdown-editor/table-editor/context-menu.ts
+++ b/source/common/modules/markdown-editor/table-editor/context-menu.ts
@@ -8,6 +8,7 @@ import { selectAllCommand } from '../keymaps/table-editor'
 import { addRowAfter, addRowBefore, clearRow, deleteRow, swapNextRow, swapPrevRow } from './commands/rows'
 import { addColAfter, addColBefore, clearCol, deleteCol, swapNextCol, swapPrevCol } from './commands/columns'
 import { clearTable, deleteTable, setAlignment } from './commands/tables'
+import { getMacOSLookupItem } from '../context-menu/macos-lookup-item'
 
 export function displayTableContextMenu (event: MouseEvent, mainView: EditorView, subviewOrView: EditorView): void {
   const template: AnyMenuItem[] = [
@@ -213,6 +214,11 @@ export function displayTableContextMenu (event: MouseEvent, mainView: EditorView
       ]
     }
   ]
+
+  const lookupItem = getMacOSLookupItem(subviewOrView)
+  if (lookupItem !== undefined) {
+    template.unshift(lookupItem, { type: 'separator' })
+  }
 
   const point = { x: event.clientX, y: event.clientY }
   showPopupMenu(point, template)

--- a/source/common/modules/markdown-editor/table-editor/context-menu.ts
+++ b/source/common/modules/markdown-editor/table-editor/context-menu.ts
@@ -217,7 +217,7 @@ export function displayTableContextMenu (event: MouseEvent, mainView: EditorView
 
   const lookupItem = getMacOSLookupItem(subviewOrView)
   if (lookupItem !== undefined) {
-    template.unshift(lookupItem, { type: 'separator' })
+    template.push({ type: 'separator' }, lookupItem)
   }
 
   const point = { x: event.clientX, y: event.clientY }


### PR DESCRIPTION
## Description
Implement "Look Up" feature request on macOS platform (Closes #6455)

## Changes
Implemented the feature as a helper in similar fashion to existing project standards and applied to the relevant contextual menu sites throughout the app, limiting the feature in link prose to only non-empty highlighted text. Purposefully not applied to text input sites, as they appear limited mostly to custom user-specific preference items (regex patterns, etc)

## Additional information

macOS UI standards dictate the "Look Up" item be included as the first item in the relevant contextual menu (which I concur with, for consistency sake) but since Zettlr currently does not adhere to the guidance, the implementation would be a marked change for all users accustomed to the current behavior. At maintainer's discretion, feel free to accept either the feature as-is which renders the Look Up feature at the top of the contextual menu, or the refactor commit addition which renders the feature below the current Zettlr structure, prior to the rest of the system menu additions.

- hand-tested functionality on all targeted sites via project test build frame work (very nice setup ! thanks for making it trivial for us 😃 )
- yarn lint: Passed with exit code 0. It reported 147 existing repository warnings and zero errors; no change from current `develop` head.
- yarn test: Passed—all 375 tests.
- Tested on: macOS Tahoe 26.5.2 (M5)
- Support for other platforms investigated, but none have a similar base-OS-provided feature without additional apps/plugins.

## AI Disclosure Statement

OpenAI model `OpenAI Codex GPT-5.6 Sol` was used in the making of this PR with complete human inspection of all final code.

