### PR TITLE
fix(snippets): correctly update snippet statefield

### DIFF
--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -147,7 +147,7 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
   update (val, transaction) {
     for (const effect of transaction.effects) {
       if (effect.is(snippetsUpdate)) {
-        val.availableSnippets = effect.value.map(entry => {
+        let availableSnippets = effect.value.map(entry => {
           return {
             label: entry.name,
             info: entry.content,
@@ -155,16 +155,16 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
           }
         })
 
-        return { ...val }
+        return { ...val, availableSnippets }
       } else if (effect.is(snippetTabsEffect)) {
-        val.activeSelections = effect.value
+        let activeSelections = effect.value
 
         // Calculate the association when the effects come in
         // because we need access to the current tab stop
         // range, which is the `transaction.selection` value.
-        val.association = getAssociation(val.activeSelections, transaction.selection?.main.from)
+        let association = getAssociation(val.activeSelections, transaction.selection?.main.from)
 
-        return { ...val }
+        return { ...val, activeSelections, association }
       } else if (effect.is(shiftNextTabEffect)) {
         // NOTE: We cannot shift the range in the nextTab() command, as this
         // change is not transparent to the library (hence it would render a
@@ -172,10 +172,12 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
         // up the fact that this range doesn't exist anymore after the user
         // starts typing, which re-evaluates the length of the activeRanges
         // array.)
-        val.activeSelections.shift()
-        val.association = getAssociation(val.activeSelections, transaction.selection?.main.from)
+        let activeSelections = val.activeSelections
+        activeSelections.shift()
 
-        return { ...val }
+        let association = getAssociation(val.activeSelections, transaction.selection?.main.from)
+
+        return { ...val, activeSelections, association }
       }
     }
 

--- a/source/common/modules/markdown-editor/autocomplete/snippets.ts
+++ b/source/common/modules/markdown-editor/autocomplete/snippets.ts
@@ -180,11 +180,11 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
     }
 
     if (!transaction.docChanged || val.activeSelections.length === 0) {
-      return val
+      return { ...val }
     }
 
     // This monstrosity ensures that our ranges stay in sync while the user types
-    val.activeSelections = val.activeSelections
+    let activeSelections = val.activeSelections
       .filter(selection => {
         return selection.ranges
           .some(r => transaction.changes.mapPos(r.from, 1, r.empty ? MapMode.TrackAfter : MapMode.TrackDel) !== null)
@@ -205,7 +205,7 @@ export const snippetsUpdateField = StateField.define<SnippetStateField>({
         }))
       })
 
-    return { ...val }
+    return { ...val, activeSelections }
   },
   // Turns any active ranges into decorations to highlight them
   provide: field => {


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below. Do not change the
  structure and the headings of this PR template.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  1. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  2. I documented the code where applicable ("why" not "what").
  3. This PR targets the develop branch, *not* the master branch.
  4. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  5. `yarn lint` and `yarn test` run successfully locally.
  6. I followed the code-style of the repository.
  7. I agree that my code will be published under the GNU GPL v3 license.
  8. All new files have the correct license/description header (see existing
     files).
  9. Before opening this PR, I ran `git pull` one last time to prevent merge
     conflicts.
  10. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, just ask the devs
  in the accompanying issue or on the community forum or on Discord.
-->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->
Statefields should be immutable, but the snippet field was updating `activeSelections` on the field itself which causes problems with the `transactionExtender` and `transactionFilter` functions. As such, the statefield will stop updating, and for snippets, this means the placeholder decorations start to drift down the page. 

This seems to be explicitly caused by the `scrollIntoView` transaction, as this forum post reports an identical issue: https://discuss.codemirror.net/t/using-editorview-scrollintoview-in-transactionextender-breaks-statefield-updates/7476

Closes #6467

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

## Tested on
<!-- Tell us on which platforms you tested your changes. -->

## Additional information
<!--
  If there is anything else that might be of interest, please provide it here.
  If this PR closes one or more issues, include a list of these issues with a
  "closing keyword" (see: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
-->

## AI Disclosure Statement

<!-- Describe how AI has been used in this PR (GPT-models/coding agents). -->

None

## Declarations
<!-- Add an "x" to the following checkboxes once you have read and understood each item. Do not add any other text in this section. -->

- [ x ] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [x  ] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [ x ] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.

<!-- Tag (do not remove): sTCF6g8X80A= -->
