### PR TITLE
Fix spell checker ignoring text inside inline footnotes

### DIFF
--- a/source/common/modules/markdown-utils/index.ts
+++ b/source/common/modules/markdown-utils/index.ts
@@ -136,6 +136,25 @@ export function extractTextnodes (ast: ASTNode, filter?: (node: ASTNode) => bool
       break
     }
 
+    case 'Footnote': {
+      // Inline footnotes (^[text]) contain their text content in the label
+      // property rather than as children. We need to expose that text so it
+      // gets spell-checked, counted, and processed by the readability mode.
+      // The label text starts at from + 2 (after the ^[ prefix).
+      if (ast.inline) {
+        textNodes.push({
+          type: 'Text',
+          name: 'text',
+          from: ast.from + 2,
+          to: ast.from + 2 + ast.label.length,
+          value: ast.label,
+          whitespaceBefore: ast.whitespaceBefore,
+          attributes: {}
+        })
+      }
+      break
+    }
+
     case 'Generic':
     case 'Heading':
     case 'Emphasis':


### PR DESCRIPTION
## Summary

Fixes #6242 — misspellings inside inline footnotes (e.g. `^[Just liek thsi.]`) are not detected by the spell checker.

## The problem

`extractTextnodes` in `source/common/modules/markdown-utils/index.ts` converts a Markdown AST into a flat list of text nodes, which the spell checker (and the word counter, readability mode, and LanguageTool linter) iterate over to find words.

The function handles `FootnoteRef` nodes (footnote definitions like `[^1]: body text`) by recursing into their children, but it does **not** handle `Footnote` nodes — the inline indicators within the text.

For a regular footnote reference `[^1]`, this is fine: the label is just a number. But for an **inline footnote** `^[Just liek thsi.]`, the parser produces a `Footnote` node with `inline: true` and the footnote's text content stored in the `label` property (not as children). Since `extractTextnodes` has no `case 'Footnote'`, that text is never extracted, so it is never spell-checked.

## The fix

A single, targeted addition to the `switch` in `extractTextnodes`: a `case 'Footnote'` that, when `ast.inline` is true, pushes a `TextNode` constructed from the label. The text offsets (`from`/`to`) are set to `ast.from + 2` and `ast.from + 2 + ast.label.length`, which corresponds to the text between the `^[` prefix and the closing `]` — exactly where the words appear in the source document.

Non-inline footnotes (`inline: false`) are left untouched: their label is a reference number, not prose.

## Scope touched

- `source/common/modules/markdown-utils/index.ts` — one new `case 'Footnote'` block in `extractTextnodes`.

No other files are changed. The fix also benefits the word counter (`counter.ts`), readability mode (`readability.ts`), and LanguageTool linter (`language-tool.ts`), all of which call `extractTextnodes`.

## Testing

I verified the AST structure by reading the parser code in `markdown-ast/index.ts`: for `^[text]`, the parser sets `inline: true` and `label` to the text between `^[` and `]`. The existing `test/markdown-to-ast.spec.ts` does not test `extractTextnodes` or inline footnotes, so no test changes were needed.

## AI usage disclosure

Per Zettlr's AI Usage Policy: an AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #6242