### PR TITLE
fix(file-manager): Remove IPC listeners on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
 ## Under the Hood
 
 - Update Electron to `v43.4.0`.
+- Fixed a memory leak in the file manager: `FileItem` and `TreeItem` registered
+  `fsal-event` (and, for directories, `shortcut`) IPC listeners on mount without
+  ever removing them, so listeners accumulated as tree items were unmounted and
+  re-created. This surfaced as recurring
+  `MaxListenersExceededWarning: 101 fsal-event listeners added` warnings in the
+  renderer log.
 
 # 4.7.0
 

--- a/source/win-main/file-manager/FileItem.vue
+++ b/source/win-main/file-manager/FileItem.vue
@@ -159,7 +159,7 @@ import formatSize from '@common/util/format-size'
 import PopoverDirProps from './util/PopoverDirProps.vue'
 import PopoverFileProps from './util/PopoverFileProps.vue'
 
-import { ref, computed, toRef, watch, onMounted } from 'vue'
+import { ref, computed, toRef, watch, onMounted, onUnmounted } from 'vue'
 import { type AnyDescriptor, type MDFileDescriptor } from '@dts/common/fsal'
 import { useConfigStore, useTagsStore, useWindowStateStore } from 'source/pinia'
 import { useItemComposable } from './util/item-composable'
@@ -198,43 +198,47 @@ async function fetchChildren (): Promise<void> {
   children.value = await ipcRenderer.invoke('fsal', { command: 'read-directory', payload: props.item.path })
 }
 
+function handleFSALEvent (_event: unknown, payload: FSALEventPayload): void {
+  const affectedPath = payload.event === 'unlink' || payload.event === 'unlinkDir'
+    ? payload.path
+    : (payload as FSALEventPayloadChange).descriptor.path
+
+  // Figure out if this event relates to us, which is only the case if the
+  // affected path is a direct descendant of this tree item. If it's itself or
+  // a parent path, another tree item takes over. If it's a nested dependent,
+  // any of the children of this tree item takes over.
+  // How can we figure this out? Easy, by resolving the path from this item
+  // to the affected path and checking if there are any additional path
+  // separators in there.
+  if (!affectedPath.startsWith(props.item.path)) {
+    return
+  }
+
+  if (affectedPath === props.item.path) {
+    return // Taken care of by the parent
+  }
+
+  const relative = relativePath(props.item.path, affectedPath)
+  const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
+  if (relative.includes(PATH_SEP)) {
+    return
+  }
+
+  // Now we can be sure that the event pertains to a direct child of this item
+  // and we need to handle it. We'll make it easy and simply re-fetch the list
+  // of children.
+  fetchChildren().catch(err => console.error(`[TreeItem] Could not fetch children for item "${props.item.path}": ${err.message}`, err))
+}
+
+const offFSALEvent = ipcRenderer.on('fsal-event', handleFSALEvent)
+
 onMounted(async () => {
-  ipcRenderer.on('fsal-event', (_, payload: FSALEventPayload) => {
-    const affectedPath = payload.event === 'unlink' || payload.event === 'unlinkDir'
-      ? payload.path
-      : (payload as FSALEventPayloadChange).descriptor.path
-    
-    // Figure out if this event relates to us, which is only the case if the
-    // affected path is a direct descendant of this tree item. If it's itself or
-    // a parent path, another tree item takes over. If it's a nested dependent,
-    // any of the children of this tree item takes over.
-    // How can we figure this out? Easy, by resolving the path from this item
-    // to the affected path and checking if there are any additional path
-    // separators in there.
-    if (!affectedPath.startsWith(props.item.path)) {
-      return
-    }
-
-    if (affectedPath === props.item.path) {
-      return // Taken care of by the parent
-    }
-
-    const relative = relativePath(props.item.path, affectedPath)
-    const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
-    if (relative.includes(PATH_SEP)) {
-      return
-    }
-
-    // Now we can be sure that the event pertains to a direct child of this item
-    // and we need to handle it. We'll make it easy and simply re-fetch the list
-    // of children.
-    fetchChildren().catch(err => console.error(`[TreeItem] Could not fetch children for item "${props.item.path}": ${err.message}`, err))
-  })
-
   if (props.item.type === 'directory') {
     await fetchChildren()
   }
 })
+
+onUnmounted(() => { offFSALEvent() })
 
 const {
   nameEditing,

--- a/source/win-main/file-manager/TreeItem.vue
+++ b/source/win-main/file-manager/TreeItem.vue
@@ -170,7 +170,7 @@ import PopoverDirProps from './util/PopoverDirProps.vue'
 import PopoverFileProps from './util/PopoverFileProps.vue'
 
 import RingProgress from '@common/vue/window/toolbar-controls/RingProgress.vue'
-import { nextTick, ref, computed, watch, onMounted, toRef } from 'vue'
+import { nextTick, ref, computed, watch, onMounted, onUnmounted, toRef } from 'vue'
 import type { AnyDescriptor } from '@dts/common/fsal'
 import { useConfigStore, useWindowStateStore, useWorkspaceStore } from 'source/pinia'
 import { pathBasename, relativePath } from '@common/util/renderer-path-polyfill'
@@ -494,53 +494,63 @@ watch(showDotFiles, async function () {
   }
 })
 
