### PR TITLE
feat: Add bidirectional (RTL/LTR) writing support

### DIFF
--- a/scripts/test-gui/test-files/GUI Tests/Bidirectional Text.md
+++ b/scripts/test-gui/test-files/GUI Tests/Bidirectional Text.md
@@ -1,0 +1,35 @@
+# Bidirectional Text
+
+This file exercises the bidi/Arabic typing support (spec §1 acceptance criteria).
+
+## Pure paragraphs
+
+This is a plain English paragraph. It must render exactly as before, left-to-right, with no visible change.
+
+هذه فقرة عربية خالصة. يجب أن تُعرض من اليمين إلى اليسار، وأن تكون علامات الترقيم في نهاية الجملة على الجانب الأيسر.
+
+## Mixed paragraphs
+
+في هذه الفقرة نستخدم مصطلح Markdown وكذلك اسم CodeMirror داخل جملة عربية، ويجب أن يبقى المؤشر متوقعاً عند التحرك بالأسهم.
+
+This English paragraph mentions the Arabic word السلام in the middle of a Latin sentence.
+
+## Inline syntax inside Arabic
+
+- نص **غامق بالعربية** ونص **bold in English** في سطر واحد.
+- شيفرة مضمّنة: `let x = 1` داخل جملة عربية.
+- رابط بعنوان عربي: [مقدمة في التحرير](https://example.com/intro) — يجب أن تظهر الأقواس في مواضعها الصحيحة.
+- رابط ويكي: [[ملاحظات عربية]] داخل الجملة.
+- وسم: #تجربة في نهاية السطر.
+
+## Headings
+
+### عنوان عربي من المستوى الثالث
+
+### English level-three heading
+
+## Frontmatter override
+
+Create a copy of this file and add `direction: rtl` to a YAML frontmatter, or
+use the statusbar toggle (bottom right) — empty lines and neutral lines should
+then also align right.

--- a/source/app/service-providers/config/get-config-template.ts
+++ b/source/app/service-providers/config/get-config-template.ts
@@ -148,6 +148,7 @@ export interface ConfigOptions {
     fontSize: number
     countChars: boolean
     inputMode: 'default'|'vim'|'emacs'
+    defaultTextDirection: 'auto'|'ltr'|'rtl'
     boldFormatting: '**'|'__'
     italicFormatting: '_'|'*'
     highlightFormatting: 'span'|'=='
@@ -365,6 +366,7 @@ export function getConfigTemplate (): ConfigOptions {
       fontSize: 18, // The editor's font size in pixels
       countChars: false, // Set to true to enable counting characters instead of words
       inputMode: 'default', // Can be default, vim, emacs
+      defaultTextDirection: 'auto', // Base direction for documents without a frontmatter override
       boldFormatting: '**', // Can be ** or __
       italicFormatting: '_', // Can be * or _
       highlightFormatting: '==', // Can be 'span' or ==

--- a/source/common/modules/markdown-editor/editor-extension-sets.ts
+++ b/source/common/modules/markdown-editor/editor-extension-sets.ts
@@ -76,6 +76,7 @@ import { vimPlugin } from './plugins/vim-mode'
 import { projectInfoField } from './plugins/project-info-field'
 import { headingGutter } from './renderers/render-headings'
 import { citationTooltips } from './tooltips/citations'
+import { writerBidi } from './writer/bidi'
 
 /**
  * This interface describes the required properties which the extension sets
@@ -337,6 +338,7 @@ export function getMarkdownExtensions (options: CoreExtensionOptions): Extension
     backgroundLayers, // Add a background behind inline code and code blocks
     defaultContextMenu, // A default context menu
     softwrapVisualIndent, // Always indent visually
+    writerBidi(), // Bidirectional (Arabic/English) writing support
     tagClasses(), // Apply a custom class to each tag so that users can style them (#4589)
     EditorView.domEventHandlers(options.domEventsListeners)
   ]

--- a/source/common/modules/markdown-editor/parser/markdown-parser.ts
+++ b/source/common/modules/markdown-editor/parser/markdown-parser.ts
@@ -95,6 +95,7 @@ import { pandocAttributesParser } from './pandoc-attributes-parser'
 import { highlightParser } from './highlight-parser'
 import { zknTagParser } from './zkn-tag-parser'
 import { pandocDivComposite, pandocDivParser, pandocSpanParser } from './pandoc-div-span-parser'
+import { bidiIsolateProps } from '../writer/bidi-isolate-props'
 
 const codeLanguages: Array<{ mode: Language|LanguageDescription|null, selectors: string[] }> = [
   { mode: markdownLanguage, selectors: [ 'markdown', 'md' ] },
@@ -218,7 +219,8 @@ export default function markdownParser (config?: MarkdownParserConfig): Language
     addKeymap: false,
     extensions: {
       props: [
-        customFoldNodeProp
+        customFoldNodeProp,
+        bidiIsolateProps
       ],
       // yamlCodeParse is a wrapper that scans the document for the existence of
       // a YAML frontmatter and then parses its contents. NOTE: Since a single

--- a/source/common/modules/markdown-editor/statusbar/index.ts
+++ b/source/common/modules/markdown-editor/statusbar/index.ts
@@ -22,6 +22,7 @@ import { languageToolStatus } from './language-tool'
 import { diagnosticsStatus } from './diagnostics'
 import { statusbarProjectInfo } from '../plugins/project-info-field'
 import { renderingModeToggle } from '../renderers'
+import { textDirectionStatus } from '../writer/direction-statusbar'
 import { sanitizeHTML } from 'source/common/util/sanitize-html'
 
 /**
@@ -80,6 +81,7 @@ function createStatusbar (_view: EditorView): Panel {
         cursorStatus,
         wordcountStatus,
         charcountStatus,
+        textDirectionStatus,
         inputModeStatus,
         languageToolStatus,
         diagnosticsStatus

--- a/source/common/modules/markdown-editor/util/configuration.ts
+++ b/source/common/modules/markdown-editor/util/configuration.ts
@@ -67,6 +67,7 @@ export interface EditorConfiguration {
   highlightFormatting: 'span'|'=='
   citeStyle: 'in-text'|'in-text-suffix'|'regular'
   inputMode: 'default'|'vim'|'emacs'
+  defaultTextDirection: 'auto'|'ltr'|'rtl'
   muteLines: boolean
   readabilityAlgorithm: 'dale-chall'|'gunning-fog'|'coleman-liau'|'automated-readability'
   readabilityMode: boolean
@@ -135,6 +136,7 @@ export function getDefaultConfig (): EditorConfiguration {
     muteLines: true,
     readabilityAlgorithm: 'dale-chall',
     inputMode: 'default',
+    defaultTextDirection: 'auto',
     readabilityMode: false,
     typewriterMode: false,
     distractionFree: false,

--- a/source/common/modules/markdown-editor/writer/bidi-isolate-props.ts
+++ b/source/common/modules/markdown-editor/writer/bidi-isolate-props.ts
@@ -1,0 +1,45 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Bidi isolate node props
+ * CVM-Role:        Lezer Node Props
+ * Maintainer:      Writer fork
+ * License:         GNU GPL v3
+ *
+ * Description:     Marks inline Markdown syntax nodes as bidirectional
+ *                  isolates, so that the bidiIsolates() extension (see
+ *                  writer/bidi.ts) renders them as coherent units inside
+ *                  runs of opposite-direction text: URLs stay left-to-right,
+ *                  emphasis marks stick to their content, link brackets and
+ *                  parentheses appear on the correct sides.
+ *
+ *                  NOTE: This file must stay importable from the main process
+ *                  (the FSAL file parser loads the Markdown parser, too), so
+ *                  it must not import from @codemirror/view.
+ *
+ * END HEADER
+ */
+
+import { NodeProp, type NodePropSource } from '@lezer/common'
+
+/**
+ * Isolate directions per node type. 'auto' resolves from the node's first
+ * strong character; 'ltr' pins the node (used for content that is virtually
+ * always Latin, such as URLs and citekeys).
+ */
+export const bidiIsolateProps: NodePropSource = NodeProp.isolate.add({
+  // Nodes from @lezer/markdown
+  URL: 'ltr',
+  Autolink: 'ltr',
+  InlineCode: 'auto', // Also covers Zettlr's inline math (math-parser reuses the node)
+  Link: 'auto',
+  Image: 'auto',
+  Emphasis: 'auto',
+  StrongEmphasis: 'auto',
+  HTMLTag: 'ltr',
+  // Custom Zettlr nodes
+  ZknLink: 'auto',
+  ZknTag: 'auto',
+  Citation: 'ltr'
+})

--- a/source/common/modules/markdown-editor/writer/bidi.ts
+++ b/source/common/modules/markdown-editor/writer/bidi.ts
@@ -1,0 +1,178 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Bidirectional text support
+ * CVM-Role:        CodeMirror Extension
+ * Maintainer:      Writer fork
+ * License:         GNU GPL v3
+ *
+ * Description:     Makes the Markdown editor usable for mixed-direction
+ *                  (e.g. Arabic/English) writing: every line resolves its own
+ *                  base direction from its first strong character, unless the
+ *                  document's YAML frontmatter pins a direction via the
+ *                  `direction: ltr|rtl|auto` key. Inline syntax elements are
+ *                  rendered as bidi isolates so that link brackets, code
+ *                  backticks etc. are not reordered by surrounding RTL runs.
+ *
+ * END HEADER
+ */
+
+import { bidiIsolates } from '@codemirror/language'
+import { RangeSetBuilder, StateField, type EditorState, type Extension, type Text } from '@codemirror/state'
+import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view'
+import { configField } from '../util/configuration'
+
+export type DocumentDirection = 'ltr'|'rtl'|'auto'
+
+/**
+ * Changes further into the document than this cannot affect the frontmatter's
+ * direction key, so we skip re-scanning for them. Also caps the scan itself in
+ * case of an unterminated frontmatter.
+ */
+const FRONTMATTER_SCAN_LIMIT = 10_000
+
+/**
+ * Reads the base direction for a document from the `direction:` key of its
+ * YAML frontmatter, if present.
+ *
+ * @param   {Text}                    doc  The document
+ *
+ * @return  {DocumentDirection|null}       The direction; null if the document
+ *                                         has no override
+ */
+function readDirection (doc: Text): DocumentDirection|null {
+  if (doc.lines < 2 || doc.line(1).text !== '---') {
+    return null
+  }
+
+  const lastLine = doc.lineAt(Math.min(doc.length, FRONTMATTER_SCAN_LIMIT)).number
+  for (let i = 2; i <= lastLine; i++) {
+    const text = doc.line(i).text
+    if (text === '---' || text === '...') {
+      return null // Fence closed without a direction key
+    }
+
+    const match = /^direction:\s*["']?(ltr|rtl|auto)["']?\s*$/.exec(text)
+    if (match !== null) {
+      return match[1] as DocumentDirection
+    }
+  }
+
+  return null
+}
+
+/**
+ * Returns the direction that actually applies to the document: its
+ * frontmatter override if present, else the application-wide default from the
+ * preferences ('auto' as the last resort).
+ *
+ * @param   {EditorState}        state  The editor state
+ *
+ * @return  {DocumentDirection}         The effective direction
+ */
+export function effectiveDirection (state: EditorState): DocumentDirection {
+  const override = state.field(documentDirectionField, false) ?? null
+  return override ?? state.field(configField, false)?.defaultTextDirection ?? 'auto'
+}
+
+/**
+ * Holds the document's base text direction override as configured in its YAML
+ * frontmatter (null if the key is absent).
+ */
+export const documentDirectionField = StateField.define<DocumentDirection|null>({
+  create (state) {
+    return readDirection(state.doc)
+  },
+  update (value, transaction) {
+    if (!transaction.docChanged) {
+      return value
+    }
+
+    let touchesHead = false
+    transaction.changes.iterChangedRanges((fromA) => {
+      if (fromA <= FRONTMATTER_SCAN_LIMIT) {
+        touchesHead = true
+      }
+    })
+
+    return touchesHead ? readDirection(transaction.newDoc) : value
+  }
+})
+
+const lineDirections: Record<DocumentDirection, Decoration> = {
+  auto: Decoration.line({ attributes: { dir: 'auto' } }),
+  ltr: Decoration.line({ attributes: { dir: 'ltr' } }),
+  rtl: Decoration.line({ attributes: { dir: 'rtl' } })
+}
+
+/**
+ * Builds one line decoration per visible line, setting the line's dir
+ * attribute according to the document direction.
+ *
+ * @param   {EditorView}     view  The view
+ *
+ * @return  {DecorationSet}        The line decorations
+ */
+function buildLineDecorations (view: EditorView): DecorationSet {
+  const direction = effectiveDirection(view.state)
+  const decoration = lineDirections[direction]
+  const builder = new RangeSetBuilder<Decoration>()
+  let lastLine = -1
+  for (const { from, to } of view.visibleRanges) {
+    let pos = from
+    while (pos <= to) {
+      const line = view.state.doc.lineAt(pos)
+      if (line.number > lastLine) {
+        // dir="auto" on a line without any strong character falls back to LTR
+        // anyway, so empty lines need no attribute (which also keeps the caret
+        // of a new, still-empty line where the user expects it).
+        if (line.text !== '' || direction !== 'auto') {
+          builder.add(line.from, line.from, decoration)
+        }
+        lastLine = line.number
+      }
+      pos = line.to + 1
+    }
+  }
+  return builder.finish()
+}
+
+const perLineDirection = ViewPlugin.fromClass(class {
+  decorations: DecorationSet
+
+  constructor (view: EditorView) {
+    this.decorations = buildLineDecorations(view)
+  }
+
+  update (update: ViewUpdate): void {
+    if (
+      update.docChanged || update.viewportChanged ||
+      effectiveDirection(update.state) !== effectiveDirection(update.startState)
+    ) {
+      this.decorations = buildLineDecorations(update.view)
+    }
+  }
+}, { decorations: plugin => plugin.decorations })
+
+/**
+ * Bidirectional text support for the Markdown editor. NOTE: This only affects
+ * the text content; the editor chrome (gutters, statusbar, panels) explicitly
+ * keeps the application's layout direction. The bidi isolation of inline
+ * syntax additionally requires `bidiIsolateProps` to be registered with the
+ * Markdown parser (see writer/bidi-isolate-props.ts).
+ *
+ * @return  {Extension}  The extension set
+ */
+export function writerBidi (): Extension {
+  return [
+    // Resolve text direction per line instead of for the whole editor (this
+    // also keeps EditorView.textDirection -- and thus the chrome -- LTR).
+    EditorView.perLineTextDirection.of(true),
+    documentDirectionField,
+    perLineDirection,
+    // Renders nodes marked with NodeProp.isolate as bidi isolates and informs
+    // CodeMirror's cursor motion about them
+    bidiIsolates()
+  ]
+}

--- a/source/common/modules/markdown-editor/writer/direction-statusbar.ts
+++ b/source/common/modules/markdown-editor/writer/direction-statusbar.ts
@@ -1,0 +1,117 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        Text direction statusbar item
+ * CVM-Role:        View
+ * Maintainer:      Writer fork
+ * License:         GNU GPL v3
+ *
+ * Description:     A statusbar item that shows the document's base text
+ *                  direction and lets the user switch it. The choice is
+ *                  persisted as a `direction:` key in the document's YAML
+ *                  frontmatter ('auto' is the default and removes the key).
+ *
+ * END HEADER
+ */
+
+import { type EditorState } from '@codemirror/state'
+import { type EditorView } from '@codemirror/view'
+import { trans } from '@common/i18n-renderer'
+import showPopupMenu, { type AnyMenuItem } from '@common/modules/window-register/application-menu-helper'
+import { hasMarkdownExt } from '@common/util/file-extention-checks'
+import { type StatusbarItem } from '../statusbar'
+import { configField } from '../util/configuration'
+import { type DocumentDirection, documentDirectionField, effectiveDirection } from './bidi'
+
+/**
+ * Persists the given direction in the document's YAML frontmatter: replaces or
+ * removes an existing `direction:` key, inserts one into an existing
+ * frontmatter, or creates a frontmatter if the document has none.
+ *
+ * @param  {EditorView}         view       The editor view
+ * @param  {DocumentDirection}  direction  The direction to persist
+ */
+function applyDirection (view: EditorView, direction: DocumentDirection|null): void {
+  const doc = view.state.doc
+
+  if (doc.lines >= 2 && doc.line(1).text === '---') {
+    for (let i = 2; i <= doc.lines; i++) {
+      const line = doc.line(i)
+
+      if (/^direction:/.test(line.text)) {
+        if (direction === null) {
+          // No override -> remove the key (including its line break)
+          view.dispatch({ changes: { from: line.from, to: Math.min(line.to + 1, doc.length) } })
+        } else {
+          view.dispatch({ changes: { from: line.from, to: line.to, insert: `direction: ${direction}` } })
+        }
+        return
+      }
+
+      if (line.text === '---' || line.text === '...') {
+        // Fence closed without a direction key -> insert one before the fence
+        if (direction !== null) {
+          view.dispatch({ changes: { from: line.from, insert: `direction: ${direction}\n` } })
+        }
+        return
+      }
+    }
+    // Unterminated frontmatter: not actually a frontmatter, so fall through
+  }
+
+  if (direction !== null) {
+    view.dispatch({ changes: { from: 0, insert: `---\ndirection: ${direction}\n---\n\n` } })
+  }
+}
+
+/**
+ * Displays the document's base text direction and allows changing it.
+ *
+ * @param   {EditorState}    state  The editor state
+ * @param   {EditorView}     view   The editor view
+ *
+ * @return  {StatusbarItem}         The statusbar item, or null
+ */
+export function textDirectionStatus (state: EditorState, view: EditorView): StatusbarItem|null {
+  const config = state.field(configField, false)
+  const override = state.field(documentDirectionField, false)
+  if (config === undefined || override === undefined || !hasMarkdownExt(config.metadata.path)) {
+    return null
+  }
+
+  const labels: Record<DocumentDirection, string> = {
+    auto: trans('Automatic'),
+    ltr: trans('Left-to-right'),
+    rtl: trans('Right-to-left')
+  }
+
+  return {
+    content: `⇆ ${labels[effectiveDirection(state)]}`,
+    title: trans('Base text direction'),
+    onClick (event) {
+      // Ensure the event doesn't get propagated to the DOM root where it would
+      // be picked up by the context menu handler and closed again immediately.
+      event.stopPropagation()
+      const items: AnyMenuItem[] = [
+        {
+          type: 'checkbox',
+          id: 'default',
+          label: trans('Application default'),
+          checked: override === null
+        },
+        { type: 'separator' },
+        ...([ 'auto', 'ltr', 'rtl' ] as const).map((dir): AnyMenuItem => ({
+          type: 'checkbox',
+          id: dir,
+          label: labels[dir],
+          checked: override === dir
+        }))
+      ]
+
+      showPopupMenu({ x: event.clientX, y: event.clientY }, items, clickedID => {
+        applyDirection(view, clickedID === 'default' ? null : clickedID as DocumentDirection)
+      })
+    }
+  }
+}

--- a/source/common/modules/markdown-utils/markdown-to-html.ts
+++ b/source/common/modules/markdown-utils/markdown-to-html.ts
@@ -129,6 +129,11 @@ function getTagInfo (node: GenericNode): HTMLTag {
     ret.attributes.push([ 'class', node.name.toLowerCase() ])
   }
 
+  if (ret.tagName === 'p') {
+    // Each block resolves its own base text direction (bidi support)
+    ret.attributes.push([ 'dir', 'auto' ])
+  }
+
   if ([ 'span', 'div' ].includes(ret.tagName)) {
     ret.attributes.push([ 'class', node.name.toLowerCase() ])
   }
@@ -234,6 +239,7 @@ export function nodeToHTML (node: ASTNode|ASTNode[], options: MD2HTMLOptions, in
     const attr = renderNodeAttributes(node)
     return `${node.whitespaceBefore}<div${attr}>${nodeToHTML(node.children, options, indent)}</div>`
   } else if (node.type === 'Heading') {
+    addAttribute(node, 'dir', 'auto')
     const attr = renderNodeAttributes(node)
     return `${node.whitespaceBefore}<h${node.level}${attr}>${nodeToHTML(node.children, options, indent)}</h${node.level}>`
   } else if (node.type === 'Highlight') {
@@ -298,7 +304,7 @@ export function nodeToHTML (node: ASTNode|ASTNode[], options: MD2HTMLOptions, in
         cells.push(nodeToHTML(cell.children, options, indent))
       }
       const tag = row.isHeaderOrFooter ? 'th' : 'td'
-      const content = cells.map(c => `<${tag}>${c}</${tag}>`).join('\n')
+      const content = cells.map(c => `<${tag} dir="auto">${c}</${tag}>`).join('\n')
       const attr = renderNodeAttributes(row)
       if (row.isHeaderOrFooter) {
         rows.push(`${row.whitespaceBefore}<thead>\n<tr${attr}>\n${content}\n</tr>\n</thead>`)

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -275,6 +275,7 @@ const editorConfiguration = computed<EditorConfigOptions>(() => {
     zknAddFileTitle: zkn.linkAddFileTitle,
     linkWithIDIfPossible: zkn.linkWithIDIfPossible,
     inputMode: editor.inputMode,
+    defaultTextDirection: editor.defaultTextDirection,
     lintMarkdown: editor.lint.markdown,
     // The editor only needs to know if it should use languageTool
     lintLanguageTool: editor.lint.languageTool.active,

--- a/source/win-preferences/schema/editor.ts
+++ b/source/win-preferences/schema/editor.ts
@@ -37,12 +37,19 @@ export function getEditorFields (config: ConfigOptions): PreferencesFieldset[] {
     },
     {
       title: trans('Writing direction'),
-      infoString: trans('We are currently planning on re-introducing bidirectional writing support, which will then be configurable here.'),
+      infoString: trans('The default base direction for documents. "Automatic" resolves each line from its first strong character, which is recommended for documents mixing left-to-right and right-to-left text. A "direction" key in a document\'s YAML frontmatter overrides this setting.'),
       group: PreferencesGroups.Editor,
-      help: undefined, // TODO
-      fields: [
-        // TODO: Add field for LTR/RTL
-      ]
+      titleField: {
+        type: 'select',
+        model: 'editor.defaultTextDirection',
+        options: {
+          auto: trans('Automatic'),
+          ltr: trans('Left-to-right'),
+          rtl: trans('Right-to-left')
+        }
+      },
+      help: undefined,
+      fields: []
     },
     {
       title: trans('Markdown rendering'),


### PR DESCRIPTION
## Description

Adds bidirectional (RTL/LTR) writing support to the Markdown editor, so
documents that mix left-to-right and right-to-left text (for example English
and Arabic) can be written without the caret and the Markdown syntax jumping
around. This also fills the "Writing direction" preferences section, which
currently contains a `// TODO: Add field for LTR/RTL` placeholder.

Now, text direction is set per line based on its leading character, which is the same behavior in GTK editors (xed), or Qt6 (QOwnnotes).

## Changes

- **Per-line base direction.** `EditorView.perLineTextDirection` is enabled and
  a `ViewPlugin` adds `dir="auto"` to each rendered line, so every line resolves
  its base direction from its first strong character.
- **Bidi isolation of inline syntax.** Link/image nodes, URLs, autolinks,
  emphasis, inline code, wikilinks, tags and citations are marked with
  `NodeProp.isolate` and rendered through `bidiIsolates()` from
  `@codemirror/language`, so brackets, parentheses and URLs are not reordered
  by a surrounding RTL run.
- **New setting `editor.defaultTextDirection`** (`auto` | `ltr` | `rtl`),
  exposed as a select in the previously empty "Writing direction" fieldset.
- **Per-document override.** A `direction: ltr|rtl|auto` key in a document's
  YAML frontmatter takes precedence over the setting. A statusbar item shows
  the effective direction and writes/removes that key.
- **Preview/export parity.** `md2html` emits `dir="auto"` on paragraphs,
  headings and table cells.
- New files live in `source/common/modules/markdown-editor/writer/`; existing
  files are touched only at integration points (extension set, parser props,
  statusbar item list, config template, `MainEditor.vue`, HTML emitter).

Non-breaking: the default (`auto`) leaves pure-LTR documents rendering as
before, and cursor motion is left at CodeMirror's defaults (visual arrows,
logical Backspace/Delete). Editor chrome does not mirror — `perLineTextDirection`
keeps `EditorView.textDirection` LTR, so gutters, panels and the statusbar keep
their positions.

## Tested on

- Linux (X11, kernel 6.8), both `yarn start` and a packaged AppImage build.
- Not tested on macOS or Windows. The change is platform-independent (no
  platform APIs are involved), but a cross-check would be welcome.
- Manual cases: pure Arabic, pure English and mixed paragraphs; caret motion
  across an Arabic↔Latin boundary; selection across that boundary; a Markdown
  link with an Arabic label and a Latin URL; Arabic headings; and a regression
  pass over pure-LTR documents. A sample document covering these is added to
  the test-gui workspace.

## Additional information

- **No new dependencies.** `perLineTextDirection` and `bidiIsolates` ship with
  the already-pinned `@codemirror/view` (6.41.1) and `@codemirror/language`
  (6.12.3).
- Prior art consulted: Joplin PR #10810 and `obsidian-rtl` PR #48, which use
  the same CodeMirror 6 primitives, plus the CodeMirror bidi example.
- The new directory name (`writer/`) comes from a downstream fork; happy to
  rename it to whatever fits the repository's conventions.
- `yarn test` passes. `vue-tsc --noEmit` reports no errors in the files touched
  by this PR (the errors it does report on `develop` are pre-existing and
  unrelated: `remark-gfm` types and implicit `any`s in `textbundle-exporter.ts`).

## AI Disclosure Statement

The code in this PR was written by Claude (Anthropic's coding agent) working
under my direction and review, as part of a downstream fork. I reviewed the
result, ran it, and tested the behaviour described above before opening this
PR. The commit message contains no AI co-author trailer. This PR description
was likewise drafted with the agent's help and then reviewed by me.

## Declarations

- [x] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [ ] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [ ] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.
