### PR TITLE
feat: Make tags in frontmatters clickable again

### DIFF
--- a/scripts/test-gui/test-files/Miscellaneous/YAML Frontmatter.md
+++ b/scripts/test-gui/test-files/Miscellaneous/YAML Frontmatter.md
@@ -1,0 +1,16 @@
+---
+title: "YAML Frontmatter Test File"
+# tags is an official way to denote keywords in the frontmatter
+tags: [a, list, of, tags]
+# keywords is the same, but specifically for Pandoc
+keywords:
+  - Keywords with spaces
+  - More
+  - 12345 # A number which may produce a different node type
+---
+
+# YAML Frontmatter Test File
+
+Use this file to test out Zettlr's ability to detect, parse, display, and interact with YAML frontmatters in Markdown files.
+
+#test

--- a/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
+++ b/source/common/modules/markdown-editor/parser/frontmatter-parser.ts
@@ -22,11 +22,27 @@ import { yaml } from '@codemirror/lang-yaml'
 export function yamlCodeParse (): ParseWrapper {
   const parser = yaml().language.parser
   return parseMixed((node, _input) => {
-    if (node.type.name === 'YAMLFrontmatter') {
-      return { parser, overlay: node => node.type.name === 'CodeText' }
+    // NOTE: Previously, we would check if the node.type.name is "YAMLFrontmatter"
+    // and would provide an overlay property with the function
+    // `node => node.type.name === 'CodeText'`. This then essentially parsed the
+    // entire contents of the CodeText, but mounted them as an overlay, which
+    // means that the tree was inaccessible to the syntaxTree iterators. Now, we
+    // reversed the logic and checked for a node of type CodeText that has a
+    // parent of YAMLFrontmatter, and do not provide the overlay property. This
+    // way, the entire tree replaces the CodeText node. This makes styling a bit
+    // more difficult since we can't just target the CodeText node anymore to
+    // apply a background color to the YAML frontmatter, but makes available the
+    // entirety of the frontmatter to other parts of our code.
+    if (node.type.name === 'YAMLCodeContainer' && node.node.parent?.name === 'CodeText' && node.node.parent?.parent?.name === 'YAMLFrontmatter') {
+      return { parser }
     } else {
       return null
     }
+    // if (node.type.name === 'YAMLFrontmatter') {
+    //   return { parser, overlay: node => node.type.name === 'CodeText' }
+    // } else {
+    //   return null
+    // }
   })
 }
 
@@ -81,7 +97,7 @@ export const frontmatterParser: BlockParser = {
 
     const wrapperNode = ctx.elt('YAMLFrontmatter', 0, ctx.lineStart + 3, [
       ctx.elt('YAMLFrontmatterStart', 0, 3),
-      ctx.elt('CodeText', 4, ctx.lineStart - 1),
+      ctx.elt('CodeText', 4, ctx.lineStart - 1, [ctx.elt('YAMLCodeContainer', 4, ctx.lineStart - 1)]),
       ctx.elt('YAMLFrontmatterEnd', ctx.lineStart, ctx.lineStart + 3)
     ])
 

--- a/source/common/modules/markdown-editor/parser/markdown-parser.ts
+++ b/source/common/modules/markdown-editor/parser/markdown-parser.ts
@@ -254,6 +254,7 @@ export default function markdownParser (config?: MarkdownParserConfig): Language
       defineNodes: [
         { name: 'YAMLFrontmatter', block: true },
         { name: 'YAMLFrontmatterStart', style: customTags.YAMLFrontmatterStart },
+        { name: 'YAMLCodeContainer', block: true },
         { name: 'YAMLFrontmatterEnd', style: customTags.YAMLFrontmatterEnd },
         // Citation elements
         { name: 'Citation', style: { 'Citation/...': customTags.Citation } },

--- a/source/common/modules/markdown-editor/plugins/click-listeners.ts
+++ b/source/common/modules/markdown-editor/plugins/click-listeners.ts
@@ -47,7 +47,6 @@ function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): bo
   // FlowSequence -> list of Item/Literal nodes (one-line array-style list)
 
   if (node.type.name !== 'Literal' && node.type.name !== 'QuotedLiteral') {
-    console.log('Node is neither Literal nor QuotedLiteral')
     return false
   }
 
@@ -60,7 +59,6 @@ function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): bo
   }
 
   if (parent?.type.name !== 'YAMLFrontmatter') {
-    console.log('Node is not within a Frontmatter')
     return false
   }
 
