### PR TITLE
Add WinGet installation method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Thanks to our community, we can also offer you a variety of other installation o
 * [Homebrew (macOS)](https://formulae.brew.sh/cask/zettlr)
 * [Aptitude (Ubuntu/Debian)](https://apt.zettlr.com)
 * [Flathub (Linux)](https://flathub.org/apps/details/com.zettlr.Zettlr)
+* [WinGet (Windows)](https://winstall.app/apps/Zettlr.Zettlr)
 * [Chocolatey (Windows)](https://community.chocolatey.org/packages/zettlr/)
 * [Arch Linux](https://wiki.archlinux.org/title/Zettlr)
 


### PR DESCRIPTION
## Description

Add WinGet as an installation option to the README. This makes the existing Windows installation method easier to discover for users who prefer WinGet.

## Changes

Add a WinGet entry to the list of installation methods in README.md. No application code, UI, or internal APIs were changed.

## Tested on

Documentation-only change.

## Additional information

No issues are being closed by this PR.

## AI Disclosure Statement

AI was not used to write this PR.

## Declarations
<!-- Add an "x" to the following checkboxes once you have read and understood each item. Do not add any other text in this section. -->

- [x] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [x] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [x] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.

<!-- Tag (do not remove): sTCF6g8X80A= -->