+function handleShortcut (_event: unknown, message: string): void {
+  if (message === 'new-dir') {
+    operationType.value = 'createDir'
+  }
+}
+
+function handleFSALEvent (_event: unknown, payload: FSALEventPayload): void {
+  const affectedPath = payload.event === 'unlink' || payload.event === 'unlinkDir'
+    ? payload.path
+    : (payload as FSALEventPayloadChange).descriptor.path
+
+  // Figure out if this event relates to us, which is only the case if the
+  // affected path is a direct descendant of this tree item. If it's itself or
+  // a parent path, another tree item takes over. If it's a nested dependent,
+  // any of the children of this tree item takes over.
+  // How can we figure this out? Easy, by resolving the path from this item
+  // to the affected path and checking if there are any additional path
+  // separators in there.
+  if (!affectedPath.startsWith(props.item.path)) {
+    return
+  }
+
+  if (affectedPath === props.item.path) {
+    return // Taken care of by the parent
+  }
+
+  const relative = relativePath(props.item.path, affectedPath)
+  const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
+  if (relative.includes(PATH_SEP)) {
+    return
+  }
+
+  // Now we can be sure that the event pertains to a direct child of this item
+  // and we need to handle it. We'll make it easy and simply re-fetch the list
+  // of children.
+  fetchChildren().catch(err => console.error(`[TreeItem] Could not fetch children for item "${props.item.path}": ${err.message}`, err))
+}
+
+const offFSALEvent = ipcRenderer.on('fsal-event', handleFSALEvent)
+let offShortcut: (() => void)|undefined
+
 onMounted(async () => {
   if (props.item.type === 'directory') {
-    ipcRenderer.on('shortcut', (_, message) => {
-      if (message === 'new-dir') {
-        operationType.value = 'createDir'
-      }
-    })
+    offShortcut = ipcRenderer.on('shortcut', handleShortcut)
 
     await fetchChildren()
   }
-
-  ipcRenderer.on('fsal-event', (_, payload: FSALEventPayload) => {
-    const affectedPath = payload.event === 'unlink' || payload.event === 'unlinkDir'
-      ? payload.path
-      : (payload as FSALEventPayloadChange).descriptor.path
-
-    // Figure out if this event relates to us, which is only the case if the
-    // affected path is a direct descendant of this tree item. If it's itself or
-    // a parent path, another tree item takes over. If it's a nested dependent,
-    // any of the children of this tree item takes over.
-    // How can we figure this out? Easy, by resolving the path from this item
-    // to the affected path and checking if there are any additional path
-    // separators in there.
-    if (!affectedPath.startsWith(props.item.path)) {
-      return
-    }
-
-    if (affectedPath === props.item.path) {
-      return // Taken care of by the parent
-    }
-
-    const relative = relativePath(props.item.path, affectedPath)
-    const PATH_SEP = process.platform === 'win32' ? '\\' : '/'
-    if (relative.includes(PATH_SEP)) {
-      return
-    }
-
-    // Now we can be sure that the event pertains to a direct child of this item
-    // and we need to handle it. We'll make it easy and simply re-fetch the list
-    // of children.
-    fetchChildren().catch(err => console.error(`[TreeItem] Could not fetch children for item "${props.item.path}": ${err.message}`, err))
-  })
 
   // Initially scroll into view if this item is selected
   if (isSelected.value) {
     scrollIntoView()
   }
+})
+
+onUnmounted(() => {
+  offFSALEvent()
+  offShortcut?.()
 })
 
 /**


### PR DESCRIPTION
## Description

`FileItem` and `TreeItem` in the file manager registered IPC listeners on mount but never removed them, leaking one `fsal-event` listener per unmounted tree item. This fixes the leak by unsubscribing in `onUnmounted`.

## Changes

Both components registered an `fsal-event` listener (and, for directories, a `shortcut` listener) inside `onMounted` without ever removing it. Tree items are unmounted and re-created whenever the tree re-renders — collapsing/expanding directories, typing in the filter box, switching workspaces — so listeners accumulate over the lifetime of a window. On my machine this reliably produced

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
101 fsal-event listeners added.
```

in the renderer log, typically within 2–20 minutes of starting the app, depending on how much I used the file manager.

Both components now keep the unsubscribe callback returned by `ipcRenderer.on()` and call it in `onUnmounted`, matching how other components in this repository handle IPC listeners (`FilterTab.vue`, `DefaultsTab.vue`, `CustomCSS.vue`, `SnippetsTab.vue`, `GlobalSearch.vue`, `win-update/App.vue`).

The event handler bodies are unchanged — they were only extracted into named functions so the same reference can be passed to `on()` and used with its returned unsubscribe function. No behavioural change is intended.

## Tested on

macOS 26.6.2 (Apple Silicon), built from `develop`.

- `yarn lint` — 0 errors (147 pre-existing warnings, none in the changed files)
- `yarn test` — 375 passing
- `yarn start` — app boots, file manager works, clean shutdown, no new warnings or errors in the log

## Additional information

Two caveats I want to be upfront about:

1. I have not empirically verified that listener growth actually stops. My `yarn start` session was short and did not exercise the file manager heavily enough for the warning to appear even on unpatched builds, so "no warning appeared" is not evidence by itself. The reasoning for the fix is from the code: the listener is registered per component instance and never removed.

2. I suspect, but cannot prove, that this leak is related to #6522, where tab clicks stop responding after a `RangeError: Maximum call stack size exceeded` and every subsequent interaction throws `TypeError: Cannot read properties of null (reading 'Symbol(_vei)')`. Both the listener warnings and those errors appeared in the same sessions on my machine. I am not claiming this PR fixes #6522.

Transparency about AI use, per the checklist: I investigated this issue and prepared the patch with the assistance of an AI coding agent (Claude Code). I reviewed the diff, ran the checks above myself, and take full responsibility for the code. No AI is listed as an author or co-author on the commit.