@@ -70,15 +68,12 @@ function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): bo
   const directParent = node.node.parent
   const valueContainer = directParent?.type.name === 'Item' ? directParent.parent : directParent
   if (valueContainer == null || ![ 'FlowSequence', 'BlockSequence', 'Pair' ].includes(valueContainer.type.name)) {
-    console.log('Node is neither part of a FlowSequence nor BlockSequence, nor Pair')
-    console.log(valueContainer?.type.name)
     return false
   }
 
   // It's a literal in a flow or block sequence, or direct part of a pair.
   const maybePair = valueContainer.type.name === 'Pair' ? valueContainer : valueContainer.parent
   if (maybePair?.type.name !== 'Pair') {
-    console.log('Node is not part of a Pair')
     return false
   }
 
@@ -86,13 +81,11 @@ function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): bo
   // "keywords" or "tags".
   const key = maybePair.getChild('Key')
   if (key === null) {
-    console.log('Nodes Pair did not have a key.')
     return false
   }
 
   const keyValue = state.sliceDoc(key.from, key.to)
   if (keyValue !== 'keywords' && keyValue !== 'tags') {
-    console.log('Key value was neither keywords nor tags')
     return false
   }
 
@@ -101,7 +94,6 @@ function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): bo
   // Pair -> BlockMapping -> Document
   // (The frontmatter is one large BlockMapping)
   if (maybePair.parent?.name !== 'BlockMapping' || maybePair.parent?.parent?.name !== 'Document') {
-    console.log('Pair was not a top-level element.')
     return false
   }
 

--- a/source/common/modules/markdown-editor/plugins/click-listeners.ts
+++ b/source/common/modules/markdown-editor/plugins/click-listeners.ts
@@ -15,12 +15,98 @@
  */
 import { syntaxTree } from '@codemirror/language'
 import type { DOMEventHandlers } from '@codemirror/view'
-import type { SyntaxNode } from '@lezer/common'
+import type { SyntaxNode, SyntaxNodeRef } from '@lezer/common'
 import openMarkdownLink from '../util/open-markdown-link'
