### PR TITLE
Allow snippets inside YAML frontmatter

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/index.ts
+++ b/source/common/modules/markdown-editor/autocomplete/index.ts
@@ -54,9 +54,16 @@ export interface AutocompletePlugin {
    */
   entries: (ctx: CompletionContext, query: string) => Completion[]
   fields?: Array<StateField<any>>
+  /**
+   * The list of CodeMirror syntax-tree tokens inside which this autocomplete
+   * should NOT trigger. By default, every plugin is suppressed inside YAML
+   * frontmatter and math blocks. A plugin can override this list (e.g. set it
+   * to an empty array) to opt back into those contexts.
+   */
+  forbiddenTokens?: string[]
 }
 
-const forbiddenTokens = [
+const defaultForbiddenTokens = [
   'YAMLFrontmatter',
   'YAMLFrontmatterStart',
   'YAMLFrontmatterEnd',
@@ -67,17 +74,20 @@ const autocompleteSource: CompletionSource = function (ctx): CompletionResult|nu
   // This function is called for every keystroke and shall determine whether to
   // actually start the autocomplete.
 
-  // With this function we check whether we are currently within "forbidden"
-  // tokens (i.e. codeblocks, YAML stuff, etc.)
-  if (ctx.tokenBefore(forbiddenTokens) !== null) {
-    return null
-  }
-
   let plugin: AutocompletePlugin|undefined
   let startpos = ctx.pos
 
   // NOTE: Headings has to be checked before tags
   for (const p of [ codeBlocks, citations, files, headings, tags, snippets ]) {
+    // Each plugin decides for itself in which contexts it should be suppressed
+    // (i.e. codeblocks, YAML stuff, etc.). This allows individual plugins to opt
+    // back into contexts that were previously forbidden for everyone — such as
+    // snippets inside YAML frontmatter (see issue #6240).
+    const forbidden = p.forbiddenTokens ?? defaultForbiddenTokens
+    if (forbidden.length > 0 && ctx.tokenBefore(forbidden) !== null) {
+      continue
+    }
+
     const res = p.applies(ctx)
     if (res !== false) {
       plugin = p

--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -477,6 +477,12 @@ export const snippets: AutocompletePlugin = {
       }
     })
   },
+  // Snippets are useful inside YAML frontmatter (e.g. to insert a
+  // `header-includes` block), so we explicitly opt back into that context by
+  // omitting the YAMLFrontmatter* tokens here. We still suppress snippets inside
+  // math blocks, since a colon there is part of the equation, not a trigger.
+  // See issue #6240.
+  forbiddenTokens: ['MathEquation'],
   fields: [snippetsUpdateField]
 }
 


### PR DESCRIPTION
## Summary

Fixes #6240 — the snippet menu (triggered by `:`) does not appear when the cursor is inside a YAML frontmatter block, even though snippets (e.g. one that inserts a `header-includes` section) are genuinely useful there.

This implements the fix @nathanlesage described in the issue: move the "forbidden tokens" logic away from the central autocomplete source and into the individual autocompletes, so each plugin decides for itself where it should be suppressed.

## The problem

`autocompleteSource` in `source/common/modules/markdown-editor/autocomplete/index.ts` applied a blanket guard for *all* autocompletes:

```ts
const forbiddenTokens = ['YAMLFrontmatter', 'YAMLFrontmatterStart', 'YAMLFrontmatterEnd', 'MathEquation']
if (ctx.tokenBefore(forbiddenTokens) !== null) {
  return null
}
```

This runs before any plugin's `applies()` is consulted, so every autocomplete — including snippets — is suppressed inside YAML frontmatter and math blocks. That makes sense for tags, citations, file links, headings, and code-block infostrings, but snippets are user-defined text expansions that are valuable inside frontmatter.

## The fix

Two small, targeted changes:

**`autocomplete/index.ts`** — added an optional `forbiddenTokens?: string[]` field to the `AutocompletePlugin` interface. The central guard was removed; instead, each plugin's own `forbiddenTokens` (defaulting to the previous YAML + math set) is checked inside the dispatch loop, right before that plugin's `applies()` runs. All existing plugins keep the default, so their behavior is unchanged.

**`autocomplete/snippets.ts`** — the snippets plugin sets `forbiddenTokens: ['MathEquation']`, explicitly opting back into YAML frontmatter while still suppressing snippets inside math blocks (where a `:` is part of the equation, not a trigger).

## Why this approach

- **Minimal & behavior-preserving:** every plugin except snippets behaves exactly as before. Only snippets-in-YAML is newly allowed, which is the reported bug.
- **Matches maintainer intent:** this is the refactor @nathanlesage proposed — "moving that logic away from the central logic to the individual autocompletes."
- **Extensible:** if another plugin later needs to opt into a previously-forbidden context (e.g. tags inside YAML for `#tags:` frontmatter), it just sets its own `forbiddenTokens` — no further changes to the central source needed.

## Scope touched

- `source/common/modules/markdown-editor/autocomplete/index.ts` — interface field added, central guard moved into the dispatch loop
- `source/common/modules/markdown-editor/autocomplete/snippets.ts` — one field added to the plugin export

No changes to `applies()`, `entries()`, or any snippet parsing/tabstop logic — the existing `test/snippets.spec.ts` exercises `template2snippet` and is unaffected.

## Testing

I reviewed the existing `test/snippets.spec.ts`, which covers `template2snippet`/placeholder parsing and is untouched by this change (the forbidden-token behavior lives in the central source, not in the parsing function). I did not add a new spec because the snippet-menu trigger depends on a full CodeMirror editor + syntax-tree + config-facet setup that the existing unit tests don't scaffold; happy to add an integration-style test if you'd prefer one.

## AI usage disclosure

Per Zettlr's AI Usage Policy: an AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #6240