### PR TITLE
fix: apply 'AND' operator in plain text seach by default (#6517)

### DIFF
--- a/source/app/service-providers/search/util/boolean-search.ts
+++ b/source/app/service-providers/search/util/boolean-search.ts
@@ -245,7 +245,7 @@ export function searchFileBoolean (descriptor: MDFileDescriptor|CodeFileDescript
   }
 
   // Save the info on whether all terms have been matched in the metadata alone.
-  const hasAllTermsMatchedInMetadata = termsMatched !== termsToSearch.length
+  const hasAllTermsMatchedInMetadata = termsMatched === termsToSearch.length
 
   // Now, regardless of whether we have already matched everything in the
   // metadata, perform a search over the full text. This way we can show

--- a/test/compile-search-terms.spec.ts
+++ b/test/compile-search-terms.spec.ts
@@ -12,7 +12,8 @@
  * END HEADER
  */
 
-import { compileBooleanQuery, type BooleanTerm } from '../source/app/service-providers/search/util/boolean-search'
+import { MDFileDescriptor } from 'source/types/common/fsal'
+import { compileBooleanQuery, searchFileBoolean, SearchQueryBoolean, type BooleanTerm } from '../source/app/service-providers/search/util/boolean-search'
 import assert from 'assert'
 
 const testSearches: Array<{ query: string, expected: BooleanTerm[] }> = [
@@ -76,3 +77,135 @@ describe('SearchProvider#compileBooleanQuery()', function () {
     })
   }
 })
+
+describe('SearchProvider#searchFileBoolean()', function () {
+  const descriptor: MDFileDescriptor = {
+    dir: '/home/laurent/Documents/Zettlr Tutorial',
+    path: '/home/laurent/Documents/Zettlr Tutorial/references.md',
+    name: 'references.md',
+    ext: '.md',
+    size: 6348,
+    id: '',
+    tags: ['zotero', 'jabref', 'csl json', 'bibtex', 'reference management'],
+    links: [],
+    citekeys: [],
+    bom: '',
+    type: 'file',
+    wordCount: 833,
+    charCount: 5181,
+    modtime: 1787142034211.494,
+    creationtime: 1787142034211.494,
+    linefeed: ``,
+    firstHeading: 'Les références avec Zettlr 💬',
+    yamlTitle: 'Les références avec Zettlr',
+    frontmatter: {
+      title: 'Les références avec Zettlr',
+      keywords: [
+        'Zotero',
+        'JabRef',
+        'CSL JSON',
+        'BibTex',
+        'Reference Management',
+      ],
+    },
+  };
+  const fileContent: string = `---
+title: "Les références avec Zettlr"
+keywords:
+- Zotero
+- JabRef
+- Reference Management
+...
+
+# Les références avec Zettlr
+Dans ce dernier guide, nous nous plongerons dans l'art de citer des références automatiquement en utilisant Zettlr !
+`;
+
+  it('should return correct count excerpt of simple search', function () {
+    const query: SearchQueryBoolean = {
+      type: 'boolean',
+      caseInsensitive: true,
+      terms: [
+        {
+          words: ['zettlr'],
+          operator: 'AND',
+        },
+      ],
+    };
+
+    const searchResult = searchFileBoolean(descriptor, fileContent, query);
+    assert.equal(searchResult.length, 3);
+  });
+
+  it('should return correct count excerpt of NOT search', function () {
+    const query: SearchQueryBoolean = {
+      type: 'boolean',
+      caseInsensitive: true,
+      terms: [
+        {
+          words: ['NOT zettlr'],
+          operator: 'AND',
+        },
+      ],
+    };
+
+    const searchResult = searchFileBoolean(descriptor, fileContent, query);
+    assert.equal(searchResult.length, 0);
+  });
+
+  it('should return correct count excerpt of OR search', function () {
+    const query: SearchQueryBoolean = {
+      type: 'boolean',
+      caseInsensitive: true,
+      terms: [
+        {
+          words: ['zettlr', 'azerty'],
+          operator: 'OR',
+        },
+      ],
+    };
+
+    const searchResult = searchFileBoolean(descriptor, fileContent, query);
+    assert.equal(searchResult.length, 3);
+  });
+
+  it('should return correct count excerpt of AND search (two words are present)', function () {
+    const query: SearchQueryBoolean = {
+      type: 'boolean',
+      caseInsensitive: true,
+      terms: [
+        {
+          words: ['zettlr'],
+          operator: 'AND',
+        },
+        {
+          words: ['guide'],
+          operator: 'AND',
+        },
+      ],
+    };
+
+    const searchResult = searchFileBoolean(descriptor, fileContent, query);
+    assert.equal(searchResult.length, 4);
+  });
+
+  it('should return correct count excerpt of AND search (only one word is present)', function () {
+    const query: SearchQueryBoolean = {
+      type: 'boolean',
+      caseInsensitive: true,
+      terms: [
+        {
+          words: ['zettlr'],
+          operator: 'AND',
+        },
+        {
+          words: ['azerty'],
+          operator: 'AND',
+        },
+      ],
+    };
+
+    const searchResult = searchFileBoolean(descriptor, fileContent, query);
+    assert.equal(searchResult.length, 0);
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below. Do not change the
  structure and the headings of this PR template.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  1. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  2. I documented the code where applicable ("why" not "what").
  3. This PR targets the develop branch, *not* the master branch.
  4. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  5. `yarn lint` and `yarn test` run successfully locally.
  6. I followed the code-style of the repository.
  7. I agree that my code will be published under the GNU GPL v3 license.
  8. All new files have the correct license/description header (see existing
     files).
  9. Before opening this PR, I ran `git pull` one last time to prevent merge
     conflicts.
  10. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, just ask the devs
  in the accompanying issue or on the community forum or on Discord.
-->

## Description
This PR restores the default AND operator behavior in plain text searches.

Previously, searching for multiple terms (e.g. mot1 mot2) evaluated to an implicit OR operator, returning notes containing either mot1 OR mot2. With this fix, multi-word searches correctly return only notes that contain both mot1 AND mot2.

Issue : #6517

## Changes
- Corrected the boolean test evaluation in the plain text search engine by changing the strict inequality operator (!==) to strict equality (===).
- Added unit test cases covering multi-word queries to verify that default query parsing adheres to the AND operator.

## Tested on
- Run unit tests: yarn test
- Test build binaries on Debian 13

## Additional information
<!--
  If there is anything else that might be of interest, please provide it here.
  If this PR closes one or more issues, include a list of these issues with a
  "closing keyword" (see: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
-->
None

## AI Disclosure Statement
<!-- Describe how AI has been used in this PR (GPT-models/coding agents). -->
None

## Declarations
<!-- Add an "x" to the following checkboxes once you have read and understood each item. Do not add any other text in this section. -->

- [x] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [x] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [x] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.

<!-- Tag (do not remove): sTCF6g8X80A= -->