+import { type EditorState } from '@codemirror/state'
 
 export interface ClickListenerCallbacks {
   onWikiLink?: (url: string) => void
   onTag?: (tag: string) => void
+}
+
+/**
+ * This function takes in a tree node, and returns true if that specific node is
+ * a "keywords" or "tags" value that can be clicked by the user.
+ *
+ * @param   {SyntaxNodeRef}  node   The node
+ * @param   {EditorState}    state  The editor state (to check values)
+ *
+ * @return  {boolean}               Whether it contains an actual frontmatter tag.
+ */
+function isFrontmatterKeywordOrTag (node: SyntaxNodeRef, state: EditorState): boolean {
+  // YAML grammar structure (see https://code.haverbeke.berlin/lezer/yaml/src/branch/main/src/yaml.grammar)
+  //
+  // We want a "Pair" as a child of YAMLFrontmatter
+  // That Pair needs to have a "Key" with the child "Literal" and value
+  // "keywords" or "tags".
+  // That pair will then also have a value, which can be:
+  //
+  // Literal -> Unquoted value, as is
+  // QuotedLiteral -> Quoted value
+  // BlockSequence -> list of Item/Literal nodes (long list)
+  // FlowSequence -> list of Item/Literal nodes (one-line array-style list)
+
+  if (node.type.name !== 'Literal' && node.type.name !== 'QuotedLiteral') {
+    console.log('Node is neither Literal nor QuotedLiteral')
+    return false
+  }
+
+  let parent = node.node.parent
+  while (parent !== null) {
+    if (parent.type.name === 'YAMLFrontmatter') {
+      break
+    }
+    parent = parent.parent
+  }
+
+  if (parent?.type.name !== 'YAMLFrontmatter') {
+    console.log('Node is not within a Frontmatter')
+    return false
+  }
+
+  // It's definitely a YAML (quoted) literal somewhere in the frontmatter. It
+  // must be furthermore a child of a FlowSequence or BlockSequence, or a Pair.
+  // If it's part of a sequence, it additionally has a parent called "Item"
+  const directParent = node.node.parent
+  const valueContainer = directParent?.type.name === 'Item' ? directParent.parent : directParent
+  if (valueContainer == null || ![ 'FlowSequence', 'BlockSequence', 'Pair' ].includes(valueContainer.type.name)) {
+    console.log('Node is neither part of a FlowSequence nor BlockSequence, nor Pair')
+    console.log(valueContainer?.type.name)
+    return false
+  }
+
+  // It's a literal in a flow or block sequence, or direct part of a pair.
+  const maybePair = valueContainer.type.name === 'Pair' ? valueContainer : valueContainer.parent
+  if (maybePair?.type.name !== 'Pair') {
+    console.log('Node is not part of a Pair')
+    return false
+  }
+
+  // It's also part of a Pair, which must have a "Key" with either value
+  // "keywords" or "tags".
+  const key = maybePair.getChild('Key')
+  if (key === null) {
+    console.log('Nodes Pair did not have a key.')
+    return false
+  }
+
+  const keyValue = state.sliceDoc(key.from, key.to)
+  if (keyValue !== 'keywords' && keyValue !== 'tags') {
+    console.log('Key value was neither keywords nor tags')
+    return false
+  }
+
+  // Final check: This could be a nested property. By definition, tags/keywords
+  // must be the top-level element. Thus, the parent chain of the Pair must be:
+  // Pair -> BlockMapping -> Document
+  // (The frontmatter is one large BlockMapping)
+  if (maybePair.parent?.name !== 'BlockMapping' || maybePair.parent?.parent?.name !== 'Document') {
+    console.log('Pair was not a top-level element.')
+    return false
+  }
+
+  // Yup, it's a keyword.
+  return true
 }
 
 /**
@@ -74,6 +160,17 @@ export function clickListeners<T = unknown> (callbacks?: ClickListenerCallbacks)
         // A tag!
         const mark = nodeAt.getChild('ZknTagMark')
         const tagContents = view.state.sliceDoc(mark ? mark.to : nodeAt.from, nodeAt.to)
+        callbacks?.onTag?.(tagContents)
+        event.preventDefault()
+        return true
+      } else if (isFrontmatterKeywordOrTag(nodeAt, view.state)) {
+        // "Literal" is a value type node that can occur in YAML text, or in
+        // YAML frontmatters, and the function has verified that it is indeed
+        // either a "keyword" or a "tag".
+        let tagContents = view.state.sliceDoc(nodeAt.from, nodeAt.to)
+        if (nodeAt.type.name === 'QuotedLiteral') {
+          tagContents = tagContents.slice(1, tagContents.length - 1)
+        }
         callbacks?.onTag?.(tagContents)
         event.preventDefault()
         return true

--- a/source/common/modules/markdown-editor/util/custom-tags.ts
+++ b/source/common/modules/markdown-editor/util/custom-tags.ts
@@ -21,6 +21,7 @@ import { Tag, tags } from '@lezer/highlight'
 export const customTags = {
   YAMLFrontmatter: Tag.define(tags.monospace),
   YAMLFrontmatterStart: Tag.define(tags.contentSeparator),
+  YAMLCodeContainer: Tag.define(),
   YAMLFrontmatterEnd: Tag.define(tags.contentSeparator),
   // Citations: @citations
   Citation: Tag.define(),

--- a/source/win-main/MainEditor.vue
+++ b/source/win-main/MainEditor.vue
@@ -666,13 +666,23 @@ function maybeHighlightSearchResults (): void {
     return
   }
 
+  // NOTE: We have to filter out "whole-file" results
+  const contentResults = result.result
+    .filter((res): res is FileContentSearchResult => {
+      return res.type === 'content' && res.line > -1
+    })
+
   // Construct CodeMirror.Ranges from the results
   const rangesToHighlight = []
-  // NOTE: We have to filter out "whole-file" results
-  for (const res of result.result.filter((res): res is FileContentSearchResult => res.type === 'content' && res.line > -1)) {
-    const startIdx = currentEditor.instance.state.doc.line(res.line + 1).from
-    for (const range of res.ranges) {
-      const { from, to } = range
+  for (const { line, ranges } of contentResults) {
+    const lineCount = currentEditor.instance.state.doc.lines
+    if (line > lineCount) {
+      console.warn(`[maybeHighlightSearchResults()] Cannot highlight line ${line}: Document only has ${lineCount} lines.`)
+      continue
+    }
+
+    const startIdx = currentEditor.instance.state.doc.line(line).from
+    for (const { from, to } of ranges) {
       rangesToHighlight.push(EditorSelection.range(startIdx + from, startIdx + to))
     }
   }


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below. Do not change the
  structure and the headings of this PR template.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  1. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  2. I documented the code where applicable ("why" not "what").
  3. This PR targets the develop branch, *not* the master branch.
  4. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  5. `yarn lint` and `yarn test` run successfully locally.
  6. I followed the code-style of the repository.
  7. I agree that my code will be published under the GNU GPL v3 license.
  8. All new files have the correct license/description header (see existing
     files).
  9. Before opening this PR, I ran `git pull` one last time to prevent merge
     conflicts.
  10. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, just ask the devs
  in the accompanying issue or on the community forum or on Discord.
-->

## Description
<!-- Describe what the PR does in one or two short sentences. What did you do? And why? -->

This PR addresses the clickability of tags in the frontmatter. The editor now has the capability to properly detect keywords in both the "keywords" and "tags" properties and emit the appropriate search command.

## Changes
<!-- What changes did you make? State any breaking changes in UI/UX or any of the internal APIs. -->

To do so, I had to do a few silly things. First, I had to insert a new dummy node into the frontmatter that can be replaced with the YAML syntax tree. The reason is that this way the styling of the CodeText node isn't harmed. Next, the YAML frontmatter is properly mounted (no longer as an overlay), making the syntax tree available to the editor, thereby replacing said dummy node. Finally, the click handlers have been amended with an odd construction that tests whether a clicked node is a keyword which is part of the correct tree structure to be a valid keyword, and, if so, a tag event is emitted that contains that value. Quoted strings are unquoted in the process.

## Tested on
<!-- Tell us on which platforms you tested your changes. -->

macOS Tahoe 26.6

## Additional information
<!--
  If there is anything else that might be of interest, please provide it here.
  If this PR closes one or more issues, include a list of these issues with a
  "closing keyword" (see: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
-->

I have received a few range errors while testing, I'm not sure if those are emanating from the search or from the new implementation. I almost can't imagine that they're due to this PR, but I'd like someone to sanity check this first.

## AI Disclosure Statement

<!-- Describe how AI has been used in this PR (GPT-models/coding agents). -->

I doubt any LLM would have been able to come up with this weird contraption I did there. So none used for this.

## Declarations
<!-- Add an "x" to the following checkboxes once you have read and understood each item. Do not add any other text in this section. -->

- [x] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [x] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [x] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.

<!-- Tag (do not remove): sTCF6g8X80A= -->