### PR TITLE
ci: fix i18n sorting

### DIFF
--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -20,7 +20,7 @@ node ./scripts/split-vue-sfc.js
 
 # Extract all messages from any JS and TS file within source into the template
 # file static/i18n.pot. (NOTE: this includes the previously transformed SFCs.)
-FILES=$(find ./source -type f -name "*.ts" -o -name "*.js")
+FILES=$(find ./source -type f \( -name "*.ts" -o -name "*.js" \) | LC_ALL=C sort)
 PKGVER=$(cat package.json | jq -r '.version')
 
 echo "Current version is $PKGVER"


### PR DESCRIPTION
<!--
  Thank you for opening up this pull request! Please read this comment carefully
  and make sure to fill in as much info as possible below. Do not change the
  structure and the headings of this PR template.

  First, the obligatory checklist. By opening your PR, you acknowledge that you
  have followed this list:

  1. I have read and agree with the CONTRIBUTING.md file and the Code of Conduct.
  2. I documented the code where applicable ("why" not "what").
  3. This PR targets the develop branch, *not* the master branch.
  4. I have tested all changes by running `yarn start`, and added unit tests
     where applicable. I have paid attention to cross-platform issues.
  5. `yarn lint` and `yarn test` run successfully locally.
  6. I followed the code-style of the repository.
  7. I agree that my code will be published under the GNU GPL v3 license.
  8. All new files have the correct license/description header (see existing
     files).
  9. Before opening this PR, I ran `git pull` one last time to prevent merge
     conflicts.
  10. I hereby confirm that I am solely responsible for the code provided in this
     PR. Usage of AI to generate code has been documented and made transparent.
     I understand that AI cannot be an author and the commit messages do not
     contain any chatbots or agents as "co-authors". There are no copyright
     issues with my code.

  If you don't know how to fulfill some of the above points, just ask the devs
  in the accompanying issue or on the community forum or on Discord.
-->

## Description
Fixes the huge PR changes that are made from the i18n CI workflows.

## Changes
Sort the files before extracting messages from files into a POT. 
Also group the type f to be an AND to the extensions instead of "(type f AND .ts) OR .js"

## Tested on
opensuse tumbleweed/macos and act.

## Additional information
Will probably make a big PR the first time, but afterwards should keep it stable.

## AI Disclosure Statement
N/A

## Declarations
<!-- Add an "x" to the following checkboxes once you have read and understood each item. Do not add any other text in this section. -->

- [x] I hereby confirm that I am solely responsible for the code provided in
  this PR. Usage of AI to generate code has been documented and made
  transparent. I understand that AI cannot be an author and the commit messages
  do not contain any chatbots or agents as "co-authors". There are no copyright
  issues with my code.
- [x] I hereby confirm that I wrote this PR description myself and that I did
  not use an LLM to draft this description.
- [x] I have specified any open issues that this PR fixes/closes accordingly in
  the additional information section.

<!-- Tag (do not remove): sTCF6g8X80A= -->
