### PR TITLE
Fix preview failing on filenames containing a bare percent sign (%)

### DIFF
--- a/source/app/util/custom-protocols.ts
+++ b/source/app/util/custom-protocols.ts
@@ -48,6 +48,28 @@ function headersForFileType (filePath: string): Record<string, string> {
   return headers
 }
 
+/**
+ * Decodes a (potentially partially-encoded) URI component safely.
+ *
+ * The `URL` constructor encodes some characters (e.g. spaces become `%20`) but
+ * leaves a bare `%` in the original filename untouched, since `%` is a valid
+ * path character. A subsequent `decodeURIComponent` then throws "URI malformed"
+ * because a lone `%` is not a valid percent-encoding sequence. This helper
+ * first re-encodes any `%` that is not followed by two hex digits to `%25`,
+ * so that `decodeURIComponent` succeeds and the bare `%` is restored as a
+ * literal character in the resulting path.
+ *
+ * See: https://github.com/Zettlr/Zettlr/issues/6261
+ *
+ * @param   {string}  str  The (partially-encoded) URI component to decode
+ *
+ * @return  {string}       The decoded string
+ */
+function safeDecodeURIComponent (str: string): string {
+  const sanitized = str.replace(/%(?![0-9A-Fa-f]{2})/g, '%25')
+  return decodeURIComponent(sanitized)
+}
+
 export default function registerCustomProtocols (logger: LogProvider): void {
   // Make it possible to safely load external files
   // In order to load files, the 'safe-file' protocol has to be used instead of 'file'
@@ -58,7 +80,7 @@ export default function registerCustomProtocols (logger: LogProvider): void {
   protocol.handle(protocolName, async request => {
     const url = new URL(request.url)
     try {
-      let pathName = decodeURIComponent(url.pathname)
+      let pathName = safeDecodeURIComponent(url.pathname)
 
       // Due to the colons in the drive letters on Windows, the pathname will
       // look like this: /C:/Users/Documents/test.jpg


### PR DESCRIPTION
## Summary

Fixes #6261 — PDF files (and any other previewable file) whose filename contains a bare percent sign (`%`) fail to render in the preview pane, showing "Error loading external file: URI malformed" instead.

## The problem

When a file is loaded in the preview pane, its path is turned into a `safe-file://` URL by `makeValidUri` (via `new URL(...)`). The `URL` constructor percent-encodes some characters in the pathname (e.g. spaces become `%20`) but leaves a bare `%` untouched, since `%` is a valid path character.

The `safe-file` protocol handler in `source/app/util/custom-protocols.ts` then calls `decodeURIComponent(url.pathname)` to recover the original path. `decodeURIComponent` throws `URI malformed` when it encounters a lone `%` that is not part of a valid `%XX` percent-encoding sequence — which is exactly what happens with a filename like `Test % im Dateinamen.pdf`. The resulting pathname looks like `Test%20%%20im%20Dateinamen.pdf`, where `%%20` is an invalid sequence.

The error is caught by the `try/catch` and surfaced as "Error loading external file: URI malformed", so the file never renders.

## The fix

A single, targeted change in `source/app/util/custom-protocols.ts`: replace the bare `decodeURIComponent(url.pathname)` with a small `safeDecodeURIComponent` helper that first re-encodes any `%` not followed by two hex digits to `%25` (the correct percent-encoding for a literal `%`), and *then* calls `decodeURIComponent`. This way:

- Valid percent-encodings produced by the `URL` constructor (e.g. `%20` for a space) are still decoded correctly.
- A bare `%` in the original filename is preserved as a literal `%` in the resulting path.

```ts
function safeDecodeURIComponent (str: string): string {
  const sanitized = str.replace(/%(?![0-9A-Fa-f]{2})/g, '%25')
  return decodeURIComponent(sanitized)
}
```

This is the only place the `safe-file` protocol handler decodes the pathname, so it is the correct and complete fix for the preview rendering path.

## Scope touched

- `source/app/util/custom-protocols.ts` — added `safeDecodeURIComponent` helper (with JSDoc), changed one call site from `decodeURIComponent` to `safeDecodeURIComponent`.

No other files are touched. Existing behavior for filenames without `%` is unchanged: `safeDecodeURIComponent` produces the same output as `decodeURIComponent` when there are no bare percent signs.

## Testing

I verified the fix logic against the exact case from the issue (`Test % im Dateinamen.pdf`) and several edge cases (`100%done.pdf`, `a%b%c.pdf`, filenames with spaces that are already `%20`-encoded) — all produce the correct decoded path. There is no existing unit test for the `safe-file` protocol handler (it runs in the main process and depends on Electron's `protocol.handle`), so no test changes were needed or possible without scaffolding an Electron test harness.

## AI usage disclosure

Per Zettlr's AI Usage Policy: an AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #6261
